### PR TITLE
Debian: build-dep change, python-pip -> python-setuptools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Kevin P. Dyer <kpdyer@gmail.com>
 Build-Depends: debhelper (>= 9),
  libgmp-dev,
  python-dev,
- python-pip
+ python-setuptools
 Standards-Version: 3.9.5
 Homepage: https://fteproxy.org/
 Vcs-Git: git@github.com:kpdyer/fteproxy.git -b debian/unstable


### PR DESCRIPTION
Using python-pip during the build of a package would break Debian policy as all builds must be performed using only that which is already in the Debian archive. The setup.py file for python-libfte does however require python-setuptools.

This patch has already been applied in the version I uploaded to the Debian archives.