### PR TITLE
Migrate to libfte 0.4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master, main ]
   pull_request:
-    branches: [ master, main ]
 
 permissions:
   contents: read

--- a/examples/chat/client.py
+++ b/examples/chat/client.py
@@ -45,9 +45,9 @@ def main():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock = fteproxy.wrap_socket(sock,
                                     outgoing_regex=CLIENT_TO_SERVER,
-                                    outgoing_fixed_slice=256,
+                                    outgoing_fixed_slice=520,
                                     incoming_regex=SERVER_TO_CLIENT,
-                                    incoming_fixed_slice=256,
+                                    incoming_fixed_slice=520,
                                     negotiate=False)
         sock.connect((HOST, PORT))
         print("Connected!")

--- a/examples/chat/server.py
+++ b/examples/chat/server.py
@@ -46,9 +46,9 @@ def main():
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock = fteproxy.wrap_socket(sock,
                                     outgoing_regex=SERVER_TO_CLIENT,
-                                    outgoing_fixed_slice=256,
+                                    outgoing_fixed_slice=520,
                                     incoming_regex=CLIENT_TO_SERVER,
-                                    incoming_fixed_slice=256,
+                                    incoming_fixed_slice=520,
                                     negotiate=False)
         sock.bind((HOST, PORT))
         sock.listen(1)

--- a/examples/formats/comparison_demo.py
+++ b/examples/formats/comparison_demo.py
@@ -6,6 +6,7 @@ Encodes the same message with multiple formats side-by-side
 to show how different formats transform the same data.
 """
 
+import os
 import sys
 import fte
 
@@ -24,6 +25,8 @@ FORMATS = [
 
 def main():
     secret = b"Hello, World!"
+    # libfte 0.4 requires an explicit 32-byte key; one key for the whole script is fine
+    key = os.urandom(32)
     errors = 0
     
     print("=" * 70)
@@ -38,12 +41,13 @@ def main():
     
     for name, regex in FORMATS:
         try:
-            encoder = fte.Encoder(regex, 256)
-            ciphertext = encoder.encode(secret)
+            # Slice 1024 so the low-entropy binary format has enough capacity
+            encoder = fte.FTE(output_format=fte.RegexFormat(regex, length=1024), key=key)
+            ciphertext = encoder.encrypt(secret)
             sample = ciphertext[:50].decode('ascii', errors='ignore')
-            
+
             # Verify it decodes correctly
-            decoded, _ = encoder.decode(ciphertext)
+            decoded = encoder.decrypt(ciphertext)
             if decoded == secret:
                 status = "[OK]"
             else:

--- a/examples/formats/http_demo.py
+++ b/examples/formats/http_demo.py
@@ -6,6 +6,7 @@ Shows data encoded to look like HTTP requests.
 Useful for blending in with normal web traffic.
 """
 
+import os
 import sys
 import fte
 
@@ -15,8 +16,10 @@ def main():
     regex = "^GET \\/[a-zA-Z0-9]+ HTTP\\/1\\.1\\r\\n\\r\\n$"
     fixed_slice = 256
     errors = 0
-    
-    encoder = fte.Encoder(regex, fixed_slice)
+
+    # libfte 0.4 requires an explicit 32-byte key
+    key = os.urandom(32)
+    encoder = fte.FTE(output_format=fte.RegexFormat(regex, length=fixed_slice), key=key)
     
     print("=" * 60)
     print("HTTP FORMAT DEMO")
@@ -27,7 +30,7 @@ def main():
     
     for msg in messages:
         try:
-            ciphertext = encoder.encode(msg)
+            ciphertext = encoder.encrypt(msg)
             http_output = ciphertext[:256].decode('ascii', errors='ignore')
             
             print(f"\nOriginal: {msg}")
@@ -36,7 +39,7 @@ def main():
                 print(f"    {repr(line)}")
             
             # Verify
-            decoded, _ = encoder.decode(ciphertext)
+            decoded = encoder.decrypt(ciphertext)
             if decoded == msg:
                 print("[OK] Roundtrip verified")
             else:

--- a/examples/formats/words_demo.py
+++ b/examples/formats/words_demo.py
@@ -6,6 +6,7 @@ Shows data encoded as space-separated lowercase words.
 This is useful when you want traffic to look like natural text.
 """
 
+import os
 import sys
 import fte
 
@@ -15,8 +16,10 @@ def main():
     regex = "^([a-z]+ )+[a-z]+$"
     fixed_slice = 256
     errors = 0
-    
-    encoder = fte.Encoder(regex, fixed_slice)
+
+    # libfte 0.4 requires an explicit 32-byte key
+    key = os.urandom(32)
+    encoder = fte.FTE(output_format=fte.RegexFormat(regex, length=fixed_slice), key=key)
     
     messages = [
         b"Hello!",
@@ -31,7 +34,7 @@ def main():
     print("=" * 60)
     
     for msg in messages:
-        ciphertext = encoder.encode(msg)
+        ciphertext = encoder.encrypt(msg)
         words = ciphertext[:256].decode('ascii', errors='ignore')
         
         print(f"\nOriginal: {msg}")
@@ -42,7 +45,7 @@ def main():
         print(f"Words:    {word_count} words generated")
         
         # Verify roundtrip
-        decoded, _ = encoder.decode(ciphertext)
+        decoded = encoder.decrypt(ciphertext)
         if decoded == msg:
             print("[OK] Roundtrip verified")
         else:

--- a/examples/programmatic/custom_format.py
+++ b/examples/programmatic/custom_format.py
@@ -62,8 +62,8 @@ def main():
     
     # Example 3: File extension-like
     print("\n[3] Filename Format")
-    print("    Regex: ^[a-z]+\\.[a-z]{3}$")
-    filename_regex = "^[a-z]+\\.[a-z]{3}$"
+    print("    Regex: ^[a-z]+\\.[a-z][a-z][a-z]$")
+    filename_regex = "^[a-z]+\\.[a-z][a-z][a-z]$"
     try:
         encoder = fte.FTE(output_format=fte.RegexFormat(filename_regex, length=256), key=key)
         plaintext = b"Hi"

--- a/examples/programmatic/custom_format.py
+++ b/examples/programmatic/custom_format.py
@@ -5,6 +5,7 @@ Custom Format Example
 Shows how to create your own regex format for FTE encoding.
 """
 
+import os
 import sys
 import fte
 
@@ -13,7 +14,10 @@ def main():
     print("=" * 60)
     print("CUSTOM FORMAT EXAMPLE")
     print("=" * 60)
-    
+
+    # libfte 0.4 requires an explicit 32-byte key; one key for the whole script is fine
+    key = os.urandom(32)
+
     errors = 0
     
     # Example 1: DNA sequences
@@ -21,10 +25,10 @@ def main():
     print("    Regex: ^[ACGT]+$")
     dna_regex = "^[ACGT]+$"
     try:
-        encoder = fte.Encoder(dna_regex, 256)
+        encoder = fte.FTE(output_format=fte.RegexFormat(dna_regex, length=512), key=key)
         plaintext = b"Secret genetic data"
-        ciphertext = encoder.encode(plaintext)
-        decoded, _ = encoder.decode(ciphertext)
+        ciphertext = encoder.encrypt(plaintext)
+        decoded = encoder.decrypt(ciphertext)
         print(f"    Input:  {plaintext.decode()}")
         print(f"    Output: {ciphertext[:50].decode('ascii', errors='ignore')}...")
         if decoded == plaintext:
@@ -41,10 +45,10 @@ def main():
     print("    Regex: ^[ox]+$")
     pattern_regex = "^[ox]+$"
     try:
-        encoder = fte.Encoder(pattern_regex, 256)
+        encoder = fte.FTE(output_format=fte.RegexFormat(pattern_regex, length=1024), key=key)
         plaintext = b"Hidden message"
-        ciphertext = encoder.encode(plaintext)
-        decoded, _ = encoder.decode(ciphertext)
+        ciphertext = encoder.encrypt(plaintext)
+        decoded = encoder.decrypt(ciphertext)
         print(f"    Input:  {plaintext.decode()}")
         print(f"    Output: {ciphertext[:50].decode('ascii', errors='ignore')}...")
         if decoded == plaintext:
@@ -61,10 +65,10 @@ def main():
     print("    Regex: ^[a-z]+\\.[a-z]{3}$")
     filename_regex = "^[a-z]+\\.[a-z]{3}$"
     try:
-        encoder = fte.Encoder(filename_regex, 64)
+        encoder = fte.FTE(output_format=fte.RegexFormat(filename_regex, length=256), key=key)
         plaintext = b"Hi"
-        ciphertext = encoder.encode(plaintext)
-        decoded, _ = encoder.decode(ciphertext)
+        ciphertext = encoder.encrypt(plaintext)
+        decoded = encoder.decrypt(ciphertext)
         print(f"    Input:  {plaintext.decode()}")
         print(f"    Output: {ciphertext[:50].decode('ascii', errors='ignore')}...")
         if decoded == plaintext:
@@ -81,10 +85,10 @@ def main():
     print("    Regex: ^[0-9a-f][0-9a-f]+$")
     mac_regex = "^[0-9a-f][0-9a-f]+$"
     try:
-        encoder = fte.Encoder(mac_regex, 256)
+        encoder = fte.FTE(output_format=fte.RegexFormat(mac_regex, length=256), key=key)
         plaintext = b"Network data"
-        ciphertext = encoder.encode(plaintext)
-        decoded, _ = encoder.decode(ciphertext)
+        ciphertext = encoder.encrypt(plaintext)
+        decoded = encoder.decrypt(ciphertext)
         print(f"    Input:  {plaintext.decode()}")
         print(f"    Output: {ciphertext[:50].decode('ascii', errors='ignore')}...")
         if decoded == plaintext:

--- a/examples/programmatic/format_demo.py
+++ b/examples/programmatic/format_demo.py
@@ -5,6 +5,7 @@ FTE Format Demonstration
 Shows how the same data looks when encoded with different regex formats.
 """
 
+import os
 import sys
 import fte
 
@@ -25,7 +26,10 @@ FORMATS = {
 
 def main():
     secret = b"Secret Message!"
-    fixed_slice = 256
+    # Use a slice large enough for even the low-entropy binary format below
+    fixed_slice = 1024
+    # libfte 0.4 requires an explicit 32-byte key; one key for the whole script is fine
+    key = os.urandom(32)
     errors = 0
     
     print("=" * 70)
@@ -41,8 +45,8 @@ def main():
         print(f"   Regex: {regex}")
         
         try:
-            encoder = fte.Encoder(regex, fixed_slice)
-            ciphertext = encoder.encode(secret)
+            encoder = fte.FTE(output_format=fte.RegexFormat(regex, length=fixed_slice), key=key)
+            ciphertext = encoder.encrypt(secret)
             
             # Show first 60 chars of output
             preview = ciphertext[:60].decode('ascii', errors='ignore')
@@ -50,7 +54,7 @@ def main():
             print(f"   Length: {len(ciphertext)} bytes")
             
             # Verify roundtrip
-            decoded, _ = encoder.decode(ciphertext)
+            decoded = encoder.decrypt(ciphertext)
             if decoded != secret:
                 print(f"   [FAIL] Roundtrip failed!")
                 errors += 1

--- a/examples/programmatic/simple_encoder.py
+++ b/examples/programmatic/simple_encoder.py
@@ -6,6 +6,7 @@ This demonstrates direct use of the FTE encoder without network sockets.
 Great for understanding how Format-Transforming Encryption works.
 """
 
+import os
 import sys
 import fte
 
@@ -14,12 +15,15 @@ def main():
     # The regex defines what the output looks like
     # This one produces lowercase letters only
     regex = "^[a-z]+$"
-    
+
     # Fixed slice determines the capacity (bits encoded per output character)
     fixed_slice = 256
-    
-    # Create the encoder
-    encoder = fte.Encoder(regex, fixed_slice)
+
+    # libfte 0.4 requires an explicit 32-byte key (there is no random-key path)
+    key = os.urandom(32)
+
+    # Create the cipher
+    encoder = fte.FTE(output_format=fte.RegexFormat(regex, length=fixed_slice), key=key)
     
     # Our secret message
     plaintext = b"Hello, World! This is a secret message."
@@ -28,14 +32,14 @@ def main():
     print()
     
     # Encode the message
-    ciphertext = encoder.encode(plaintext)
+    ciphertext = encoder.encrypt(plaintext)
     print(f"Encoded (looks like random letters):")
     print(f"  {ciphertext[:100].decode('ascii', errors='ignore')}...")
     print(f"Encoded length: {len(ciphertext)} bytes")
     print()
     
     # Decode back to original
-    decoded, remaining = encoder.decode(ciphertext)
+    decoded = encoder.decrypt(ciphertext)
     print(f"Decoded message: {decoded.decode()}")
     
     # Verify roundtrip

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -14,6 +14,20 @@ import fteproxy.record_layer
 import fte
 
 
+def _make_cipher(regex, fixed_slice, key):
+    """Build a libfte 0.4 engine that hides bytes as one fixed-length covertext
+    matching ``regex``.
+
+    This replaces libfte 0.3's ``fte.Encoder(regex, fixed_slice, key)``. The
+    engine ``encrypt``/``decrypt`` one whole covertext per call; the record
+    layer handles stream chunking and framing on top of it.
+    """
+    return fte.FTE(
+        output_format=fte.RegexFormat(regex, length=fixed_slice),
+        key=key,
+    )
+
+
 class InvalidRoleException(Exception):
     pass
 
@@ -110,6 +124,14 @@ class NegotiationManager(object):
         self._K1 = K1
         self._K2 = K2
 
+    def _key(self):
+        # libfte 0.4 requires an explicit 32-byte key; the old "key=None means
+        # generate a random key" path is gone (and never interoperated across a
+        # client/server pair anyway). Fall back to the configured shared key.
+        if self._K1 and self._K2:
+            return self._K1 + self._K2
+        return fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+
     def getNegotiationComplete(self):
         return self._negotiationComplete
 
@@ -136,8 +158,7 @@ class NegotiationManager(object):
                 incoming_fixed_slice = fteproxy.defs.getFixedSlice(
                     incoming_language)
 
-                key = (self._K1 + self._K2) if self._K1 and self._K2 else None
-                incoming_decoder = fte.Encoder(incoming_regex, incoming_fixed_slice, key)
+                incoming_decoder = _make_cipher(incoming_regex, incoming_fixed_slice, self._key())
                 decoder = fteproxy.record_layer.Decoder(decoder=incoming_decoder)
 
                 decoder.push(data)
@@ -157,14 +178,14 @@ class NegotiationManager(object):
         encoder = None
         decoder = None
 
-        key = (self._K1 + self._K2) if self._K1 and self._K2 else None
+        key = self._key()
 
         if outgoing_regex != None and outgoing_fixed_slice != -1:
-            outgoing_encoder = fte.Encoder(outgoing_regex, outgoing_fixed_slice, key)
+            outgoing_encoder = _make_cipher(outgoing_regex, outgoing_fixed_slice, key)
             encoder = fteproxy.record_layer.Encoder(encoder=outgoing_encoder)
 
         if incoming_regex != None and incoming_fixed_slice != -1:
-            incoming_decoder = fte.Encoder(incoming_regex, incoming_fixed_slice, key)
+            incoming_decoder = _make_cipher(incoming_regex, incoming_fixed_slice, key)
             decoder = fteproxy.record_layer.Decoder(decoder=incoming_decoder)
 
         return [encoder, decoder]

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -12,8 +12,6 @@ import argparse
 import threading
 import traceback
 
-import fte
-
 import fteproxy
 import fteproxy.conf
 import fteproxy.server
@@ -106,7 +104,10 @@ class FTEMain(threading.Thread):
             fteproxy.fatal_error('Invalid format name ' + stream_format)
 
         fixed_slice = fteproxy.defs.getFixedSlice(stream_format)
-        fte.Encoder(regex, fixed_slice, key)
+        # Build the engine to validate the format is usable with this key.
+        # libfte 0.4 raises FormatCapacityError here if the format is too small
+        # to carry the cipher's frame overhead.
+        fteproxy._make_cipher(regex, fixed_slice, key)
 
     def do_client(self):
 

--- a/fteproxy/defs/20131224.json
+++ b/fteproxy/defs/20131224.json
@@ -1,20 +1,20 @@
 {
     "manual-http-request": {
-        "regex": "^GET\\ \\/([a-zA-Z0-9\\.\\/]*) HTTP/1\\.1\\r\\n\\r\\n$"
+        "regex": "^GET\\ \\/([a-zA-Z0-9./]*) HTTP/1\\.1\\r\\n\\r\\n$"
     },
     "manual-http-response": {
-        "regex": "^HTTP/1\\.1\\ 200 OK\\r\\nContent-Type:\\ ([a-zA-Z0-9]+)\\r\\n\\r\\n\\C*$"
+        "regex": "^HTTP/1\\.1\\ 200 OK\\r\\nContent-Type:\\ ([a-zA-Z0-9]+)\\r\\n\\r\\n.*$"
     },
     "manual-ssh-request": {
-        "regex": "^SSH\\-2\\.0\\C*$"
+        "regex": "^SSH\\-2\\.0.*$"
     },
     "manual-ssh-response": {
-        "regex": "^SSH\\-2\\.0\\C*$"
+        "regex": "^SSH\\-2\\.0.*$"
     },
     "dummy-request": {
-        "regex": "^\\C+$"
+        "regex": "^.+$"
     },
     "dummy-response": {
-        "regex": "^\\C+$"
+        "regex": "^.+$"
     }
 }

--- a/fteproxy/defs/20260110.json
+++ b/fteproxy/defs/20260110.json
@@ -176,15 +176,15 @@
         "fixed_slice": 312
     },
     "manual-http-request": {
-        "regex": "^GET\\ \\/([a-zA-Z0-9\\.\\/]*) HTTP/1\\.1\\r\\n\\r\\n$"
+        "regex": "^GET\\ \\/([a-zA-Z0-9./]*) HTTP/1\\.1\\r\\n\\r\\n$"
     },
     "manual-http-response": {
-        "regex": "^HTTP/1\\.1\\ 200 OK\\r\\nContent-Type:\\ ([a-zA-Z0-9]+)\\r\\n\\r\\n\\C*$"
+        "regex": "^HTTP/1\\.1\\ 200 OK\\r\\nContent-Type:\\ ([a-zA-Z0-9]+)\\r\\n\\r\\n.*$"
     },
     "dummy-request": {
-        "regex": "^\\C+$"
+        "regex": "^.+$"
     },
     "dummy-response": {
-        "regex": "^\\C+$"
+        "regex": "^.+$"
     }
 }

--- a/fteproxy/defs/20260110.json
+++ b/fteproxy/defs/20260110.json
@@ -9,42 +9,42 @@
     },
     "ssh-request": {
         "regex": "^SSH-2\\.0-[a-zA-Z0-9_]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 184,
         "description": "SSH protocol version banner (e.g., SSH-2.0-OpenSSH_8.4)"
     },
     "ssh-response": {
         "regex": "^SSH-2\\.0-[a-zA-Z0-9_]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 184,
         "description": "SSH protocol version banner"
     },
     "tls-sni-request": {
         "regex": "^[a-z0-9]+\\.[a-z0-9]+\\.[a-z]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 200,
         "description": "TLS Server Name Indication style (subdomain.domain.tld)"
     },
     "tls-sni-response": {
         "regex": "^[a-z0-9]+\\.[a-z0-9]+\\.[a-z]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 200,
         "description": "TLS Server Name Indication style"
     },
     "smtp-request": {
         "regex": "^EHLO [a-z0-9]+\\.[a-z]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 208,
         "description": "SMTP EHLO command (e.g., EHLO mail.example.com)"
     },
     "smtp-response": {
         "regex": "^250-[a-z0-9]+\\.[a-z]+ [A-Z]+$",
-        "fixed_slice": 128,
+        "fixed_slice": 208,
         "description": "SMTP 250 response"
     },
     "ftp-request": {
         "regex": "^USER [a-z0-9]+$",
-        "fixed_slice": 64,
+        "fixed_slice": 208,
         "description": "FTP USER command"
     },
     "ftp-response": {
         "regex": "^220 [a-z]+\\.[a-z]+ ready$",
-        "fixed_slice": 128,
+        "fixed_slice": 232,
         "description": "FTP welcome banner (e.g., 220 ftp.example.com ready)"
     },
     "lowercase-request": {
@@ -89,11 +89,11 @@
     },
     "binary-request": {
         "regex": "^[01]+$",
-        "fixed_slice": 256
+        "fixed_slice": 1032
     },
     "binary-response": {
         "regex": "^[01]+$",
-        "fixed_slice": 256
+        "fixed_slice": 1032
     },
     "base64-request": {
         "regex": "^[a-zA-Z0-9+/]+$",
@@ -121,19 +121,19 @@
     },
     "ip-address-request": {
         "regex": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
-        "fixed_slice": 64
+        "fixed_slice": 312
     },
     "ip-address-response": {
         "regex": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
-        "fixed_slice": 64
+        "fixed_slice": 312
     },
     "domain-request": {
         "regex": "^[a-z0-9]+\\.[a-z]+$",
-        "fixed_slice": 128
+        "fixed_slice": 200
     },
     "domain-response": {
         "regex": "^[a-z0-9]+\\.[a-z]+$",
-        "fixed_slice": 128
+        "fixed_slice": 200
     },
     "url-path-request": {
         "regex": "^\\/[a-z0-9]+(\\/[a-z0-9]+)*$",
@@ -145,11 +145,11 @@
     },
     "key-value-request": {
         "regex": "^[a-z]+=[a-zA-Z0-9]+$",
-        "fixed_slice": 128
+        "fixed_slice": 176
     },
     "key-value-response": {
         "regex": "^[a-z]+=[a-zA-Z0-9]+$",
-        "fixed_slice": 128
+        "fixed_slice": 176
     },
     "csv-request": {
         "regex": "^[a-zA-Z0-9]+(,[a-zA-Z0-9]+)+$",
@@ -161,19 +161,19 @@
     },
     "email-simple-request": {
         "regex": "^[a-z]+@[a-z]+\\.[a-z]+$",
-        "fixed_slice": 128
+        "fixed_slice": 224
     },
     "email-simple-response": {
         "regex": "^[a-z]+@[a-z]+\\.[a-z]+$",
-        "fixed_slice": 128
+        "fixed_slice": 224
     },
     "timestamp-request": {
         "regex": "^[0-9]+:[0-9]+:[0-9]+$",
-        "fixed_slice": 64
+        "fixed_slice": 312
     },
     "timestamp-response": {
         "regex": "^[0-9]+:[0-9]+:[0-9]+$",
-        "fixed_slice": 64
+        "fixed_slice": 312
     },
     "manual-http-request": {
         "regex": "^GET\\ \\/([a-zA-Z0-9\\.\\/]*) HTTP/1\\.1\\r\\n\\r\\n$"

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -3,12 +3,9 @@
 
 
 
-import fte.encoder
+import fte
 
 import fteproxy.conf
-
-
-MAX_CELL_SIZE = fteproxy.conf.getValue('runtime.fteproxy.record_layer.max_cell_size')
 
 
 class Encoder:
@@ -18,6 +15,11 @@ class Encoder:
         encoder,
     ):
         self._encoder = encoder
+        # libfte 0.4 caps the plaintext a single covertext can carry at the
+        # output format's capacity; there is no unformatted-overflow escape
+        # hatch anymore. Chunk the stream to that capacity so every cell maps
+        # to exactly one fixed-length covertext.
+        self._capacity = encoder.max_plaintext_bytes
         self._buffer = b''
 
     def push(self, data):
@@ -27,23 +29,22 @@ class Encoder:
         self._buffer += data
 
     def pop(self):
-        """Pop data off the FIFO buffer. We pop at most
-        ``runtime.fteproxy.record_layer.max_cell_size``
-        bytes. The returned value is encrypted and encoded
-        with ``encoder`` specified in ``__init__``.
+        """Pop data off the FIFO buffer. We pop the whole buffer, sliced into
+        capacity-sized chunks. Each chunk is encrypted and encoded into one
+        fixed-length covertext with the ``encoder`` specified in ``__init__``.
         """
         buffer = self._buffer
         if not buffer:
             return b''
 
-        # Encode each ``MAX_CELL_SIZE`` slice via a moving offset and join the
+        # Encrypt each ``self._capacity`` slice via a moving offset and join the
         # cells once at the end. Slicing the head off ``self._buffer`` inside the
         # loop instead would recopy the whole remaining buffer every iteration,
         # making a single large ``push`` quadratic in the number of cells.
         cells = []
-        for offset in range(0, len(buffer), MAX_CELL_SIZE):
-            plaintext = buffer[offset:offset + MAX_CELL_SIZE]
-            cells.append(self._encoder.encode(plaintext))
+        for offset in range(0, len(buffer), self._capacity):
+            plaintext = buffer[offset:offset + self._capacity]
+            cells.append(self._encoder.encrypt(plaintext))
 
         self._buffer = b''
         return b''.join(cells)
@@ -56,6 +57,12 @@ class Decoder:
         decoder,
     ):
         self._decoder = decoder
+        # A fixed-length output format emits one covertext of exactly
+        # ``max_length`` bytes per message, and ``decrypt`` consumes exactly one
+        # such value (it does not return a remainder). The record layer therefore
+        # frames the byte stream itself, slicing whole covertexts off the head of
+        # the buffer and leaving any trailing partial frame for the next push.
+        self._frame_size = decoder.output_format.max_length
         self._buffer = b''
 
     def push(self, data):
@@ -66,42 +73,50 @@ class Decoder:
 
     def pop(self, oneCell=False):
         """Pop data off the FIFO buffer.
-        The returned value is decoded with ``_decoder`` then decrypted
-        with ``_decrypter`` specified in ``__init__``.
+        The returned value is decrypted and decoded with ``_decoder``
+        specified in ``__init__``.
         """
 
-        # Consume cells from a local buffer and join the decoded messages once at
-        # the end; ``+= msg`` per cell would be quadratic in the number of cells.
-        # ``self._buffer`` is written back once, and on a decode failure it keeps
-        # the undecodable remainder (``buffer`` is unchanged by a raising decode).
+        # Consume whole covertext frames from a local buffer and join the decoded
+        # messages once at the end; ``+= msg`` per cell would be quadratic in the
+        # number of cells. ``self._buffer`` is written back once, and on a decode
+        # failure it keeps the undecodable remainder (the offset does not advance
+        # past a raising frame).
         buffer = self._buffer
         messages = []
+        offset = 0
 
-        while len(buffer) > 0:
+        while len(buffer) - offset >= self._frame_size:
+            covertext = buffer[offset:offset + self._frame_size]
             try:
-                msg, buffer = self._decoder.decode(buffer)
-                messages.append(msg)
-            except fte.encoder.DecodeFailureError as e:
-                fteproxy.info("fteproxy.encoder.DecodeFailure: "+str(e))
-                break
-            except fte.encrypter.RecoverableDecryptionError as e:
-                fteproxy.info("fteproxy.encrypter.RecoverableDecryptionError: "+str(e))
-                break
-            except fte.encrypter.UnrecoverableDecryptionError as e:
-                fteproxy.fatal_error("fteproxy.encrypter.UnrecoverableDecryptionError: "+str(e))
+                msg = self._decoder.decrypt(covertext)
+            except fte.MessageTooLargeError as e:
+                # A complete, authenticating frame that claims a plaintext the
+                # format cannot hold has no recoverable interpretation. This is
+                # the successor to libfte 0.3's UnrecoverableDecryptionError, so
+                # keep the fatal semantics.
+                fteproxy.fatal_error("fteproxy.record_layer.MessageTooLargeError: "+str(e))
                 # exit
-            except Exception as e:
+            except fte.InvalidCovertextError as e:
+                # A corrupt, wrong-format, or failed-MAC frame. Stop draining and
+                # leave the bytes buffered. The negotiation scan relies on this to
+                # fall through to the next candidate format.
+                fteproxy.info("fteproxy.record_layer.InvalidCovertextError: "+str(e))
+                break
+            except fte.FTEError as e:
                 fteproxy.warn("fteproxy.record_layer exception: "+str(e))
                 break
+
+            messages.append(msg)
+            offset += self._frame_size
 
             # Stop after a single cell only once one was decoded successfully.
             # This must live outside a ``finally`` block: a ``break`` in
             # ``finally`` swallows any in-flight exception (including the
-            # SystemExit raised by ``fatal_error`` on an unrecoverable
-            # decryption error), silently turning a fatal condition into a
-            # normal return.
+            # SystemExit raised by ``fatal_error`` on a fatal decryption error),
+            # silently turning a fatal condition into a normal return.
             if oneCell:
                 break
 
-        self._buffer = buffer
+        self._buffer = buffer[offset:]
         return b''.join(messages)

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -15,6 +15,16 @@ import fte
 import fteproxy
 import fteproxy.conf
 import fteproxy.defs
+import fteproxy.record_layer
+
+
+# libfte 0.4 requires an explicit key; use fteproxy's configured shared key.
+_KEY = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+
+
+def _cipher(regex, fixed_slice):
+    """Build a libfte 0.4 engine, the successor to ``fte.Encoder(regex, slice)``."""
+    return fteproxy._make_cipher(regex, fixed_slice, _KEY)
 
 
 class TestBuiltinFormats:
@@ -40,17 +50,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex(format_name)
         fixed_slice = fteproxy.defs.getFixedSlice(format_name)
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Hello, World!"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         # Extract only the text portion (ciphertext may include binary padding)
         text_portion = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         assert len(text_portion) > 0
         # Check at least the beginning matches the pattern
         assert pattern_check(text_portion[:20]) or len(text_portion) < 20
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_words_format(self):
@@ -58,17 +68,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("words-request")
         fixed_slice = fteproxy.defs.getFixedSlice("words-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Secret message"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should contain spaces and lowercase letters
         assert ' ' in decoded
         assert all(c in 'abcdefghijklmnopqrstuvwxyz ' for c in decoded)
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_sentences_format(self):
@@ -76,17 +86,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("sentences-request")
         fixed_slice = fteproxy.defs.getFixedSlice("sentences-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Test"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should end with a period and have capital letters
         assert decoded.endswith('.')
         assert any(c.isupper() for c in decoded)
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_csv_format(self):
@@ -94,10 +104,10 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("csv-request")
         fixed_slice = fteproxy.defs.getFixedSlice("csv-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Data"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should contain commas
@@ -105,7 +115,7 @@ class TestBuiltinFormats:
         fields = decoded.split(',')
         assert len(fields) >= 2
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_ip_address_format(self):
@@ -113,10 +123,10 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("ip-address-request")
         fixed_slice = fteproxy.defs.getFixedSlice("ip-address-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Hi"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         # Only decode the fixed_slice portion (rest may be binary padding)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
@@ -125,7 +135,7 @@ class TestBuiltinFormats:
         assert len(parts) == 4
         assert all(part.isdigit() for part in parts)
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_domain_format(self):
@@ -133,10 +143,10 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("domain-request")
         fixed_slice = fteproxy.defs.getFixedSlice("domain-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should look like a domain
@@ -144,7 +154,7 @@ class TestBuiltinFormats:
         parts = decoded.split('.')
         assert len(parts) == 2
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_email_format(self):
@@ -152,17 +162,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("email-simple-request")
         fixed_slice = fteproxy.defs.getFixedSlice("email-simple-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should look like an email
         assert '@' in decoded
         assert '.' in decoded
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_url_path_format(self):
@@ -170,16 +180,16 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("url-path-request")
         fixed_slice = fteproxy.defs.getFixedSlice("url-path-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Hello"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should start with / and look like a path
         assert decoded.startswith('/')
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_key_value_format(self):
@@ -187,10 +197,10 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("key-value-request")
         fixed_slice = fteproxy.defs.getFixedSlice("key-value-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should contain =
@@ -198,7 +208,7 @@ class TestBuiltinFormats:
         parts = decoded.split('=')
         assert len(parts) == 2
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_timestamp_format(self):
@@ -206,10 +216,10 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("timestamp-request")
         fixed_slice = fteproxy.defs.getFixedSlice("timestamp-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         # Only decode the fixed_slice portion (rest may be binary padding)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
@@ -218,7 +228,7 @@ class TestBuiltinFormats:
         assert len(parts) == 3
         assert all(part.isdigit() for part in parts)
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_http_simple_request_format(self):
@@ -226,17 +236,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("http-simple-request")
         fixed_slice = fteproxy.defs.getFixedSlice("http-simple-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext.decode('ascii')
         
         # Should look like an HTTP request
         assert decoded.startswith('GET /')
         assert 'HTTP/1.1' in decoded
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_ssh_format(self):
@@ -244,16 +254,16 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("ssh-request")
         fixed_slice = fteproxy.defs.getFixedSlice("ssh-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
         # Should look like an SSH banner
         assert decoded.startswith('SSH-2.0-')
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_tls_sni_format(self):
@@ -261,17 +271,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("tls-sni-request")
         fixed_slice = fteproxy.defs.getFixedSlice("tls-sni-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
         # Should look like subdomain.domain.tld
         parts = decoded.split('.')
         assert len(parts) == 3
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_smtp_format(self):
@@ -279,17 +289,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("smtp-request")
         fixed_slice = fteproxy.defs.getFixedSlice("smtp-request")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
         # Should look like SMTP EHLO command
         assert decoded.startswith('EHLO ')
         assert '.' in decoded
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     def test_ftp_format(self):
@@ -297,17 +307,17 @@ class TestBuiltinFormats:
         regex = fteproxy.defs.getRegex("ftp-response")
         fixed_slice = fteproxy.defs.getFixedSlice("ftp-response")
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"X"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
         # Should look like FTP welcome banner
         assert decoded.startswith('220 ')
         assert 'ready' in decoded
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
 
@@ -331,15 +341,15 @@ class TestProtocolFormats:
         regex = fteproxy.defs.getRegex(format_name)
         fixed_slice = fteproxy.defs.getFixedSlice(format_name)
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = b"Test"
         
-        ciphertext = encoder.encode(test_data)
+        ciphertext = encoder.encrypt(test_data)
         decoded = ciphertext[:fixed_slice].decode('ascii', errors='ignore')
         
         assert decoded.startswith(expected_prefix)
         
-        plaintext, _ = encoder.decode(ciphertext)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
 
@@ -376,20 +386,20 @@ class TestFormatPairs:
         # Test request format
         req_regex = fteproxy.defs.getRegex(request_format)
         req_slice = fteproxy.defs.getFixedSlice(request_format)
-        req_encoder = fte.Encoder(req_regex, req_slice)
+        req_encoder = _cipher(req_regex, req_slice)
         
         test_data = b"Test"
-        ciphertext = req_encoder.encode(test_data)
-        plaintext, _ = req_encoder.decode(ciphertext)
+        ciphertext = req_encoder.encrypt(test_data)
+        plaintext = req_encoder.decrypt(ciphertext)
         assert plaintext == test_data
         
         # Test response format
         resp_regex = fteproxy.defs.getRegex(response_format)
         resp_slice = fteproxy.defs.getFixedSlice(response_format)
-        resp_encoder = fte.Encoder(resp_regex, resp_slice)
+        resp_encoder = _cipher(resp_regex, resp_slice)
         
-        ciphertext = resp_encoder.encode(test_data)
-        plaintext, _ = resp_encoder.decode(ciphertext)
+        ciphertext = resp_encoder.encrypt(test_data)
+        plaintext = resp_encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
 
@@ -414,46 +424,59 @@ class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
     def test_empty_input(self):
-        """Test encoding empty input produces empty output."""
+        """Empty input round-trips; the record layer emits nothing for it."""
         regex = "^[a-z]+$"
         fixed_slice = 256
-        
-        encoder = fte.Encoder(regex, fixed_slice)
-        ciphertext = encoder.encode(b"")
-        # Empty input produces empty ciphertext
-        assert ciphertext == b""
+
+        cipher = _cipher(regex, fixed_slice)
+        # The record layer emits no covertext for an empty push.
+        encoder = fteproxy.record_layer.Encoder(encoder=cipher)
+        encoder.push(b"")
+        assert encoder.pop() == b""
+        # The raw engine still emits a full covertext that decrypts to empty.
+        assert cipher.decrypt(cipher.encrypt(b"")) == b""
 
     def test_large_input(self):
-        """Test encoding larger data."""
+        """Data larger than one covertext's capacity round-trips via the record
+        layer, which chunks it into multiple fixed-length cells.
+
+        libfte 0.4 caps a single ``encrypt`` at the format's capacity (there is
+        no unformatted-overflow escape hatch), so chunking is the record layer's
+        job, not the engine's.
+        """
         regex = "^[a-z]+$"
         fixed_slice = 256
-        
-        encoder = fte.Encoder(regex, fixed_slice)
+
+        cipher = _cipher(regex, fixed_slice)
+        encoder = fteproxy.record_layer.Encoder(encoder=cipher)
+        decoder = fteproxy.record_layer.Decoder(decoder=cipher)
         test_data = b"X" * 500
-        ciphertext = encoder.encode(test_data)
-        plaintext, _ = encoder.decode(ciphertext)
-        assert plaintext == test_data
+        encoder.push(test_data)
+        decoder.push(encoder.pop())
+        assert decoder.pop() == test_data
 
     def test_binary_data(self):
-        """Test encoding binary data."""
+        """All 256 byte values round-trip through the record layer."""
         regex = "^[a-z]+$"
         fixed_slice = 256
-        
-        encoder = fte.Encoder(regex, fixed_slice)
+
+        cipher = _cipher(regex, fixed_slice)
+        encoder = fteproxy.record_layer.Encoder(encoder=cipher)
+        decoder = fteproxy.record_layer.Decoder(decoder=cipher)
         test_data = bytes(range(256))
-        ciphertext = encoder.encode(test_data)
-        plaintext, _ = encoder.decode(ciphertext)
-        assert plaintext == test_data
+        encoder.push(test_data)
+        decoder.push(encoder.pop())
+        assert decoder.pop() == test_data
 
     def test_unicode_data(self):
         """Test encoding unicode data."""
         regex = "^[a-z]+$"
         fixed_slice = 256
         
-        encoder = fte.Encoder(regex, fixed_slice)
+        encoder = _cipher(regex, fixed_slice)
         test_data = "Hello, 世界! 🌍".encode('utf-8')
-        ciphertext = encoder.encode(test_data)
-        plaintext, _ = encoder.decode(ciphertext)
+        ciphertext = encoder.encrypt(test_data)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
     @pytest.mark.parametrize("test_data", [
@@ -469,9 +492,9 @@ class TestEdgeCases:
         regex = "^[a-z]+$"
         fixed_slice = 256
         
-        encoder = fte.Encoder(regex, fixed_slice)
-        ciphertext = encoder.encode(test_data)
-        plaintext, _ = encoder.decode(ciphertext)
+        encoder = _cipher(regex, fixed_slice)
+        ciphertext = encoder.encrypt(test_data)
+        plaintext = encoder.decrypt(ciphertext)
         assert plaintext == test_data
 
 
@@ -490,10 +513,10 @@ class TestAllDefinedFormats:
                 regex = fteproxy.defs.getRegex(format_name)
                 fixed_slice = fteproxy.defs.getFixedSlice(format_name)
                 
-                encoder = fte.Encoder(regex, fixed_slice)
+                encoder = _cipher(regex, fixed_slice)
                 test_data = b"Test"
-                ciphertext = encoder.encode(test_data)
-                plaintext, _ = encoder.decode(ciphertext)
+                ciphertext = encoder.encrypt(test_data)
+                plaintext = encoder.decrypt(ciphertext)
                 
                 if plaintext != test_data:
                     failed.append((format_name, "roundtrip failed"))

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -413,7 +413,7 @@ class TestLegacyFormats:
         
         # Test dummy format
         regex = fteproxy.defs.getRegex('dummy-request')
-        assert regex == '^\\C+$'
+        assert regex == '^.+$'
         
         # Test manual-http-request
         regex = fteproxy.defs.getRegex('manual-http-request')

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -137,6 +137,11 @@ class TestWrapSocket:
         
         client_server_regex = '^(0|1)+$'
         server_client_regex = '^(A|B)+$'
+        # These are 1-bit-per-character formats. libfte 0.4's expanding cipher
+        # has fixed frame overhead and no unformatted overflow, so the slice
+        # must be large enough to hold the payload plus that frame. 520 gives a
+        # 32-byte capacity here (256 would be rejected as too small).
+        fixed_slice = 520
         test_data = b'Hello, world!'
         received_data = []
         
@@ -145,9 +150,9 @@ class TestWrapSocket:
             server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             server_sock = fteproxy.wrap_socket(server_sock,
                 outgoing_regex=server_client_regex,
-                outgoing_fixed_slice=256,
+                outgoing_fixed_slice=fixed_slice,
                 incoming_regex=client_server_regex,
-                incoming_fixed_slice=256,
+                incoming_fixed_slice=fixed_slice,
                 negotiate=False)
             server_sock.bind(('127.0.0.1', port))
             server_sock.listen(1)
@@ -179,9 +184,9 @@ class TestWrapSocket:
         client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         client_sock = fteproxy.wrap_socket(client_sock,
             outgoing_regex=client_server_regex,
-            outgoing_fixed_slice=256,
+            outgoing_fixed_slice=fixed_slice,
             incoming_regex=server_client_regex,
-            incoming_fixed_slice=256,
+            incoming_fixed_slice=fixed_slice,
             negotiate=False)
         
         try:

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -23,12 +23,13 @@ def record_layer_pairs():
     """Create encoder/decoder pairs for all defined languages."""
     fteproxy.conf.setValue('runtime.mode', 'client')
     
+    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
     pairs = []
     definitions = fteproxy.defs.load_definitions()
     for language in definitions.keys():
         regex = fteproxy.defs.getRegex(language)
         fixed_slice = fteproxy.defs.getFixedSlice(language)
-        regex_encoder = fte.Encoder(regex, fixed_slice)
+        regex_encoder = fteproxy._make_cipher(regex, fixed_slice, key)
         encoder = fteproxy.record_layer.Encoder(encoder=regex_encoder)
         decoder = fteproxy.record_layer.Decoder(decoder=regex_encoder)
         pairs.append((language, encoder, decoder))
@@ -90,42 +91,48 @@ class TestRecordLayer:
                 assert plaintext == decoded, f"Failed for {language}"
 
 
+class _Format:
+    """Minimal output-format stub exposing the frame size the Decoder reads."""
+
+    def __init__(self, max_length):
+        self.max_length = max_length
+
+
 class _RaisingDecoder:
-    """Decoder stub whose decode() always raises a given exception."""
+    """Decoder stub whose decrypt() always raises a given exception."""
 
-    def __init__(self, exc):
+    def __init__(self, exc, frame_size=4):
         self._exc = exc
+        self.output_format = _Format(frame_size)
 
-    def decode(self, buffer):
+    def decrypt(self, covertext):
         raise self._exc
 
 
 class _FixedCellDecoder:
-    """Decoder stub that consumes a fixed-size 'cell' and echoes it."""
+    """Decoder stub that decrypts a fixed-size covertext frame to itself."""
 
     def __init__(self, cell_size=4):
-        self._cell_size = cell_size
+        self.output_format = _Format(cell_size)
 
-    def decode(self, buffer):
-        return buffer[:self._cell_size], buffer[self._cell_size:]
+    def decrypt(self, covertext):
+        return covertext
 
 
 class TestDecoderExceptionHandling:
     """Regression tests for Decoder.pop() exception semantics."""
 
     def test_unrecoverable_error_not_swallowed_in_onecell_mode(self):
-        """An unrecoverable decryption error must not be silently swallowed.
+        """A fatal decryption error must not be silently swallowed.
 
         ``fatal_error()`` raises ``SystemExit``; a ``break`` in a ``finally``
         block swallows it and lets pop() return normally, silently discarding a
         fatal condition. With ``oneCell=True`` (the negotiation path) the error
-        must still propagate.
+        must still propagate. ``fte.MessageTooLargeError`` is the libfte 0.4
+        successor to 0.3's ``UnrecoverableDecryptionError``.
         """
-        import fte.encrypter
-
         decoder = fteproxy.record_layer.Decoder(
-            decoder=_RaisingDecoder(
-                fte.encrypter.UnrecoverableDecryptionError("boom")))
+            decoder=_RaisingDecoder(fte.MessageTooLargeError("boom")))
         decoder.push(b'some-ciphertext-bytes')
 
         with pytest.raises(SystemExit):

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -10,8 +10,6 @@ decoder (e.g. the peer was cut off part-way through a covertext cell).
 
 import pytest
 
-import fte
-
 import fteproxy
 import fteproxy.conf
 import fteproxy.defs
@@ -34,7 +32,9 @@ def _regex_slice():
 def _make_cell(payload):
     """Encode ``payload`` into one covertext record-layer cell."""
     regex, fixed_slice = _regex_slice()
-    encoder = fteproxy.record_layer.Encoder(encoder=fte.Encoder(regex, fixed_slice))
+    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+    encoder = fteproxy.record_layer.Encoder(
+        encoder=fteproxy._make_cipher(regex, fixed_slice, key))
     encoder.push(payload)
     return encoder.pop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fte>=0.3.0,<0.4",
+    "fte>=0.4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fte>=0.4.0",
+    "fte>=0.4.0,<0.5.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fte>=0.3.0,<0.4
+fte>=0.4.0
 pytest>=9.1.1
 pytest-timeout>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fte>=0.4.0
+fte>=0.4.0,<0.5.0
 pytest>=9.1.1
 pytest-timeout>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     },
     packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
     package_data=package_data,
-    install_requires=['fte>=0.3.0,<0.4'],
+    install_requires=['fte>=0.4.0'],
     python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     },
     packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
     package_data=package_data,
-    install_requires=['fte>=0.4.0'],
+    install_requires=['fte>=0.4.0,<0.5.0'],
     python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Summary

Migrates fteproxy from libfte 0.3.x (the `fte.Encoder` API) to the **released libfte 0.4.0** (the single-engine `fte.FTE` API), pinned as `fte>=0.4.0,<0.5.0`.

This is **part 1 of 5** of splitting #221 into reviewable pieces. The later parts are stacked on this branch: terminology renames, the hybrid record layer, sealed covertexts, and the AES-CTR+HMAC hybrid body. Merge in order (squash), retargeting each next PR to `master` as its base merges.

The 0.4 wire format is **not compatible with 0.3.x**. Both endpoints must upgrade together.

## The libfte 0.4 API change

0.4 collapses `fte.Encoder` / `fte.encoder` / `fte.encrypter` into one engine, `fte.FTE`, over a pluggable `RankedFormat` (`fte.RegexFormat` is the built-in one). Four things fteproxy relied on changed:

1. **`encode()/decode()` → `encrypt()/decrypt()`.** `decrypt()` consumes exactly one whole covertext and returns only the plaintext; the old `decode(buffer)` returned `(plaintext, remainder)`.
2. **No self-delimiting stream.** 0.3 emitted a fixed-length formatted header plus a raw unformatted overflow body. 0.4 emits exactly one fixed-length covertext per message, so fteproxy frames the stream itself.
3. **Hard capacity.** The whole covertext must be a valid word of the format, so every format has a hard plaintext capacity.
4. **A 32-byte key is mandatory.** The old "no key → random keys" path is gone (it never interoperated across a client/server pair anyway); the negotiation path falls back to the configured shared key.

## What changed

- `fteproxy/record_layer.py`: chunk by per-format capacity on encode; frame the stream by fixed covertext size on decode; map the new `fte.*` exceptions (`InvalidCovertextError` stops draining, as the old `DecodeFailureError` did; `MessageTooLargeError` is fatal, mirroring 0.3's `UnrecoverableDecryptionError`).
- `fteproxy/__init__.py` / `cli.py`: a `_make_cipher()` helper; the configured key is required.
- `fteproxy/defs/20260110.json`: 20 low-capacity formats get a larger `fixed_slice` so every built-in format is usable under the expanding cipher (`fteproxy --mode server` builds a cipher for every format at startup, so an unusable one crashed it):

| format | old | old capacity | new | new capacity |
|---|---:|---:|---:|---:|
| binary-request/response | 256 | 3 | 1032 | 100 |
| ip-address-request/response | 64 | unusable | 312 | 102 |
| timestamp-request/response | 64 | unusable | 312 | 102 |
| ftp-request | 64 | 9 | 208 | 102 |
| ftp-response | 128 | 41 | 232 | 102 |
| email-simple-request/response | 128 | 47 | 224 | 104 |
| smtp-request/response | 128 | 50 | 208 | 102 |
| tls-sni-request/response | 128 | 54 | 200 | 100 |
| domain-request/response | 128 | 54 | 200 | 100 |
| ssh-request/response | 128 | 61 | 184 | 103 |
| key-value-request/response | 128 | 66 | 176 | 101 |

- Tests and examples migrated to `encrypt()/decrypt()`.

## Differences from #221 (for the released 0.4.0)

#221 was written against a libfte git branch. Against the 0.4.0 that shipped to PyPI on 2026-09-02:

- **Dependency:** `fte>=0.4.0,<0.5.0` in `pyproject.toml`, `setup.py` and `requirements.txt`. The upper bound keeps a future 0.5 (which may change the wire format again) from being picked up silently.
- **Regex dialect:** 0.4.0 validates patterns up front and rejects syntax regex2dfa used to misread. Four built-in formats tripped it, including the default `manual-http-request/response`, so a default client or server could not start. Rewritten: `\C` → `.` (dummy-*, manual-http-response, and manual-ssh-* in `20131224.json`; `.` already means any of the 256 byte values in regex2dfa), and `[a-zA-Z0-9\.\/]` → `[a-zA-Z0-9./]` in manual-http-request (the old class also admitted a literal backslash in the path). Capacities at length 256 are now 150 (request) and 192 (response). The table above is recomputed against the released 0.4.0 (its frame is 29 bytes, 4 fewer than the branch #221 measured).
- `examples/programmatic/custom_format.py`: the `{3}` brace quantifier is rejected; the extension is spelled out.
- **CI:** `tests.yml` now runs on every pull request, so the stacked PRs get CI (the trigger was filtered to PRs targeting master).

## Validation

- 89 tests pass against PyPI `fte==0.4.0` (Python 3.14, macOS), including the relay and CLI system tests.
- `fteproxy --mode server` builds a cipher for all 46 formats in `20260110.json` and all 6 in `20131224.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
