### PR TITLE
Fix break in finally that swallows exceptions in Decoder.pop()

### DIFF
--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -83,8 +83,14 @@ class Decoder:
             except Exception as e:
                 fteproxy.warn("fteproxy.record_layer exception: "+str(e))
                 break
-            finally:
-                if oneCell:
-                    break
+
+            # Stop after a single cell only once one was decoded successfully.
+            # This must live outside a ``finally`` block: a ``break`` in
+            # ``finally`` swallows any in-flight exception (including the
+            # SystemExit raised by ``fatal_error`` on an unrecoverable
+            # decryption error), silently turning a fatal condition into a
+            # normal return.
+            if oneCell:
+                break
 
         return retval

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -88,3 +88,61 @@ class TestRecordLayer:
                     decoded += data
                 
                 assert plaintext == decoded, f"Failed for {language}"
+
+
+class _RaisingDecoder:
+    """Decoder stub whose decode() always raises a given exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def decode(self, buffer):
+        raise self._exc
+
+
+class _FixedCellDecoder:
+    """Decoder stub that consumes a fixed-size 'cell' and echoes it."""
+
+    def __init__(self, cell_size=4):
+        self._cell_size = cell_size
+
+    def decode(self, buffer):
+        return buffer[:self._cell_size], buffer[self._cell_size:]
+
+
+class TestDecoderExceptionHandling:
+    """Regression tests for Decoder.pop() exception semantics."""
+
+    def test_unrecoverable_error_not_swallowed_in_onecell_mode(self):
+        """An unrecoverable decryption error must not be silently swallowed.
+
+        ``fatal_error()`` raises ``SystemExit``; a ``break`` in a ``finally``
+        block swallows it and lets pop() return normally, silently discarding a
+        fatal condition. With ``oneCell=True`` (the negotiation path) the error
+        must still propagate.
+        """
+        import fte.encrypter
+
+        decoder = fteproxy.record_layer.Decoder(
+            decoder=_RaisingDecoder(
+                fte.encrypter.UnrecoverableDecryptionError("boom")))
+        decoder.push(b'some-ciphertext-bytes')
+
+        with pytest.raises(SystemExit):
+            decoder.pop(oneCell=True)
+
+    def test_onecell_returns_exactly_one_cell(self):
+        """oneCell=True returns a single decoded cell and advances the buffer."""
+        decoder = fteproxy.record_layer.Decoder(decoder=_FixedCellDecoder(4))
+        decoder.push(b'AAAABBBBCCCC')
+
+        assert decoder.pop(oneCell=True) == b'AAAA'
+        assert decoder._buffer == b'BBBBCCCC'
+
+    def test_multicell_drains_entire_buffer(self):
+        """oneCell=False drains every cell from the buffer."""
+        decoder = fteproxy.record_layer.Decoder(decoder=_FixedCellDecoder(4))
+        decoder.push(b'AAAABBBBCCCC')
+
+        assert decoder.pop() == b'AAAABBBBCCCC'
+        assert decoder._buffer == b''


### PR DESCRIPTION
## Bug

`fteproxy.record_layer.Decoder.pop()` closed its loop with:

```python
finally:
    if oneCell:
        break
```

A `break` (or `continue`/`return`) inside a `finally` block **silently discards any exception propagating out of the `try`/`except`**. Here that includes the `SystemExit` raised by `fatal_error()` in the `UnrecoverableDecryptionError` handler.

In `oneCell` mode — the negotiation path (`NegotiationManager._acceptNegotiation` → `decoder.pop(oneCell=True)`) — an unrecoverable decryption error was therefore **swallowed and turned into a normal empty return** instead of aborting as intended.

Python also flags this construct directly: `SyntaxWarning: 'break' in a 'finally' block` on 3.12+, and it is slated to become a hard `SyntaxError`. On Python 3.14, compiling the module under `-W error::SyntaxWarning` already fails — a real risk for the in-progress 3.14 support.

## Fix

Move the single-cell `break` out of the `finally` block so it runs only after a cell decodes successfully. `oneCell` semantics are unchanged (still returns exactly one cell), but genuine errors now propagate.

## Tests

Adds `TestDecoderExceptionHandling` to `test_record_layer.py`:

- `test_unrecoverable_error_not_swallowed_in_onecell_mode` — **fails on the old code** with "DID NOT RAISE SystemExit"; passes after the fix.
- `test_onecell_returns_exactly_one_cell` / `test_multicell_drains_entire_buffer` — pin down the drain semantics the fix preserves.

Full suite: 81 passed. The module now imports cleanly under `-W error::SyntaxWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)