### PR TITLE
Standardize on python3 -m fteproxy in all docs and scripts

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -18,13 +18,13 @@ pip install fteproxy
 ### Server
 
 ```bash
-fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
+python3 -m fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
 ```
 
 ### Client
 
 ```bash
-fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
 ```
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fteproxy operates as a client-server proxy:
 On the server machine:
 
 ```bash
-fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
+python3 -m fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
 ```
 
 This listens for FTE-encoded connections on port 8080 and forwards decoded traffic to 127.0.0.1:8081.
@@ -64,7 +64,7 @@ This listens for FTE-encoded connections on port 8080 and forwards decoded traff
 On the client machine:
 
 ```bash
-fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
 ```
 
 This listens for plaintext connections on port 8079 and forwards FTE-encoded traffic to the server.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -8,7 +8,7 @@ This directory contains simple examples to get started with fteproxy.
 
 In terminal 1:
 ```bash
-python -m fteproxy --mode server --server_port 8080 --proxy_port 8081
+python3 -m fteproxy --mode server --server_port 8080 --proxy_port 8081
 ```
 
 ### 2. Start a destination service
@@ -23,7 +23,7 @@ nc -l -k 8081
 
 In terminal 3:
 ```bash
-python -m fteproxy --mode client --client_port 8079 --server_ip 127.0.0.1 --server_port 8080
+python3 -m fteproxy --mode client --client_port 8079 --server_ip 127.0.0.1 --server_port 8080
 ```
 
 ### 4. Send data

--- a/examples/basic/start_client.sh
+++ b/examples/basic/start_client.sh
@@ -8,7 +8,7 @@ echo "  Listening for plaintext on: 127.0.0.1:8079"
 echo "  Connecting to FTE server: $SERVER_IP:8080"
 echo ""
 
-python -m fteproxy --mode client \
+python3 -m fteproxy --mode client \
     --client_ip 127.0.0.1 \
     --client_port 8079 \
     --server_ip "$SERVER_IP" \

--- a/examples/basic/start_server.sh
+++ b/examples/basic/start_server.sh
@@ -6,7 +6,7 @@ echo "  Listening for FTE connections on: 0.0.0.0:8080"
 echo "  Forwarding plaintext to: 127.0.0.1:8081"
 echo ""
 
-python -m fteproxy --mode server \
+python3 -m fteproxy --mode server \
     --server_ip 0.0.0.0 \
     --server_port 8080 \
     --proxy_ip 127.0.0.1 \

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -10,7 +10,7 @@ Tunnel SSH connections through fteproxy so they look like HTTP traffic.
 
 ```bash
 # Terminal 1: Start fteproxy server (forwards to local SSH)
-fteproxy --mode server --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 22
+python3 -m fteproxy --mode server --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 22
 
 # Make sure sshd is running on port 22
 ```
@@ -19,7 +19,7 @@ fteproxy --mode server --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 22
 
 ```bash
 # Terminal 1: Start fteproxy client
-fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
 
 # Terminal 2: Connect via SSH through fteproxy
 ssh -p 8079 user@localhost
@@ -34,14 +34,14 @@ Use fteproxy to tunnel an HTTP proxy.
 ```bash
 # Start a simple HTTP proxy (e.g., tinyproxy) on port 8888
 # Then start fteproxy to expose it:
-fteproxy --mode server --server_port 8080 --proxy_port 8888
+python3 -m fteproxy --mode server --server_port 8080 --proxy_port 8888
 ```
 
 ### Client Side
 
 ```bash
 # Start fteproxy client
-fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
 
 # Use curl with the proxy
 curl -x socks5://localhost:8079 https://example.com
@@ -55,7 +55,7 @@ Transfer files using netcat through FTE encoding.
 
 ```bash
 # Terminal 1: Start fteproxy server
-fteproxy --mode server --server_port 8080 --proxy_port 9999
+python3 -m fteproxy --mode server --server_port 8080 --proxy_port 9999
 
 # Terminal 2: Wait for file with netcat
 nc -l 9999 > received_file.txt
@@ -65,7 +65,7 @@ nc -l 9999 > received_file.txt
 
 ```bash
 # Terminal 1: Start fteproxy client
-fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
 
 # Terminal 2: Send file
 cat myfile.txt | nc localhost 8079
@@ -81,10 +81,10 @@ KEY=$(openssl rand -hex 32)
 echo "Using key: $KEY"
 
 # Server
-fteproxy --mode server --key $KEY --server_port 8080 --proxy_port 8081
+python3 -m fteproxy --mode server --key $KEY --server_port 8080 --proxy_port 8081
 
 # Client (use the SAME key)
-fteproxy --mode client --key $KEY --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy --mode client --key $KEY --server_ip <server-ip> --server_port 8080
 ```
 
 ## Chaining with socat

--- a/examples/integration/ssh_tunnel.sh
+++ b/examples/integration/ssh_tunnel.sh
@@ -19,7 +19,7 @@ case "$MODE" in
         echo ""
         echo "Make sure sshd is running on port 22"
         echo ""
-        python -m fteproxy --mode server \
+        python3 -m fteproxy --mode server \
             --server_ip 0.0.0.0 \
             --server_port 8080 \
             --proxy_ip 127.0.0.1 \
@@ -34,7 +34,7 @@ case "$MODE" in
         echo "To connect via SSH, run:"
         echo "  ssh -p 8079 user@localhost"
         echo ""
-        python -m fteproxy --mode client \
+        python3 -m fteproxy --mode client \
             --client_ip 127.0.0.1 \
             --client_port 8079 \
             --server_ip "$SERVER_IP" \

--- a/examples/integration/web_proxy.sh
+++ b/examples/integration/web_proxy.sh
@@ -23,7 +23,7 @@ case "$MODE" in
         echo "Make sure your web proxy is running on port $PROXY_PORT"
         echo "(e.g., tinyproxy, squid, privoxy)"
         echo ""
-        python -m fteproxy --mode server \
+        python3 -m fteproxy --mode server \
             --server_ip 0.0.0.0 \
             --server_port 8080 \
             --proxy_ip 127.0.0.1 \
@@ -41,7 +41,7 @@ case "$MODE" in
         echo "Or use curl:"
         echo "  curl -x http://localhost:8079 https://example.com"
         echo ""
-        python -m fteproxy --mode client \
+        python3 -m fteproxy --mode client \
             --client_ip 127.0.0.1 \
             --client_port 8079 \
             --server_ip "$SERVER_IP" \


### PR DESCRIPTION
Use python3 -m fteproxy explicitly instead of bare fteproxy command for better portability across different systems.