### PR TITLE
Perf: remove O(n²) buffer slicing in the record layer

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -169,15 +169,16 @@ then flush) would collapse many tiny cells into one, cutting both CPU and the 4�
 expansion. This is a latency/throughput trade-off, so gate it behind a config flag and a
 short timer so interactive latency isn't harmed.
 
-### 4. Fix the O(n²) buffer slicing in the record layer — *low effort, bulk CPU*
+### 4. Fix the O(n²) buffer slicing in the record layer — *low effort, bulk CPU* — ✅ IMPLEMENTED
 
-`record_layer.Encoder.pop` does `self._buffer = self._buffer[MAX_CELL_SIZE:]` and
-`retval += covertext` in a loop (`fteproxy/record_layer.py:37-43`); `Decoder.pop` is
-similar. Each iteration re-copies the whole remaining buffer, so a single large `push`
-is quadratic in the number of cells. Measured degradation is mild today (298 → 279 Mbit/s
-from 64 KB → 4 MB) because FTE dominates, but it will bite harder if FTE is ever sped up.
-Use a read offset / `memoryview`, or a `bytearray` with `del buf[:n]`, and join output
-chunks once.
+`record_layer.Encoder.pop` used to do `self._buffer = self._buffer[MAX_CELL_SIZE:]` and
+`retval += covertext` in a loop; `Decoder.pop` was similar. Each iteration re-copied the
+whole remaining buffer, so a single large `push` was quadratic in the number of cells. This
+is now a moving `range()` offset over the buffer with the cells joined once at the end (and
+the decoder writes `self._buffer` back a single time). Isolated buffer-management cost for a
+16 MB push fell **208 ms → 2.0 ms (~105×)**; end-to-end (real FTE) an 8 MB single-push encode
+went **296 → 360 Mbit/s (+22%)** with the large-buffer degradation tail removed. Behavior is
+unchanged and the record-layer round-trip tests pass across all languages.
 
 ### 5. Short-circuit / cache the negotiation scan — *low effort, connection-setup CPU at scale*
 

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -32,15 +32,21 @@ class Encoder:
         bytes. The returned value is encrypted and encoded
         with ``encoder`` specified in ``__init__``.
         """
-        retval = b''
+        buffer = self._buffer
+        if not buffer:
+            return b''
 
-        while len(self._buffer) > 0:
-            plaintext = self._buffer[:MAX_CELL_SIZE]
-            covertext = self._encoder.encode(plaintext)
-            self._buffer = self._buffer[MAX_CELL_SIZE:]
-            retval += covertext
+        # Encode each ``MAX_CELL_SIZE`` slice via a moving offset and join the
+        # cells once at the end. Slicing the head off ``self._buffer`` inside the
+        # loop instead would recopy the whole remaining buffer every iteration,
+        # making a single large ``push`` quadratic in the number of cells.
+        cells = []
+        for offset in range(0, len(buffer), MAX_CELL_SIZE):
+            plaintext = buffer[offset:offset + MAX_CELL_SIZE]
+            cells.append(self._encoder.encode(plaintext))
 
-        return retval
+        self._buffer = b''
+        return b''.join(cells)
 
 
 class Decoder:
@@ -64,13 +70,17 @@ class Decoder:
         with ``_decrypter`` specified in ``__init__``.
         """
 
-        retval = b''
+        # Consume cells from a local buffer and join the decoded messages once at
+        # the end; ``+= msg`` per cell would be quadratic in the number of cells.
+        # ``self._buffer`` is written back once, and on a decode failure it keeps
+        # the undecodable remainder (``buffer`` is unchanged by a raising decode).
+        buffer = self._buffer
+        messages = []
 
-        while len(self._buffer) > 0:
+        while len(buffer) > 0:
             try:
-                msg, buffer = self._decoder.decode(self._buffer)
-                retval += msg
-                self._buffer = buffer
+                msg, buffer = self._decoder.decode(buffer)
+                messages.append(msg)
             except fte.encoder.DecodeFailureError as e:
                 fteproxy.info("fteproxy.encoder.DecodeFailure: "+str(e))
                 break
@@ -87,4 +97,5 @@ class Decoder:
                 if oneCell:
                     break
 
-        return retval
+        self._buffer = buffer
+        return b''.join(messages)

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -93,9 +93,15 @@ class Decoder:
             except Exception as e:
                 fteproxy.warn("fteproxy.record_layer exception: "+str(e))
                 break
-            finally:
-                if oneCell:
-                    break
+
+            # Stop after a single cell only once one was decoded successfully.
+            # This must live outside a ``finally`` block: a ``break`` in
+            # ``finally`` swallows any in-flight exception (including the
+            # SystemExit raised by ``fatal_error`` on an unrecoverable
+            # decryption error), silently turning a fatal condition into a
+            # normal return.
+            if oneCell:
+                break
 
         self._buffer = buffer
         return b''.join(messages)

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -88,3 +88,61 @@ class TestRecordLayer:
                     decoded += data
                 
                 assert plaintext == decoded, f"Failed for {language}"
+
+
+class _RaisingDecoder:
+    """Decoder stub whose decode() always raises a given exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def decode(self, buffer):
+        raise self._exc
+
+
+class _FixedCellDecoder:
+    """Decoder stub that consumes a fixed-size 'cell' and echoes it."""
+
+    def __init__(self, cell_size=4):
+        self._cell_size = cell_size
+
+    def decode(self, buffer):
+        return buffer[:self._cell_size], buffer[self._cell_size:]
+
+
+class TestDecoderExceptionHandling:
+    """Regression tests for Decoder.pop() exception semantics."""
+
+    def test_unrecoverable_error_not_swallowed_in_onecell_mode(self):
+        """An unrecoverable decryption error must not be silently swallowed.
+
+        ``fatal_error()`` raises ``SystemExit``; a ``break`` in a ``finally``
+        block swallows it and lets pop() return normally, silently discarding a
+        fatal condition. With ``oneCell=True`` (the negotiation path) the error
+        must still propagate.
+        """
+        import fte.encrypter
+
+        decoder = fteproxy.record_layer.Decoder(
+            decoder=_RaisingDecoder(
+                fte.encrypter.UnrecoverableDecryptionError("boom")))
+        decoder.push(b'some-ciphertext-bytes')
+
+        with pytest.raises(SystemExit):
+            decoder.pop(oneCell=True)
+
+    def test_onecell_returns_exactly_one_cell(self):
+        """oneCell=True returns a single decoded cell and advances the buffer."""
+        decoder = fteproxy.record_layer.Decoder(decoder=_FixedCellDecoder(4))
+        decoder.push(b'AAAABBBBCCCC')
+
+        assert decoder.pop(oneCell=True) == b'AAAA'
+        assert decoder._buffer == b'BBBBCCCC'
+
+    def test_multicell_drains_entire_buffer(self):
+        """oneCell=False drains every cell from the buffer."""
+        decoder = fteproxy.record_layer.Decoder(decoder=_FixedCellDecoder(4))
+        decoder.push(b'AAAABBBBCCCC')
+
+        assert decoder.pop() == b'AAAABBBBCCCC'
+        assert decoder._buffer == b''


### PR DESCRIPTION
## Perf: O(n²) buffer slicing

`Encoder.pop` / `Decoder.pop` re-copied the whole remaining buffer every cell (`self._buffer = self._buffer[MAX_CELL_SIZE:]`, `retval += ...`), making a single large `push` O(n²) in the number of cells. Both now walk the buffer with a moving `range()` offset and `b''.join()` once; the decoder writes `self._buffer` back a single time (still keeping the undecodable remainder on a partial-cell failure). Behavior is unchanged.

| | before | after |
|---|---|---|
| Buffer-management only, 16 MB push | 208 ms | **2.0 ms (~105×)** |
| End-to-end `Encoder.pop`, 8 MB push | 296 Mbit/s | **360 Mbit/s (+22%)** |

## Also: break-in-finally fix (absorbs #206)

While rewriting `Decoder.pop`, this also moves the single-cell stop out of a `finally` block. A `break` in `finally` discards any in-flight exception — including the `SystemExit` from `fatal_error()` on an unrecoverable decryption error — so in `oneCell` mode (negotiation) a fatal error was silently turned into a normal return. Python also flags the construct (`SyntaxWarning` now, a hard `SyntaxError` on the horizon). Moving it out preserves `oneCell` semantics and lets real errors propagate. Supersedes #206.

## Tests

Adds `TestDecoderExceptionHandling` to `test_record_layer.py` (unrecoverable error propagates; single-/multi-cell drain pinned down). Full suite: 81 passed; module imports clean under `-W error::SyntaxWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)