### PR TITLE
release: bump version to 0.3.2, pin fte<0.4

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 import sys
 import socket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fte",
+    "fte>=0.3.0,<0.4",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fte
+fte>=0.3.0,<0.4
 pytest>=9.1.1
 pytest-timeout>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     },
     packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
     package_data=package_data,
-    install_requires=['fte'],
+    install_requires=['fte>=0.3.0,<0.4'],
     python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Bumps `fteproxy.__version__` from `0.3.1` to `0.3.2` and pins the `fte` dependency to `>=0.3.0,<0.4`. No other changes.

## Why

libfte 0.4.0 was uploaded to PyPI on 2026-09-02. It removes the entire 0.3 API that fteproxy uses (`fte.Encoder`, `fte.encoder`, `fte.encrypter`) in favor of the new `fte.FTE` engine, and its wire format is not compatible with 0.3.x. Because fteproxy 0.3.1 declares a bare, unbounded `fte` dependency, every fresh `pip install fteproxy` since then resolves to fte 0.4.0 and fails on import:

```
fteproxy/record_layer.py:6: import fte.encoder
ModuleNotFoundError: No module named 'fte.encoder'
```

This release restores a working install for PyPI users with a metadata-only change. The real migration to libfte 0.4 is #221 and will ship as fteproxy 0.4.0.

## What's in 0.3.2 (changes since v0.3.1)

- **Fix:** pin `fte>=0.3.0,<0.4` in `pyproject.toml`, `setup.py`, and `requirements.txt`, so the resolver picks the last compatible libfte (0.3.0) instead of 0.4.0

## Verification

- Fresh venv, `pip install fteproxy` (0.3.1 from PyPI) → resolves fte 0.4.0 → `import fteproxy` fails as above (reproduces the report)
- Built locally with `python -m build` → `fteproxy-0.3.2.tar.gz` + wheel; wheel METADATA has `Requires-Dist: fte<0.4,>=0.3.0`
- `twine check dist/*` → both **PASSED**
- Fresh venv, installed the built wheel with no other constraints → pip resolves **fte 0.3.0**; `fteproxy --version` works; record-layer encode/decode round trip passes
- `pytest fteproxy/tests/test_python3.py fteproxy/tests/test_record_layer.py` against the wheel's environment → all pass

Once merged, publish a GitHub Release `v0.3.2`, which triggers `publish.yml` to upload to PyPI via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
