### PR TITLE
Record layer: AES-CTR+HMAC-SHA256 hybrid body with per-record sequence binding

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -3,6 +3,7 @@
 
 __version__ = "0.3.2"
 
+import os
 import sys
 import socket
 import hashlib
@@ -13,6 +14,8 @@ import fteproxy.defs
 import fteproxy.record_layer
 
 import fte
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 
 def _make_cipher(pattern, length, key):
@@ -41,14 +44,41 @@ def _hybrid_mode():
     return fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode') == 'hybrid'
 
 
-def _make_body_cipher(key):
-    """The format-agnostic raw-bytes AEAD carrier used for hybrid-mode bodies.
+class _AEADBody:
+    """AES-256-GCM carrier for hybrid-mode record bodies.
 
-    Uses libfte's identity format (no DFA, so it runs at AEAD speed). The body
-    key is a distinct subkey so body and header ciphers never share key material.
+    libfte's identity format works as a body carrier but routes it through the
+    FTE engine (AES-CTR + HMAC-SHA512 + a big-integer frame), which is ~25-70x
+    slower than OpenSSL's AES-GCM. This carries the body directly: a fresh random
+    nonce per record (prepended to the ciphertext) plus the record's sequence
+    number as associated data, so a body authenticates only in its original
+    stream position -- reorder, drop, or replay a record and the tag check fails.
+    This is a standard AEAD (cryptography's AESGCM), not hand-rolled crypto;
+    fteproxy's only responsibility is a unique nonce per record, which the random
+    nonce satisfies. The body key is a distinct subkey, so body and header
+    ciphers never share key material.
     """
-    body_key = hashlib.sha256(key + b'fteproxy/record-layer/body/v1').digest()
-    return fte.FTE(output_format=fte.BytesFormat(), key=body_key)
+    _NONCE = 12
+    # Largest body a single record carries. Bounds memory and amortizes the one
+    # formatted header per record over a large payload.
+    max_plaintext_bytes = 2 ** 20
+
+    def __init__(self, key):
+        body_key = hashlib.sha256(key + b'fteproxy/record-layer/body/v2').digest()
+        self._aead = AESGCM(body_key)
+
+    def encrypt(self, plaintext, seq):
+        nonce = os.urandom(self._NONCE)
+        return nonce + self._aead.encrypt(nonce, plaintext, seq.to_bytes(8, 'big'))
+
+    def decrypt(self, framed, seq):
+        nonce, ciphertext = framed[:self._NONCE], framed[self._NONCE:]
+        return self._aead.decrypt(nonce, ciphertext, seq.to_bytes(8, 'big'))
+
+
+def _make_body_cipher(key):
+    """The AEAD carrier for hybrid-mode record bodies (see :class:`_AEADBody`)."""
+    return _AEADBody(key)
 
 
 def _record_encoder(header_cipher, key):

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.3.2"
 
 import os
 import sys
+import hmac
 import socket
 import hashlib
 import traceback
@@ -15,7 +16,8 @@ import fteproxy.record_layer
 
 import fte
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 
 def _make_cipher(pattern, length, key):
@@ -45,35 +47,50 @@ def _hybrid_mode():
 
 
 class _AEADBody:
-    """AES-256-GCM carrier for hybrid-mode record bodies.
+    """AES-128-CTR + HMAC-SHA256 (Encrypt-then-MAC) carrier for hybrid-mode bodies.
 
-    libfte's identity format works as a body carrier but routes it through the
-    FTE engine (AES-CTR + HMAC-SHA512 + a big-integer frame), which is ~25-70x
-    slower than OpenSSL's AES-GCM. This carries the body directly: a fresh random
-    nonce per record (prepended to the ciphertext) plus the record's sequence
-    number as associated data, so a body authenticates only in its original
-    stream position -- reorder, drop, or replay a record and the tag check fails.
-    This is a standard AEAD (cryptography's AESGCM), not hand-rolled crypto;
-    fteproxy's only responsibility is a unique nonce per record, which the random
-    nonce satisfies. The body key is a distinct subkey, so body and header
-    ciphers never share key material.
+    Matches libfte's AE construction (the FTE paper's CTR+HMAC). Under
+    fteproxy's static shared key, Encrypt-then-MAC means a nonce collision costs
+    only the confidentiality of the colliding pair, never authenticity. Each
+    record binds its sequence number into the MAC, so a reordered, dropped, or
+    replayed record fails authentication. The encryption and MAC subkeys are derived from
+    a distinct namespace, independent of the header cipher's key. libfte does the
+    same construction for the formatted header; this is the raw-body counterpart
+    the FTE paper appended as unformatted ciphertext.
     """
     _NONCE = 12
+    _TAG = 16
+    _COUNTER = 16  # AES block: 12-byte nonce || 4-byte block counter
     # Largest body a single record carries. Bounds memory and amortizes the one
     # formatted header per record over a large payload.
     max_plaintext_bytes = 2 ** 20
 
     def __init__(self, key):
-        body_key = hashlib.sha256(key + b'fteproxy/record-layer/body/v2').digest()
-        self._aead = AESGCM(body_key)
+        self._enc_key = hashlib.sha256(key + b'fteproxy/record-layer/body/enc/v3').digest()[:16]
+        self._mac_key = hashlib.sha256(key + b'fteproxy/record-layer/body/mac/v3').digest()
+
+    def _counter(self, nonce):
+        return nonce + b'\x00' * (self._COUNTER - self._NONCE)
+
+    def _tag(self, seq, nonce, ciphertext):
+        return hmac.new(
+            self._mac_key, seq.to_bytes(8, 'big') + nonce + ciphertext, hashlib.sha256
+        ).digest()[:self._TAG]
 
     def encrypt(self, plaintext, seq):
         nonce = os.urandom(self._NONCE)
-        return nonce + self._aead.encrypt(nonce, plaintext, seq.to_bytes(8, 'big'))
+        enc = Cipher(algorithms.AES(self._enc_key), modes.CTR(self._counter(nonce))).encryptor()
+        ciphertext = enc.update(plaintext) + enc.finalize()
+        return nonce + ciphertext + self._tag(seq, nonce, ciphertext)
 
     def decrypt(self, framed, seq):
-        nonce, ciphertext = framed[:self._NONCE], framed[self._NONCE:]
-        return self._aead.decrypt(nonce, ciphertext, seq.to_bytes(8, 'big'))
+        nonce = framed[:self._NONCE]
+        tag = framed[-self._TAG:]
+        ciphertext = framed[self._NONCE:-self._TAG]
+        if not hmac.compare_digest(self._tag(seq, nonce, ciphertext), tag):
+            raise InvalidTag()
+        dec = Cipher(algorithms.AES(self._enc_key), modes.CTR(self._counter(nonce))).decryptor()
+        return dec.update(ciphertext) + dec.finalize()
 
 
 def _make_body_cipher(key):

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -99,20 +99,6 @@ conf['runtime.fteproxy.relay.throttle'] = 0.01
 conf['runtime.fteproxy.negotiate.timeout'] = 5
 
 
-"""The maximum plaintext bytes packed into a single outgoing FTE cell.
-
-Each ``encode`` call carries a fixed per-cell cost (rank/unrank only touches
-the format's ~capacity bytes; the rest of the payload rides along as raw
-ciphertext), so throughput is set by how much plaintext each cell amortizes
-that cost over. The relay hands up to ``network_io.recvall_from_socket``'s
-``bufsize`` (2**18) of plaintext per write, so a smaller cell size merely
-re-splits one read into several encode calls. Matching the two lets a full
-read become a single cell -- ~3x single-stream bulk throughput on fast links
-with lower per-cell framing overhead, and no latency cost (a cell is still
-only ever as large as the data already available)."""
-conf['runtime.fteproxy.record_layer.max_cell_size'] = 2 ** 18
-
-
 """Record-layer framing mode.
 
 'hybrid' (the default) formats a fixed-length header per record and carries the

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -63,7 +63,7 @@ class Encoder:
             self._capacity = cipher.max_plaintext_bytes - _LEN.size
         else:
             # 'hybrid' mode: a sealed FTE header (carrying the body length)
-            # followed by the raw AES-GCM body. Chunk by the body's capacity, far
+            # followed by the raw authenticated body. Chunk by the body's capacity, far
             # larger than a covertext's, so bulk data pays the DFA cost once per
             # record instead of once per ~150 bytes.
             self._capacity = body_cipher.max_plaintext_bytes

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -7,6 +7,7 @@ import os
 import struct
 
 import fte
+from cryptography.exceptions import InvalidTag
 
 import fteproxy.conf
 
@@ -62,11 +63,12 @@ class Encoder:
             self._capacity = cipher.max_plaintext_bytes - _LEN.size
         else:
             # 'hybrid' mode: a sealed FTE header (carrying the body length)
-            # followed by the raw BytesFormat body. Chunk by the body's capacity,
-            # far larger than a covertext's, so bulk data pays the DFA cost once
-            # per record instead of once per ~150 bytes.
+            # followed by the raw AES-GCM body. Chunk by the body's capacity, far
+            # larger than a covertext's, so bulk data pays the DFA cost once per
+            # record instead of once per ~150 bytes.
             self._capacity = body_cipher.max_plaintext_bytes
         self._buffer = b''
+        self._seq = 0
 
     def push(self, data):
         """Push data onto the FIFO buffer."""
@@ -93,7 +95,8 @@ class Encoder:
             if self._body_cipher is None:
                 records.append(_seal(self._cipher, chunk))
             else:
-                body = self._body_cipher.encrypt(chunk)
+                body = self._body_cipher.encrypt(chunk, self._seq)
+                self._seq += 1
                 header = _seal(self._cipher, _OVERFLOW_LEN.pack(len(body)))
                 records.append(header + body)
 
@@ -118,6 +121,7 @@ class Decoder:
         # Either way a trailing partial record stays buffered.
         self._frame_size = cipher.output_format.max_length
         self._buffer = b''
+        self._seq = 0
 
     def push(self, data):
         """Push data onto the FIFO buffer."""
@@ -190,9 +194,16 @@ class Decoder:
                 if len(buffer) - body_start < body_len:
                     break  # body not fully arrived; wait for more data
                 body = buffer[body_start:body_start + body_len]
-                msg = self._decrypt(self._body_cipher, body)
-                if msg is None:
+                try:
+                    msg = self._body_cipher.decrypt(body, self._seq)
+                except InvalidTag:
+                    # Wrong key, corruption, or a record out of its stream
+                    # position (reorder/drop/replay). Stop draining.
+                    fteproxy.info(
+                        "fteproxy.record_layer: body auth failed at seq "
+                        + str(self._seq))
                     break
+                self._seq += 1
                 messages.append(msg)
                 offset = body_start + body_len
 

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -159,7 +159,7 @@ class TestDecoderExceptionHandling:
 
 
 class TestHybridRecordLayer:
-    """The hybrid framing: a formatted header covertext + a raw BytesFormat body."""
+    """The hybrid framing: a formatted header covertext + a raw AES-GCM body."""
 
     def _pair(self, language='manual-http-request'):
         fteproxy.conf.setValue('runtime.mode', 'client')
@@ -211,6 +211,23 @@ class TestHybridRecordLayer:
             decoder.push(wire[i:i + 333])
             out += decoder.pop()
         assert out == payload
+
+    def test_reordered_record_is_rejected(self):
+        """A record moved out of its stream position fails the body auth."""
+        encoder, _ = self._pair()
+        encoder.push(b'first'); r0 = encoder.pop()    # seq 0
+        encoder.push(b'second'); r1 = encoder.pop()   # seq 1
+
+        # In order: both records decode.
+        d = self._pair()[1]
+        d.push(r0 + r1)
+        assert d.pop() == b'firstsecond'
+
+        # Swapped: the record built at seq 1 arrives where seq 0 is expected, so
+        # its body AEAD (seq as associated data) fails and nothing decodes.
+        d2 = self._pair()[1]
+        d2.push(r1 + r0)
+        assert d2.pop() == b''
 
 
 def test_seal_fills_covertext_with_random_not_padding():

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -159,7 +159,7 @@ class TestDecoderExceptionHandling:
 
 
 class TestHybridRecordLayer:
-    """The hybrid framing: a formatted header covertext + a raw AES-GCM body."""
+    """The hybrid framing: a formatted header covertext + a raw authenticated body."""
 
     def _pair(self, language='manual-http-request'):
         fteproxy.conf.setValue('runtime.mode', 'client')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "fte>=0.4.0,<0.5.0",
+    "cryptography>=41.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fte>=0.4.0,<0.5.0
+cryptography>=41.0
 pytest>=9.1.1
 pytest-timeout>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     },
     packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
     package_data=package_data,
-    install_requires=['fte>=0.4.0,<0.5.0'],
+    install_requires=['fte>=0.4.0,<0.5.0', 'cryptography>=41.0'],
     python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Summary

Carries the `hybrid` record body with OpenSSL **AES-128-CTR + HMAC-SHA256** (Encrypt-then-MAC, via `cryptography`), the same construction libfte 0.4.0 uses for the formatted header, with the record's **sequence number bound into the MAC**. Lands the default record layer at 3–8x the bulk throughput of libfte 0.3.

**Part 5 of 5** of splitting #221, stacked on #227. Adds the `cryptography>=41.0` dependency (already a transitive dependency via libfte 0.4).

## Why

Profiling showed the body was ~82% of hybrid's time and that the cipher implementation, not the disguise, was the bottleneck: routing the body through libfte's engine (`BytesFormat` + a big-integer frame) ran ~118 MB/s. The two commits here first move the body to AES-GCM (25–70x faster on the body), then to AES-CTR+HMAC-SHA256 so one AE construction spans the record; under fteproxy's static shared key, Encrypt-then-MAC means a nonce collision costs only the confidentiality of the colliding pair, never authenticity. Squash on merge.

`_AEADBody` frames each body as `nonce(12) || ciphertext || tag(16)` under encryption and MAC subkeys derived from the shared key in a distinct namespace. Each record binds its sequence number into the MAC, so a body authenticates only in its original stream position: reorder, drop, or replay a record within a connection and the tag check fails.

## Measured (Apple M3 Pro, `http-simple-request`, length 256, median record-layer encrypt+decrypt round trips)

| path | 256 KiB | 4 MiB | wire |
|---|---:|---:|---:|
| libfte 0.3 (baseline) | 64 MB/s | ~64 MB/s | 1.00x |
| **0.4 `hybrid` (default)** | **220 MB/s** | **500 MB/s** | **1.00x** |
| 0.4 `format` (opt-in) | 0.15 MB/s | 0.15 MB/s | 1.83x |

With the fast body, hybrid is bounded by the single formatted header per record (a fixed ~0.5 ms), so a stream of tiny records stays header-bound (~4 MB/s at 4 KiB) while bulk runs at hundreds of MB/s.

## What changed

- `fteproxy/__init__.py`: `_AEADBody`; `_make_body_cipher` returns it.
- `fteproxy/record_layer.py`: the per-record sequence counter on both sides; `InvalidTag` stops draining.
- `fteproxy/conf.py`: drops the now-unused `runtime.fteproxy.record_layer.max_cell_size`.
- `pyproject.toml` / `setup.py` / `requirements.txt`: `cryptography>=41.0`.
- Tests: a reordered record is rejected.

## Validation

98 tests pass against PyPI `fte==0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
