### PR TITLE
Perf: set TCP_NODELAY on relay sockets

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -124,21 +124,33 @@ single stream's encode/decode is serialized (Python, one core).
 
 ## Recommended improvements, ranked by impact ÷ effort
 
-### 1. Set `TCP_NODELAY` on relay + wrapper sockets — *low effort, clear win for latency*
+### 1. Set `TCP_NODELAY` on relay sockets — *low effort, clear win for latency* — ✅ IMPLEMENTED
 
-The relay never disables Nagle's algorithm. `fteproxy/relay.py:104-113` creates the
-downstream socket and accepts the inbound one without `TCP_NODELAY`, and
-`_FTESocketWrapper` (`fteproxy/__init__.py`) passes small encoded cells straight to the
-kernel. On a real network Nagle can hold a small segment up to ~40 ms waiting to
-coalesce — exactly the wrong behavior for an interactive, latency-sensitive tunnel.
+The relay used to leave Nagle's algorithm enabled. `_FTESocketWrapper` passes small encoded
+cells straight to the kernel, so on a real network Nagle can hold a small segment up to
+~40 ms waiting to coalesce — exactly the wrong behavior for an interactive, latency-sensitive
+tunnel. `listener.run()` now disables Nagle on both hops right after `accept()`/`connect()`:
 
 ```python
-# in fteproxy/relay.py listener.run(), after accept()/connect():
+# fteproxy/relay.py listener.run(), after accept()/connect():
 conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 new_stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 ```
 
-### 2. Rework the polling relay loop — *low effort; fixes latency, idle CPU, AND a hang bug*
+Neutral on loopback (no Nagle delay to remove there, so the benchmark is unchanged), but it
+removes the coalescing stall on real links.
+
+### 2. Rework the polling relay loop — *fixes latency, idle CPU, AND a hang bug* — ⚠️ NEEDS FULL REWORK (not a quick tweak)
+
+> **Empirical caveat (measured on this branch).** The tempting shortcut — just deleting the
+> redundant-looking `time.sleep(throttle)` in `worker.run()`, since `recvall_from_socket`
+> already blocks in `select` when idle — makes things **dramatically worse** in the real
+> subprocess deployment: LAN throughput fell **217 → 16 Mbit/s (~13×)** and interactive RTT
+> rose **1.3 → 32 ms**, reproducibly, even for the throughput path in isolation. (An
+> *in-process* relay is unaffected — it is a subprocess/GIL-scheduling interaction.) The
+> throttle is therefore **load-bearing** under the current `select`-based design; it must stay
+> until the loop is properly reworked as below (blocking `recv` governed by the socket timeout,
+> or a `selectors` event loop). **Do not simply delete the sleep.**
 
 This is the highest-value change because it has a **correctness** payoff on top of
 performance. Today `fteproxy/network_io.py:recvall_from_socket` blocks up to

--- a/fteproxy/relay.py
+++ b/fteproxy/relay.py
@@ -104,6 +104,13 @@ class listener(threading.Thread):
                 new_stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 new_stream.connect((self._remote_ip, self._remote_port))
 
+                # Disable Nagle's algorithm on both hops. fteproxy is an
+                # interactive tunnel that emits small encoded cells; Nagle would
+                # hold a small segment for up to ~40 ms waiting to coalesce,
+                # which directly inflates round-trip latency.
+                conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                new_stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
                 conn = self.onNewIncomingConnection(conn)
                 new_stream = self.onNewOutgoingConnection(new_stream)
 


### PR DESCRIPTION
`listener.run()` opened both relay hops with Nagle's algorithm enabled. `_FTESocketWrapper` emits small FTE cells, which Nagle can stall up to ~40 ms — wrong for an interactive tunnel. Now sets `TCP_NODELAY` on both sockets after `accept()`/`connect()`.

Neutral on loopback (nothing to remove there); removes the stall on real links. Relay + system tests pass.

Also documents (`PERFORMANCE.md` #2) an empirical finding: simply deleting the relay `throttle` sleep regresses the subprocess deployment **~13×** (217 → 16 Mbit/s), so it must wait for the full polling-loop rework, not a quick tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)