### PR TITLE
build: drop support for EOL Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/kpdyer/fteproxy/actions/workflows/tests.yml/badge.svg)](https://github.com/kpdyer/fteproxy/actions/workflows/tests.yml)
 [![PyPI version](https://img.shields.io/pypi/v/fteproxy.svg)](https://pypi.org/project/fteproxy/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 **fteproxy** provides transport-layer protection to resist keyword filtering, censorship, and discriminatory routing policies using Format-Transforming Encryption (FTE).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/kpdyer/fteproxy/actions/workflows/tests.yml/badge.svg)](https://github.com/kpdyer/fteproxy/actions/workflows/tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://img.shields.io/pypi/v/fteproxy.svg)](https://pypi.org/project/fteproxy/)
 
 * Homepage: https://github.com/kpdyer/fteproxy
@@ -20,7 +20,7 @@ fteproxy is powered by Format-Transforming Encryption [1] and was presented at C
 
 ## Requirements
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 
 ## Installation
 

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -21,9 +21,8 @@ class TestPython3Compatibility:
     """Test Python 3 specific functionality."""
 
     def test_python_version(self):
-        """Ensure we're running Python 3.8+"""
-        assert sys.version_info.major >= 3
-        assert sys.version_info.minor >= 8
+        """Ensure we're running Python 3.10+"""
+        assert sys.version_info >= (3, 10)
 
     def test_bytes_key_config(self):
         """Test that the encryption key is properly stored as bytes."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ dynamic = ["version"]
 description = "Format-Transforming Encryption proxy for censorship circumvention"
 readme = "PYPI_README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name = "Kevin P. Dyer", email = "kpdyer@gmail.com"}
 ]
 keywords = ["fte", "encryption", "proxy", "censorship", "privacy"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,9 @@ setup(
     packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
     package_data=package_data,
     install_requires=['fte'],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
## Summary

Python 3.8 (EOL Oct 2024) and 3.9 (EOL Oct 2025) are both end-of-life. This raises the minimum supported version to **3.10** (itself supported through Oct 2026) across every place support is declared.

## Changes

- **pyproject.toml / setup.py** — `requires-python`/`python_requires` → `>=3.10`; removed the 3.8 and 3.9 trove classifiers.
- **.github/workflows/tests.yml** — dropped `3.8` and `3.9` from all three CI matrices (unit / system / example tests).
- **README.md / PYPI_README.md** — bumped the Python badge and requirements text to 3.10+.
- **fteproxy/tests/test_python3.py** — version guard is now `assert sys.version_info >= (3, 10)` (the old `minor >= 8` check was fragile across major versions).

## Notes

- No version-gated code exists outside the tests, so no runtime code needed changing. This PR only drops support declarations; it does not modernize code to use 3.10+ features.
- Verified no stray `3.8`/`3.9` references remain (outside generated `egg-info` and unrelated `PERFORMANCE.md` measurements), and both edited Python files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)