### PR TITLE
release: bump version to 0.3.1

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import sys
 import socket


### PR DESCRIPTION
Bumps `fteproxy.__version__` from `0.3.0` to `0.3.1` in preparation for a PyPI release.

## What's in 0.3.1 (changes since v0.3.0)
- **Build:** drop support for EOL Python 3.8/3.9; add Python 3.13/3.14 (#216, #202)
- **Feature:** `--key-file` option to load the key from a file (#204)
- **Security:** in-repo hardening — CodeQL, Dependabot, SECURITY.md, SHA-pinned actions, least-privilege permissions (#212)
- **Perf:** record-layer O(n²) buffer-slicing fix, TCP_NODELAY on relay sockets, negotiation scan ordering, raised max cell size (#208, #209, #210)
- **Fix:** infinite `recv()` loop on truncated cell / peer close (#205)

## Verification
- Built locally with `python -m build` → produced `fteproxy-0.3.1.tar.gz` + wheel
- `twine check dist/*` → both **PASSED**

Once merged, a GitHub Release `v0.3.1` is published which triggers `publish.yml` to upload to PyPI via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)