### PR TITLE
Add --key-file option to load the cryptographic key from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,32 @@ This listens for plaintext connections on port 8079 and forwards FTE-encoded tra
 | `--proxy_ip` | Forwarding-proxy listening IP | 127.0.0.1 |
 | `--proxy_port` | Forwarding-proxy listening port | 8081 |
 | `--key` | Cryptographic key (64 hex characters) | (default key) |
+| `--key-file` | Path to a file containing the key (64 hex characters). Mutually exclusive with `--key`. | |
 | `--quiet` | Suppress output | false |
 | `--version` | Show version and exit | |
+
+### Supplying the Key from a File
+
+Passing the key with `--key` places it in your shell history and exposes it in
+process listings (e.g. `ps aux`). To avoid this, write the key to a file and
+point fteproxy at it with `--key-file`:
+
+```bash
+# Generate a random 64-hex-character (32-byte) key
+python3 -c "import secrets; print(secrets.token_hex(32))" > fteproxy.key
+chmod 600 fteproxy.key
+```
+
+Then start each side with `--key-file` (the client and server must use the same
+key):
+
+```bash
+python3 -m fteproxy --mode server --key-file fteproxy.key --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
+python3 -m fteproxy --mode client --key-file fteproxy.key --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+```
+
+The file must contain exactly 64 hexadecimal characters (a trailing newline is
+ignored). `--key` and `--key-file` cannot be used together.
 
 ## Testing
 

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -142,6 +142,41 @@ def get_pid_file():
     return pid_file
 
 
+def parse_hex_key(hex_key):
+    """Validate a hex-encoded key and return it as bytes.
+
+    The key must be exactly 64 hexadecimal characters (a 32-byte key).
+    Surrounding whitespace is ignored so keys read from a file may end in a
+    trailing newline. Exits the process with an error on invalid input.
+    """
+    hex_key = hex_key.strip()
+    if len(hex_key) != 64:
+        fteproxy.warn('Invalid key length: ' + str(len(hex_key))
+                      + ', should be 64')
+        sys.exit(1)
+    try:
+        return bytes.fromhex(hex_key)
+    except ValueError:
+        fteproxy.warn('Invalid key format, must contain only 0-9a-fA-F')
+        sys.exit(1)
+
+
+def read_key_file(path):
+    """Read a hex-encoded key from a file and return it as bytes.
+
+    Storing the key in a file keeps it out of shell history and process
+    listings (e.g., ``ps``), unlike passing it via ``--key``. Exits the
+    process with an error if the file cannot be read or holds an invalid key.
+    """
+    try:
+        with open(path) as key_file:
+            contents = key_file.read()
+    except IOError as e:
+        fteproxy.warn('Failed to read key file "' + str(path) + '": ' + str(e))
+        sys.exit(1)
+    return parse_hex_key(contents)
+
+
 def get_args():
 
     class setConfValue(argparse.Action):
@@ -161,16 +196,14 @@ def get_args():
                 "--key":                "runtime.fteproxy.encrypter.key",
             }
 
+            if self.dest == "key_file":
+                setattr(namespace, self.dest, values)
+                fteproxy.conf.setValue('runtime.fteproxy.encrypter.key',
+                                       read_key_file(values))
+                return
+
             if self.dest == "key":
-                if len(values) != 64:
-                    fteproxy.warn('Invalid key length: ' + str(len(values))
-                                  + ', should be 64')
-                    sys.exit(1)
-                try:
-                    values = bytes.fromhex(values)
-                except ValueError:
-                    fteproxy.warn('Invalid key format, must contain only 0-9a-fA-F')
-                    sys.exit(1)
+                values = parse_hex_key(values)
 
             if self.dest == 'quiet':
                 fteproxy.conf.setValue(args_to_conf[options_string], 0)
@@ -228,10 +261,16 @@ def get_args():
     parser.add_argument('--release', action=setConfValue,
                         help='Definitions file to use, specified as YYYYMMDD',
                         default=fteproxy.conf.getValue('fteproxy.defs.release'))
-    parser.add_argument('--key', action=setConfValue,
+    key_group = parser.add_mutually_exclusive_group()
+    key_group.add_argument('--key', action=setConfValue,
                         help='Cryptographic key, hex, must be exactly 64 characters',
                         default=fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'
                                                   ).hex())
+    key_group.add_argument('--key-file', action=setConfValue, dest='key_file',
+                        metavar='PATH', default=None,
+                        help='Path to a file containing the cryptographic key '
+                             '(64 hex characters). Use instead of --key to keep '
+                             'the key out of shell history and process listings.')
     args = parser.parse_args(sys.argv[1:])
 
     if args.stop and not args.mode:

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -273,3 +273,147 @@ class TestCLI:
         cmd = get_fteproxy_cmd() + ['--mode', 'invalid']
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
         assert result.returncode != 0
+
+    def test_key_file_in_help(self):
+        """Test that --key-file appears in the help output."""
+        cmd = get_fteproxy_cmd() + ['--help']
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0
+        assert '--key-file' in result.stdout
+
+    def test_key_file_missing(self, tmp_path):
+        """Test that a nonexistent key file is rejected."""
+        missing = tmp_path / 'does-not-exist.key'
+        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(missing)]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+
+    def test_key_file_invalid_length(self, tmp_path):
+        """Test that a key file with the wrong length is rejected."""
+        key_file = tmp_path / 'short.key'
+        key_file.write_text('abcdef')
+        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+
+    def test_key_file_invalid_characters(self, tmp_path):
+        """Test that a key file with non-hex characters is rejected."""
+        key_file = tmp_path / 'nonhex.key'
+        key_file.write_text('z' * 64)
+        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+
+    def test_key_and_key_file_mutually_exclusive(self, tmp_path):
+        """Test that --key and --key-file cannot be used together."""
+        key_file = tmp_path / 'good.key'
+        key_file.write_text('a' * 64)
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'server',
+            '--key', 'a' * 64,
+            '--key-file', str(key_file),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+        assert '--key-file' in result.stderr and '--key' in result.stderr
+
+
+# A non-default 64-hex-character key, so a successful transfer proves both the
+# server and the client actually loaded the key from the shared key file.
+KEYFILE_TEST_KEY = '0123456789abcdef' * 4
+KEYFILE_CLIENT_PORT = 18179
+KEYFILE_SERVER_PORT = 18180
+KEYFILE_PROXY_PORT = 18181
+
+
+class TestKeyFileEndToEnd:
+    """End-to-end test that server and client interoperate via a key file."""
+
+    @pytest.fixture
+    def key_file(self, tmp_path):
+        """Write a shared key file used by both the server and the client."""
+        path = tmp_path / 'fteproxy.key'
+        path.write_text(KEYFILE_TEST_KEY + '\n')
+        return str(path)
+
+    @pytest.fixture
+    def fteproxy_server(self, key_file):
+        """Start an fteproxy server that reads its key from a file."""
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'server',
+            '--quiet',
+            '--server_ip', BIND_IP,
+            '--server_port', str(KEYFILE_SERVER_PORT),
+            '--proxy_ip', BIND_IP,
+            '--proxy_port', str(KEYFILE_PROXY_PORT),
+            '--key-file', key_file,
+        ]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if not wait_for_port(BIND_IP, KEYFILE_SERVER_PORT):
+            proc.terminate()
+            stdout, stderr = proc.communicate(timeout=5)
+            pytest.fail(f"Server failed to start. stdout: {stdout}, stderr: {stderr}")
+        yield proc
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    @pytest.fixture
+    def fteproxy_client(self, fteproxy_server, key_file):
+        """Start an fteproxy client that reads the same key from a file."""
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'client',
+            '--quiet',
+            '--client_ip', BIND_IP,
+            '--client_port', str(KEYFILE_CLIENT_PORT),
+            '--server_ip', BIND_IP,
+            '--server_port', str(KEYFILE_SERVER_PORT),
+            '--key-file', key_file,
+        ]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if not wait_for_port(BIND_IP, KEYFILE_CLIENT_PORT):
+            proc.terminate()
+            stdout, stderr = proc.communicate(timeout=5)
+            pytest.fail(f"Client failed to start. stdout: {stdout}, stderr: {stderr}")
+        yield proc
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    def test_key_file_data_transfer(self, fteproxy_client):
+        """Data should flow end-to-end when both sides load a key from file."""
+        test_data = b'Hello, key file!'
+        received_data = b''
+
+        dest_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        dest_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        dest_server.bind((BIND_IP, KEYFILE_PROXY_PORT))
+        dest_server.listen(1)
+        dest_server.settimeout(DATA_TIMEOUT)
+
+        try:
+            client_conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client_conn.connect((BIND_IP, KEYFILE_CLIENT_PORT))
+            client_conn.settimeout(DATA_TIMEOUT)
+
+            proxy_conn, _ = dest_server.accept()
+            proxy_conn.settimeout(DATA_TIMEOUT)
+
+            client_conn.sendall(test_data)
+
+            while len(received_data) < len(test_data):
+                chunk = proxy_conn.recv(1024)
+                if not chunk:
+                    break
+                received_data += chunk
+
+            assert received_data == test_data, \
+                f"Data mismatch: {received_data} != {test_data}"
+        finally:
+            client_conn.close()
+            proxy_conn.close()
+            dest_server.close()


### PR DESCRIPTION
Adds a `--key-file PATH` option so the FTE key can be read from a file instead of `--key`, keeping the secret out of shell history and `ps` output.

## Changes
- `cli.py`: new `--key-file`, mutually exclusive with `--key`; both set the same key config. Key validation refactored into `parse_hex_key()` / `read_key_file()` (64 hex chars, trailing newline OK, clean errors on missing/malformed files).
- `test_system.py`: 6 tests — help listing, missing/short/non-hex files, mutual exclusion, and an end-to-end transfer with a shared key file.
- `README.md`: documented `--key-file` with a `secrets.token_hex(32)` key-gen recipe.

## Notes
- Backward compatible; `--key` and the default key are unchanged.
- Exit codes: `1` for an invalid/unreadable key file, `2` for the mutual-exclusion error.
- Full suite: 84 passed (78 existing + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)