### PR TITLE
Record layer: hybrid mode (default) with a formatted header and raw body

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.3.2"
 
 import sys
 import socket
+import hashlib
 import traceback
 
 import fteproxy.conf
@@ -27,6 +28,37 @@ def _make_cipher(pattern, length, key):
         output_format=fte.RegexFormat(pattern, length=length),
         key=key,
     )
+
+
+def _hybrid_mode():
+    """Whether the record layer runs in 'hybrid' (fast bulk) mode.
+
+    'format' (default) transforms every covertext byte into the target format
+    for maximum unobservability. 'hybrid' formats only a fixed-length header per
+    record and carries the body as raw authenticated bytes: much faster for
+    bulk transfer, but everything past the header looks like random data.
+    """
+    return fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode') == 'hybrid'
+
+
+def _make_body_cipher(key):
+    """The format-agnostic raw-bytes AEAD carrier used for hybrid-mode bodies.
+
+    Uses libfte's identity format (no DFA, so it runs at AEAD speed). The body
+    key is a distinct subkey so body and header ciphers never share key material.
+    """
+    body_key = hashlib.sha256(key + b'fteproxy/record-layer/body/v1').digest()
+    return fte.FTE(output_format=fte.BytesFormat(), key=body_key)
+
+
+def _record_encoder(header_cipher, key):
+    body = _make_body_cipher(key) if _hybrid_mode() else None
+    return fteproxy.record_layer.Encoder(cipher=header_cipher, body_cipher=body)
+
+
+def _record_decoder(header_cipher, key):
+    body = _make_body_cipher(key) if _hybrid_mode() else None
+    return fteproxy.record_layer.Decoder(cipher=header_cipher, body_cipher=body)
 
 
 class InvalidRoleException(Exception):
@@ -159,8 +191,9 @@ class NegotiationManager(object):
                 incoming_length = fteproxy.defs.getLength(
                     incoming_language)
 
-                incoming_cipher = _make_cipher(incoming_regex, incoming_length, self._key())
-                decoder = fteproxy.record_layer.Decoder(cipher=incoming_cipher)
+                key = self._key()
+                incoming_cipher = _make_cipher(incoming_regex, incoming_length, key)
+                decoder = _record_decoder(incoming_cipher, key)
 
                 decoder.push(data)
                 negotiate_cell = decoder.pop(oneCell=True)
@@ -183,11 +216,11 @@ class NegotiationManager(object):
 
         if outgoing_regex != None and outgoing_length != -1:
             outgoing_cipher = _make_cipher(outgoing_regex, outgoing_length, key)
-            encoder = fteproxy.record_layer.Encoder(cipher=outgoing_cipher)
+            encoder = _record_encoder(outgoing_cipher, key)
 
         if incoming_regex != None and incoming_length != -1:
             incoming_cipher = _make_cipher(incoming_regex, incoming_length, key)
-            decoder = fteproxy.record_layer.Decoder(cipher=incoming_cipher)
+            decoder = _record_decoder(incoming_cipher, key)
 
         return [encoder, decoder]
 

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -266,12 +266,12 @@ def get_args():
     parser.add_argument('--record-layer-mode', action=setConfValue,
                         metavar='(format|hybrid)',
                         choices=['format', 'hybrid'],
-                        help='Record framing. "format" (default) transforms '
-                             'every byte into the target format for maximum '
-                             'unobservability. "hybrid" formats only a header '
-                             'per record and sends the body as raw bytes: much '
-                             'faster for bulk, but only the header blends in. '
-                             'Both endpoints must match.',
+                        help='Record framing. "hybrid" (default) formats a '
+                             'header per record and sends the body as raw '
+                             'bytes: fast, but only the header blends in with '
+                             'the target protocol. "format" transforms every '
+                             'byte into the format for full-stream realism at '
+                             'much lower throughput. Both endpoints must match.',
                         default=fteproxy.conf.getValue(
                             'runtime.fteproxy.record_layer.mode'))
     key_group = parser.add_mutually_exclusive_group()

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -195,6 +195,7 @@ def get_args():
                 "--upstream-format":    "runtime.state.upstream_language",
                 "--release":            "fteproxy.defs.release",
                 "--key":                "runtime.fteproxy.encrypter.key",
+                "--record-layer-mode":  "runtime.fteproxy.record_layer.mode",
             }
 
             if self.dest == "key_file":
@@ -262,6 +263,17 @@ def get_args():
     parser.add_argument('--release', action=setConfValue,
                         help='Definitions file to use, specified as YYYYMMDD',
                         default=fteproxy.conf.getValue('fteproxy.defs.release'))
+    parser.add_argument('--record-layer-mode', action=setConfValue,
+                        metavar='(format|hybrid)',
+                        choices=['format', 'hybrid'],
+                        help='Record framing. "format" (default) transforms '
+                             'every byte into the target format for maximum '
+                             'unobservability. "hybrid" formats only a header '
+                             'per record and sends the body as raw bytes: much '
+                             'faster for bulk, but only the header blends in. '
+                             'Both endpoints must match.',
+                        default=fteproxy.conf.getValue(
+                            'runtime.fteproxy.record_layer.mode'))
     key_group = parser.add_mutually_exclusive_group()
     key_group.add_argument('--key', action=setConfValue,
                         help='Cryptographic key, hex, must be exactly 64 characters',

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -113,6 +113,18 @@ only ever as large as the data already available)."""
 conf['runtime.fteproxy.record_layer.max_cell_size'] = 2 ** 18
 
 
+"""Record-layer framing mode.
+
+'format' (the default) transforms every covertext byte into the target format,
+for maximum unobservability. 'hybrid' formats only a fixed-length header per
+record and carries the body as raw authenticated bytes: far faster for bulk
+transfer (the DFA rank/unrank runs once per record, not once per ~150 bytes),
+but everything past the header looks like random/encrypted data, so only the
+start of each record blends in with the target protocol. Both endpoints must
+use the same mode."""
+conf['runtime.fteproxy.record_layer.mode'] = 'format'
+
+
 """The default client-to-server language."""
 conf['runtime.state.upstream_language'] = 'manual-http-request'
 

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -115,14 +115,17 @@ conf['runtime.fteproxy.record_layer.max_cell_size'] = 2 ** 18
 
 """Record-layer framing mode.
 
-'format' (the default) transforms every covertext byte into the target format,
-for maximum unobservability. 'hybrid' formats only a fixed-length header per
-record and carries the body as raw authenticated bytes: far faster for bulk
-transfer (the DFA rank/unrank runs once per record, not once per ~150 bytes),
-but everything past the header looks like random/encrypted data, so only the
-start of each record blends in with the target protocol. Both endpoints must
-use the same mode."""
-conf['runtime.fteproxy.record_layer.mode'] = 'format'
+'hybrid' (the default) formats a fixed-length header per record and carries the
+body as raw authenticated bytes: the DFA rank/unrank runs once per record, not
+once per ~150 bytes, so bulk transfer runs close to raw-AEAD speed. Only each
+record's header blends in with the target protocol; the body past it is
+high-entropy ciphertext. This is the behavior fteproxy shipped on libfte 0.3.
+
+'format' transforms every covertext byte into the target format, so the whole
+stream is indistinguishable from the protocol: stronger against entropy or
+statistical detectors, but much slower. Turn it up when you want full-stream
+realism and can spend the throughput. Both endpoints must use the same mode."""
+conf['runtime.fteproxy.record_layer.mode'] = 'hybrid'
 
 
 """The default client-to-server language."""

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -3,9 +3,16 @@
 
 
 
+import struct
+
 import fte
 
 import fteproxy.conf
+
+
+# Hybrid-mode header: a fixed-width big-endian body length. The header is one
+# FTE-formatted covertext; the body that follows it is `body_len` raw bytes.
+_BODY_LEN = struct.Struct('>I')
 
 
 class Encoder:
@@ -13,13 +20,18 @@ class Encoder:
     def __init__(
         self,
         cipher,
+        body_cipher=None,
     ):
         self._cipher = cipher
-        # libfte 0.4 caps the plaintext a single covertext can carry at the
-        # output format's capacity; there is no unformatted-overflow escape
-        # hatch anymore. Chunk the stream to that capacity so every cell maps
-        # to exactly one fixed-length covertext.
-        self._capacity = cipher.max_plaintext_bytes
+        self._body_cipher = body_cipher
+        # 'format' mode: one fixed-length covertext per capacity-sized chunk, the
+        # whole covertext transformed into the target format.
+        # 'hybrid' mode: a fixed-length FTE header (carrying the body length)
+        # followed by the raw BytesFormat body. Chunk by the body's capacity,
+        # which is far larger (~1 MiB) than a formatted covertext's, so bulk data
+        # pays the DFA cost once per record instead of once per ~150 bytes.
+        carrier = body_cipher if body_cipher is not None else cipher
+        self._capacity = carrier.max_plaintext_bytes
         self._buffer = b''
 
     def push(self, data):
@@ -29,25 +41,30 @@ class Encoder:
         self._buffer += data
 
     def pop(self):
-        """Pop data off the FIFO buffer. We pop the whole buffer, sliced into
-        capacity-sized chunks. Each chunk is encrypted by ``cipher`` (from
-        ``__init__``) into one fixed-length covertext of the output format.
+        """Pop the whole buffer, sliced into capacity-sized chunks and encrypted
+        into one record each with the ``cipher`` (and, in hybrid mode, the
+        ``body_cipher``) from ``__init__``.
         """
         buffer = self._buffer
         if not buffer:
             return b''
 
         # Encrypt each ``self._capacity`` slice via a moving offset and join the
-        # cells once at the end. Slicing the head off ``self._buffer`` inside the
-        # loop instead would recopy the whole remaining buffer every iteration,
-        # making a single large ``push`` quadratic in the number of cells.
-        cells = []
+        # records once at the end. Slicing the head off ``self._buffer`` inside
+        # the loop instead would recopy the whole remaining buffer every
+        # iteration, making a single large ``push`` quadratic.
+        records = []
         for offset in range(0, len(buffer), self._capacity):
-            plaintext = buffer[offset:offset + self._capacity]
-            cells.append(self._cipher.encrypt(plaintext))
+            chunk = buffer[offset:offset + self._capacity]
+            if self._body_cipher is None:
+                records.append(self._cipher.encrypt(chunk))
+            else:
+                body = self._body_cipher.encrypt(chunk)
+                header = self._cipher.encrypt(_BODY_LEN.pack(len(body)))
+                records.append(header + body)
 
         self._buffer = b''
-        return b''.join(cells)
+        return b''.join(records)
 
 
 class Decoder:
@@ -55,13 +72,16 @@ class Decoder:
     def __init__(
         self,
         cipher,
+        body_cipher=None,
     ):
         self._cipher = cipher
+        self._body_cipher = body_cipher
         # A fixed-length output format emits one covertext of exactly
-        # ``max_length`` bytes per message, and ``decrypt`` consumes exactly one
-        # such value (it does not return a remainder). The record layer therefore
-        # frames the byte stream itself, slicing whole covertexts off the head of
-        # the buffer and leaving any trailing partial frame for the next push.
+        # ``max_length`` bytes, and ``decrypt`` consumes exactly one such value
+        # (no remainder). The record layer frames the byte stream itself: in
+        # 'format' mode a record is that one covertext; in 'hybrid' mode it is
+        # the fixed-length header covertext plus the ``body_len`` raw bytes the
+        # header carries. Either way a trailing partial record stays buffered.
         self._frame_size = cipher.output_format.max_length
         self._buffer = b''
 
@@ -71,50 +91,70 @@ class Decoder:
             data = data.encode('utf-8')
         self._buffer += data
 
-    def pop(self, oneCell=False):
-        """Pop data off the FIFO buffer.
-        The returned value is one or more covertext frames decrypted by
-        ``cipher`` (from ``__init__``).
-        """
+    def _decrypt(self, cipher, covertext):
+        """Decrypt one covertext, mapping libfte errors to fteproxy semantics.
 
-        # Consume whole covertext frames from a local buffer and join the decoded
-        # messages once at the end; ``+= msg`` per cell would be quadratic in the
-        # number of cells. ``self._buffer`` is written back once, and on a decode
-        # failure it keeps the undecodable remainder (the offset does not advance
-        # past a raising frame).
+        Returns the plaintext, or ``None`` if the frame is not (yet) decodable
+        and the caller should stop draining and keep it buffered.
+        """
+        try:
+            return cipher.decrypt(covertext)
+        except fte.MessageTooLargeError as e:
+            # A complete, authenticating frame that claims a plaintext the format
+            # cannot hold has no recoverable interpretation. This is the
+            # successor to libfte 0.3's UnrecoverableDecryptionError, so keep the
+            # fatal semantics.
+            fteproxy.fatal_error("fteproxy.record_layer.MessageTooLargeError: "+str(e))
+            # exit
+        except fte.InvalidCovertextError as e:
+            # A corrupt, wrong-format, or failed-MAC frame. The negotiation scan
+            # relies on this to fall through to the next candidate format.
+            fteproxy.info("fteproxy.record_layer.InvalidCovertextError: "+str(e))
+            return None
+        except fte.FTEError as e:
+            fteproxy.warn("fteproxy.record_layer exception: "+str(e))
+            return None
+
+    def pop(self, oneCell=False):
+        """Pop decrypted messages off the FIFO buffer, one record at a time."""
+
+        # Consume whole records from a local buffer and join the messages once at
+        # the end; ``+= msg`` per record would be quadratic. ``self._buffer`` is
+        # written back once, and the offset never advances past a record that
+        # cannot (yet) be decoded, so the undecodable remainder is preserved.
         buffer = self._buffer
         messages = []
         offset = 0
 
         while len(buffer) - offset >= self._frame_size:
-            covertext = buffer[offset:offset + self._frame_size]
-            try:
-                msg = self._cipher.decrypt(covertext)
-            except fte.MessageTooLargeError as e:
-                # A complete, authenticating frame that claims a plaintext the
-                # format cannot hold has no recoverable interpretation. This is
-                # the successor to libfte 0.3's UnrecoverableDecryptionError, so
-                # keep the fatal semantics.
-                fteproxy.fatal_error("fteproxy.record_layer.MessageTooLargeError: "+str(e))
-                # exit
-            except fte.InvalidCovertextError as e:
-                # A corrupt, wrong-format, or failed-MAC frame. Stop draining and
-                # leave the bytes buffered. The negotiation scan relies on this to
-                # fall through to the next candidate format.
-                fteproxy.info("fteproxy.record_layer.InvalidCovertextError: "+str(e))
-                break
-            except fte.FTEError as e:
-                fteproxy.warn("fteproxy.record_layer exception: "+str(e))
+            header = buffer[offset:offset + self._frame_size]
+            head = self._decrypt(self._cipher, header)
+            if head is None:
                 break
 
-            messages.append(msg)
-            offset += self._frame_size
+            if self._body_cipher is None:
+                # 'format' mode: the header covertext IS the message.
+                messages.append(head)
+                offset += self._frame_size
+            else:
+                # 'hybrid' mode: the header carries the raw body's length. The
+                # header is authenticated, so a successful decrypt means we wrote
+                # it and the length is trustworthy.
+                body_len = _BODY_LEN.unpack(head)[0]
+                body_start = offset + self._frame_size
+                if len(buffer) - body_start < body_len:
+                    break  # body not fully arrived; wait for more data
+                body = buffer[body_start:body_start + body_len]
+                msg = self._decrypt(self._body_cipher, body)
+                if msg is None:
+                    break
+                messages.append(msg)
+                offset = body_start + body_len
 
-            # Stop after a single cell only once one was decoded successfully.
-            # This must live outside a ``finally`` block: a ``break`` in
-            # ``finally`` swallows any in-flight exception (including the
-            # SystemExit raised by ``fatal_error`` on a fatal decryption error),
-            # silently turning a fatal condition into a normal return.
+            # Stop after a single record only once one decoded successfully. This
+            # must live here, not in a ``finally``: a ``break`` in ``finally``
+            # swallows any in-flight exception (including the SystemExit raised by
+            # ``fatal_error``), silently turning a fatal condition into a return.
             if oneCell:
                 break
 

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -139,7 +139,14 @@ class Decoder:
             else:
                 # 'hybrid' mode: the header carries the raw body's length. The
                 # header is authenticated, so a successful decrypt means we wrote
-                # it and the length is trustworthy.
+                # it and the length is trustworthy. A header that authenticates
+                # but is not exactly the expected width is a peer running a
+                # different mode (or corruption); treat it as undecodable.
+                if len(head) != _BODY_LEN.size:
+                    fteproxy.info(
+                        "fteproxy.record_layer: unexpected header width "
+                        + str(len(head)))
+                    break
                 body_len = _BODY_LEN.unpack(head)[0]
                 body_start = offset + self._frame_size
                 if len(buffer) - body_start < body_len:

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -204,12 +204,14 @@ class TestWrapSocket:
         assert received_data[0] == test_data
         assert echo_data == test_data
 
-    def test_wrap_socket_hybrid_mode_end_to_end(self):
-        """Full negotiation + bulk transfer in hybrid record-layer mode."""
+    @pytest.mark.parametrize("mode", ["format", "hybrid"])
+    def test_wrap_socket_bulk_end_to_end(self, mode):
+        """Full negotiation + bulk transfer, in each record-layer mode."""
         import threading
         import time
 
-        fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'hybrid')
+        prev_mode = fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode')
+        fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', mode)
         try:
             fteproxy.conf.setValue('runtime.mode', 'client')
             fteproxy.defs.load_definitions()
@@ -275,4 +277,4 @@ class TestWrapSocket:
             assert received.get('data') == payload
             assert echo == payload
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'format')
+            fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', prev_mode)

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -198,8 +198,81 @@ class TestWrapSocket:
             client_sock.close()
         
         server.join(timeout=5)
-        
+
         # Verify data was received correctly
         assert len(received_data) == 1
         assert received_data[0] == test_data
         assert echo_data == test_data
+
+    def test_wrap_socket_hybrid_mode_end_to_end(self):
+        """Full negotiation + bulk transfer in hybrid record-layer mode."""
+        import threading
+        import time
+
+        fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'hybrid')
+        try:
+            fteproxy.conf.setValue('runtime.mode', 'client')
+            fteproxy.defs.load_definitions()
+            up = fteproxy.conf.getValue('runtime.state.upstream_language')
+            down = fteproxy.conf.getValue('runtime.state.downstream_language')
+            up_rx = fteproxy.defs.getRegex(up)
+            up_fs = fteproxy.defs.getLength(up)
+            dn_rx = fteproxy.defs.getRegex(down)
+            dn_fs = fteproxy.defs.getLength(down)
+            # Large enough to span many records (each body up to ~1 MiB).
+            payload = b'hybrid bulk payload ' * 4096  # ~80 KiB
+            received = {}
+
+            def server_thread(port):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s = fteproxy.wrap_socket(s)  # server auto-detects via negotiation
+                s.bind(('127.0.0.1', port))
+                s.listen(1)
+                conn, _ = s.accept()
+                conn.settimeout(5)
+                try:
+                    buf = b''
+                    while len(buf) < len(payload):
+                        data = conn.recv(65536)
+                        if not data:
+                            break
+                        buf += data
+                    received['data'] = buf
+                    conn.sendall(buf)  # echo
+                finally:
+                    conn.close()
+                    s.close()
+
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            probe.bind(('127.0.0.1', 0))
+            port = probe.getsockname()[1]
+            probe.close()
+
+            server = threading.Thread(target=server_thread, args=(port,))
+            server.start()
+            time.sleep(0.5)
+
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client = fteproxy.wrap_socket(
+                client,
+                outgoing_regex=up_rx, outgoing_length=up_fs,
+                incoming_regex=dn_rx, incoming_length=dn_fs)
+            try:
+                client.connect(('127.0.0.1', port))
+                client.settimeout(5)
+                client.sendall(payload)
+                echo = b''
+                while len(echo) < len(payload):
+                    data = client.recv(65536)
+                    if not data:
+                        break
+                    echo += data
+            finally:
+                client.close()
+
+            server.join(timeout=5)
+            assert received.get('data') == payload
+            assert echo == payload
+        finally:
+            fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'format')

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -153,3 +153,58 @@ class TestDecoderExceptionHandling:
 
         assert decoder.pop() == b'AAAABBBBCCCC'
         assert decoder._buffer == b''
+
+
+class TestHybridRecordLayer:
+    """The hybrid framing: a formatted header covertext + a raw BytesFormat body."""
+
+    def _pair(self, language='manual-http-request'):
+        fteproxy.conf.setValue('runtime.mode', 'client')
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        pattern = fteproxy.defs.getRegex(language)
+        length = fteproxy.defs.getLength(language)
+        header = fteproxy._make_cipher(pattern, length, key)
+        body = fteproxy._make_body_cipher(key)
+        encoder = fteproxy.record_layer.Encoder(cipher=header, body_cipher=body)
+        decoder = fteproxy.record_layer.Decoder(cipher=header, body_cipher=body)
+        return encoder, decoder
+
+    def test_roundtrip_various_sizes(self):
+        encoder, decoder = self._pair()
+        for j in range(0, 8192, 256):
+            payload = b'X' * j + b'Y'
+            encoder.push(payload)
+            wire = b''
+            while True:
+                data = encoder.pop()
+                if not data:
+                    break
+                wire += data
+            decoder.push(wire)
+            out = b''
+            while True:
+                data = decoder.pop()
+                if not data:
+                    break
+                out += data
+            assert out == payload, f"hybrid roundtrip failed at {len(payload)} bytes"
+
+    def test_header_is_formatted_body_is_raw(self):
+        """The record opens with a valid target-format covertext; the bulk is raw."""
+        encoder, decoder = self._pair()
+        encoder.push(b'Z' * 4000)
+        wire = encoder.pop()
+        assert wire[:5] == b'GET /'          # looks like the HTTP request format
+        assert len(wire) < 4000 * 1.2        # near-1x expansion (raw body)
+
+    def test_partial_arrival_reassembles(self):
+        """A record split across many small reads still reassembles."""
+        encoder, decoder = self._pair()
+        payload = (b'the quick brown fox 0123456789 ' * 700)  # ~21 KiB, multi-record
+        encoder.push(payload)
+        wire = encoder.pop()
+        out = b''
+        for i in range(0, len(wire), 333):
+            decoder.push(wire[i:i + 333])
+            out += decoder.pop()
+        assert out == payload

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -33,8 +33,10 @@ def _make_cell(payload):
     """Encode ``payload`` into one covertext record-layer cell."""
     pattern, length = _regex_length()
     key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-    encoder = fteproxy.record_layer.Encoder(
-        cipher=fteproxy._make_cipher(pattern, length, key))
+    header = fteproxy._make_cipher(pattern, length, key)
+    # Build through _record_encoder so the cell matches the configured mode (the
+    # wrapper under test decodes with whatever mode conf says).
+    encoder = fteproxy._record_encoder(header, key)
     encoder.push(payload)
     return encoder.pop()
 


### PR DESCRIPTION
## Summary

Reintroduces the formatted-header + raw-body record framing that fteproxy shipped on libfte 0.3, as a record-layer **mode**, and makes it the default.

**Part 3 of 5** of splitting #221, stacked on #225.

## Why

libfte 0.4 formats every covertext byte. A straight port therefore runs the DFA rank/unrank once per ~150 bytes of payload, which measured ~400x slower for bulk than 0.3's formatted-header + raw-overflow scheme. The record layer now has two modes:

- **`hybrid` (default).** Each record is one FTE-formatted header (carrying the raw body's length) followed by a raw authenticated body. The DFA runs once per record instead of once per ~150 bytes. This is the scheme fteproxy shipped on libfte 0.3, so the default keeps the historical behavior and throughput. In this PR the body is carried by libfte's identity `BytesFormat` under a derived subkey (part 5 replaces it with an OpenSSL AES-CTR+HMAC body).
- **`format` (opt-in, `--record-layer-mode format`).** Every covertext byte is transformed into the target format, so the whole stream is indistinguishable from the protocol: stronger against entropy/statistical detectors, but much slower.

Framing is self-delimiting (the header carries the body length), handles partial arrival across reads, and works on the negotiation path. Config: `runtime.fteproxy.record_layer.mode` / `--record-layer-mode`; **both endpoints must use the same mode**. The decoder guards a header that authenticates but is not the expected width (a peer on a different mode, or corruption) instead of raising `struct.error`.

**Security tradeoff.** In `hybrid`, only each record's header blends in with the target protocol; the body past it is raw, high-entropy ciphertext. Against a regex/protocol classifier (nDPI, l7-filter, Zeek: FTE's stated threat model) the header carries it; against an entropy/statistical detector, only `format` holds up.

## Measured (commit 1 of this PR, manual-http-request, 256 KiB)

format 0.16 MB/s → hybrid ~53 MB/s; wire expansion 1.77x → 1.03x. Part 5 takes hybrid to hundreds of MB/s.

## What changed

- `fteproxy/record_layer.py`: `Encoder`/`Decoder` take an optional `body_cipher`; hybrid framing.
- `fteproxy/__init__.py`: `_hybrid_mode()`, `_make_body_cipher()`, and the `_record_encoder`/`_record_decoder` factories that pick the mode.
- `fteproxy/conf.py`: `runtime.fteproxy.record_layer.mode` (default `hybrid`); `fteproxy/cli.py`: `--record-layer-mode`.
- Tests: hybrid round trips, partial arrival, header-formatted/body-raw; an end-to-end `wrap_socket` test parametrized over both modes; `test_socket_wrapper` builds cells through `_record_encoder` so they match the configured mode.

## Validation

96 tests pass against PyPI `fte==0.4.0` (relay and system suites exercise `hybrid` by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
