### PR TITLE
Record layer and CLI hardening from the 0.4 security review

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -52,9 +52,12 @@ class _AEADBody:
     Matches libfte's AE construction (the FTE paper's CTR+HMAC). Under
     fteproxy's static shared key, Encrypt-then-MAC means a nonce collision costs
     only the confidentiality of the colliding pair, never authenticity. Each
-    record binds its sequence number into the MAC, so a reordered, dropped, or
-    replayed record fails authentication. The encryption and MAC subkeys are derived from
-    a distinct namespace, independent of the header cipher's key. libfte does the
+    record binds its sequence number into the MAC, so a record reordered,
+    dropped, or replayed within its stream fails authentication. The key is
+    shared by every connection and both directions, so a record replayed at the
+    same position of another stream is not detected (see SECURITY.md). The
+    encryption and MAC subkeys are derived from a distinct namespace,
+    domain-separated from the header cipher's key. libfte does the
     same construction for the formatted header; this is the raw-body counterpart
     the FTE paper appended as unformatted ciphertext.
     """
@@ -64,6 +67,9 @@ class _AEADBody:
     # Largest body a single record carries. Bounds memory and amortizes the one
     # formatted header per record over a large payload.
     max_plaintext_bytes = 2 ** 20
+    # Largest framed body (nonce || ciphertext || tag) a header may announce;
+    # the decoder refuses to buffer more than this for one record.
+    max_framed_bytes = max_plaintext_bytes + _NONCE + _TAG
 
     def __init__(self, key):
         self._enc_key = hashlib.sha256(key + b'fteproxy/record-layer/body/enc/v3').digest()[:16]

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -415,6 +415,20 @@ class _FTESocketWrapper(FTEHelper, object):
             while True:
                 data = self._socket.recv(bufsize)
                 noData = (data == b'')
+                if noData and self._isServer and not self._negotiationComplete:
+                    # The peer closed before a negotiation cell decoded. Nothing
+                    # more will arrive, so report EOF. Treating this as "not
+                    # ready yet" (a socket.timeout) made the relay worker poll
+                    # the closed socket forever, since recv keeps returning b''.
+                    if self._preNegotiationBuffer_incoming:
+                        fteproxy.warn(
+                            'peer closed before negotiation completed: check '
+                            'that both endpoints share the key, '
+                            '--record-layer-mode, and the same fteproxy/libfte '
+                            'line (0.4 is not wire-compatible with 0.3)')
+                    else:
+                        fteproxy.info('peer closed without sending anything')
+                    return b''
                 data = self._processRecv(data)
 
                 if noData and not self._incoming_buffer and not self._decoder._buffer:

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -113,6 +113,7 @@ class FTEMain(threading.Thread):
 
         FTEMain.init_cipher(self, self._args.downstream_format)
         FTEMain.init_cipher(self, self._args.upstream_format)
+        warn_if_default_key()
 
         if not self._args.quiet:
             print('Client ready!')
@@ -127,6 +128,7 @@ class FTEMain(threading.Thread):
         languages = fteproxy.defs.load_definitions()
         for language in languages.keys():
             FTEMain.init_cipher(self, language)
+        warn_if_default_key()
 
         self._server = FTEMain.init_listener(self, 'server')
         self._server.daemon = True
@@ -141,6 +143,18 @@ def get_pid_file():
                               '.' + fteproxy.conf.getValue('runtime.mode')
                             + '-' + str(os.getpid()) + '.pid')
     return pid_file
+
+
+def warn_if_default_key():
+    """Warn when the built-in default key is in use.
+
+    libfte 0.4 requires a key, and fteproxy falls back to the constant in
+    ``fteproxy.conf`` when neither ``--key`` nor ``--key-file`` is given. That
+    key is public, so anyone can read and forge the tunnel's traffic.
+    """
+    if fteproxy.conf.getValue('runtime.fteproxy.encrypter.key') == fteproxy.conf.DEFAULT_KEY:
+        fteproxy.warn('using the built-in default key, which is public: pass '
+                      '--key or --key-file with a secret shared by both endpoints')
 
 
 def parse_hex_key(hex_key):

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -122,8 +122,11 @@ conf['runtime.state.upstream_language'] = 'manual-http-request'
 conf['runtime.state.downstream_language'] = 'manual-http-response'
 
 
-"""The default AE scheme key."""
-conf['runtime.fteproxy.encrypter.key'] = b'\xFF' * 16 + b'\x00' * 16
+"""The key used when neither --key nor --key-file is given. It is public (it
+is in this file), so it gives no confidentiality or integrity; fteproxy warns at
+startup when it is in use. Always supply a secret shared by both endpoints."""
+DEFAULT_KEY = b'\xFF' * 16 + b'\x00' * 16
+conf['runtime.fteproxy.encrypter.key'] = DEFAULT_KEY
 
 
 """The default length parameter to use for buildTable."""

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -14,13 +14,19 @@ import fteproxy.conf
 
 # Length prefix inside a sealed (random-padded) covertext plaintext.
 _LEN = struct.Struct('>I')
+# Sequence number inside a sealed covertext plaintext: the record's position in
+# its stream. A sealed covertext therefore only unseals at that position, so a
+# reordered, replayed, or dropped record is rejected in both modes (in hybrid
+# mode the body MAC binds the same number).
+_SEQ = struct.Struct('>Q')
+_SEAL_OVERHEAD = _LEN.size + _SEQ.size
 # Hybrid-mode header payload: the length of the raw body that follows it.
 _OVERFLOW_LEN = struct.Struct('>I')
 
 
-def _seal(cipher, message):
+def _seal(cipher, message, seq):
     """Encrypt ``message`` into one covertext, random-padded to the format's
-    full plaintext capacity.
+    full plaintext capacity and stamped with its stream position ``seq``.
 
     A short message otherwise ranks low and unranks into a covertext with a long
     run of the format's lowest character (the ``GET /0000...`` padding). Filling
@@ -30,21 +36,24 @@ def _seal(cipher, message):
     costs nothing on the wire (the covertext is a fixed length either way) and
     reveals nothing.
     """
-    plaintext = _LEN.pack(len(message)) + message
+    plaintext = _LEN.pack(len(message)) + _SEQ.pack(seq) + message
     pad = cipher.max_plaintext_bytes - len(plaintext)
     if pad > 0:
         plaintext += os.urandom(pad)
     return cipher.encrypt(plaintext)
 
 
-def _unseal(plaintext):
-    """Recover the message from a sealed plaintext, or ``None`` if it is malformed."""
-    if len(plaintext) < _LEN.size:
+def _unseal(plaintext, seq):
+    """Recover the message from a sealed plaintext, or ``None`` if it is
+    malformed or was sealed at a stream position other than ``seq``."""
+    if len(plaintext) < _SEAL_OVERHEAD:
         return None
-    length = _LEN.unpack(plaintext[:_LEN.size])[0]
-    if length > len(plaintext) - _LEN.size:
+    length = _LEN.unpack_from(plaintext)[0]
+    if _SEQ.unpack_from(plaintext, _LEN.size)[0] != seq:
         return None
-    return plaintext[_LEN.size:_LEN.size + length]
+    if length > len(plaintext) - _SEAL_OVERHEAD:
+        return None
+    return plaintext[_SEAL_OVERHEAD:_SEAL_OVERHEAD + length]
 
 
 class Encoder:
@@ -58,9 +67,9 @@ class Encoder:
         self._body_cipher = body_cipher
         if body_cipher is None:
             # 'format' mode: one sealed covertext per chunk. Reserve the length
-            # prefix; the rest of the covertext capacity is real payload, random-
-            # padded when the payload does not fill it.
-            self._capacity = cipher.max_plaintext_bytes - _LEN.size
+            # prefix and sequence number; the rest of the covertext capacity is
+            # real payload, random-padded when the payload does not fill it.
+            self._capacity = cipher.max_plaintext_bytes - _SEAL_OVERHEAD
         else:
             # 'hybrid' mode: a sealed FTE header (carrying the body length)
             # followed by the raw authenticated body. Chunk by the body's capacity, far
@@ -93,12 +102,12 @@ class Encoder:
         for offset in range(0, len(buffer), self._capacity):
             chunk = buffer[offset:offset + self._capacity]
             if self._body_cipher is None:
-                records.append(_seal(self._cipher, chunk))
+                records.append(_seal(self._cipher, chunk, self._seq))
             else:
                 body = self._body_cipher.encrypt(chunk, self._seq)
-                self._seq += 1
-                header = _seal(self._cipher, _OVERFLOW_LEN.pack(len(body)))
+                header = _seal(self._cipher, _OVERFLOW_LEN.pack(len(body)), self._seq)
                 records.append(header + body)
+            self._seq += 1
 
         self._buffer = b''
         return b''.join(records)
@@ -137,12 +146,14 @@ class Decoder:
         """
         try:
             return cipher.decrypt(covertext)
-        except fte.MessageTooLargeError as e:
-            # A complete, authenticating frame that claims a plaintext the format
-            # cannot hold has no recoverable interpretation. This is the
-            # successor to libfte 0.3's UnrecoverableDecryptionError, so keep the
-            # fatal semantics.
-            fteproxy.fatal_error("fteproxy.record_layer.MessageTooLargeError: "+str(e))
+        except fte.FormatContractError as e:
+            # The format provider broke the RankedFormat contract: a bug in the
+            # format, not bad input, so no frame can be trusted. Keep libfte
+            # 0.3's UnrecoverableDecryptionError semantics and stop the process.
+            # (In 0.4, decrypt never raises MessageTooLargeError; that is an
+            # encrypt-side limit. A corrupt or oversized covertext is the
+            # InvalidCovertextError below.)
+            fteproxy.fatal_error("fteproxy.record_layer.FormatContractError: "+str(e))
             # exit
         except fte.InvalidCovertextError as e:
             # A corrupt, wrong-format, or failed-MAC frame. The negotiation scan
@@ -169,17 +180,21 @@ class Decoder:
             head = self._decrypt(self._cipher, header)
             if head is None:
                 break
-            head = _unseal(head)
+            head = _unseal(head, self._seq)
             if head is None:
-                # Authenticated but not a sealed record: a peer on a different
-                # mode, or corruption. Treat it as undecodable.
-                fteproxy.info("fteproxy.record_layer: malformed sealed header")
+                # Authenticated but not a sealed record at this stream position:
+                # a peer on a different mode, corruption, or a record replayed,
+                # reordered, or dropped. Treat it as undecodable.
+                fteproxy.info(
+                    "fteproxy.record_layer: malformed or out-of-order sealed "
+                    "record at seq " + str(self._seq))
                 break
 
             if self._body_cipher is None:
                 # 'format' mode: the sealed covertext carried the message.
                 messages.append(head)
                 offset += self._frame_size
+                self._seq += 1
             else:
                 # 'hybrid' mode: the header carries the raw body's length. The
                 # header is authenticated, so a successful decrypt means we wrote
@@ -190,6 +205,13 @@ class Decoder:
                         + str(len(head)))
                     break
                 body_len = _OVERFLOW_LEN.unpack(head)[0]
+                if body_len > self._body_cipher.max_framed_bytes:
+                    # The header authenticates, so only a key holder can send
+                    # this, but never buffer up to 4 GiB on its say-so.
+                    fteproxy.info(
+                        "fteproxy.record_layer: body length " + str(body_len)
+                        + " exceeds the record limit")
+                    break
                 body_start = offset + self._frame_size
                 if len(buffer) - body_start < body_len:
                     break  # body not fully arrived; wait for more data

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -204,6 +204,21 @@ class TestWrapSocket:
         assert received_data[0] == test_data
         assert echo_data == test_data
 
+    def test_default_key_warns(self, capsys):
+        """Starting with the public built-in key prints a warning; a real key does not."""
+        import fteproxy.cli
+        key = 'runtime.fteproxy.encrypter.key'
+        prev = fteproxy.conf.getValue(key)
+        try:
+            fteproxy.conf.setValue(key, fteproxy.conf.DEFAULT_KEY)
+            fteproxy.cli.warn_if_default_key()
+            assert 'default key' in capsys.readouterr().out
+            fteproxy.conf.setValue(key, bytes(range(32)))
+            fteproxy.cli.warn_if_default_key()
+            assert capsys.readouterr().out == ''
+        finally:
+            fteproxy.conf.setValue(key, prev)
+
     @pytest.mark.parametrize("mode", ["format", "hybrid"])
     def test_wrap_socket_bulk_end_to_end(self, mode):
         """Full negotiation + bulk transfer, in each record-layer mode."""

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -113,13 +113,17 @@ class _RaisingCipher:
 
 class _FixedCellCipher:
     """Cipher stub for a fixed-size covertext frame. Its plaintext seals the
-    covertext bytes so the Decoder's unseal step recovers them."""
+    covertext bytes (length, then the stream position it is decrypted at) so
+    the Decoder's unseal step recovers them."""
 
     def __init__(self, cell_size=4):
         self.output_format = _Format(cell_size)
+        self._seq = 0
 
     def decrypt(self, covertext):
-        return struct.pack('>I', len(covertext)) + covertext
+        sealed = struct.pack('>IQ', len(covertext), self._seq) + covertext
+        self._seq += 1
+        return sealed
 
 
 class TestDecoderExceptionHandling:
@@ -131,11 +135,12 @@ class TestDecoderExceptionHandling:
         ``fatal_error()`` raises ``SystemExit``; a ``break`` in a ``finally``
         block swallows it and lets pop() return normally, silently discarding a
         fatal condition. With ``oneCell=True`` (the negotiation path) the error
-        must still propagate. ``fte.MessageTooLargeError`` is the libfte 0.4
-        successor to 0.3's ``UnrecoverableDecryptionError``.
+        must still propagate. ``fte.FormatContractError`` (a broken format
+        provider) is the condition that keeps libfte 0.3's
+        ``UnrecoverableDecryptionError`` semantics under 0.4.
         """
         decoder = fteproxy.record_layer.Decoder(
-            cipher=_RaisingCipher(fte.MessageTooLargeError("boom")))
+            cipher=_RaisingCipher(fte.FormatContractError("boom")))
         decoder.push(b'some-ciphertext-bytes')
 
         with pytest.raises(SystemExit):
@@ -212,6 +217,17 @@ class TestHybridRecordLayer:
             out += decoder.pop()
         assert out == payload
 
+    def test_oversized_body_length_is_rejected(self, capsys):
+        """A header announcing a body larger than any record can carry is
+        refused instead of buffering up to 4 GiB waiting for it."""
+        encoder, decoder = self._pair()
+        header = fteproxy.record_layer._seal(
+            encoder._cipher, fteproxy.record_layer._OVERFLOW_LEN.pack(2 ** 32 - 1), 0)
+        decoder.push(header + b'x' * 64)
+        assert decoder.pop() == b''
+        assert 'exceeds the record limit' in capsys.readouterr().out
+        assert len(decoder._buffer) == len(header) + 64
+
     def test_reordered_record_is_rejected(self):
         """A record moved out of its stream position fails the body auth."""
         encoder, _ = self._pair()
@@ -228,6 +244,43 @@ class TestHybridRecordLayer:
         d2 = self._pair()[1]
         d2.push(r1 + r0)
         assert d2.pop() == b''
+
+
+class TestFormatModeRecordLayer:
+    """'format' mode: one sealed covertext per record, stamped with its position."""
+
+    def _pair(self, language='manual-http-request'):
+        fteproxy.conf.setValue('runtime.mode', 'client')
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        cipher = fteproxy._make_cipher(
+            fteproxy.defs.getRegex(language), fteproxy.defs.getLength(language), key)
+        return (fteproxy.record_layer.Encoder(cipher=cipher),
+                fteproxy.record_layer.Decoder(cipher=cipher))
+
+    def test_reordered_or_replayed_record_is_rejected(self):
+        encoder, _ = self._pair()
+        encoder.push(b'first'); r0 = encoder.pop()    # seq 0
+        encoder.push(b'second'); r1 = encoder.pop()   # seq 1
+
+        d = self._pair()[1]
+        d.push(r0 + r1)
+        assert d.pop() == b'firstsecond'
+
+        swapped = self._pair()[1]
+        swapped.push(r1 + r0)
+        assert swapped.pop() == b''
+
+        replayed = self._pair()[1]
+        replayed.push(r0 + r0)
+        assert replayed.pop() == b'first'          # the replay is refused
+        assert replayed._buffer == r0
+
+    def test_multi_record_message_roundtrips(self):
+        encoder, decoder = self._pair()
+        payload = bytes(range(256)) * 8            # several records
+        encoder.push(payload)
+        decoder.push(encoder.pop())
+        assert decoder.pop() == payload
 
 
 def test_seal_fills_covertext_with_random_not_padding():

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -84,6 +84,34 @@ def _wrap(fake):
         negotiate=False)
 
 
+class TestServerNegotiationEOF:
+    """A server-role wrapper whose peer closes before negotiating reports EOF.
+
+    Regression test for a relay worker leak: a failed negotiation used to raise
+    ``socket.timeout`` ("not ready yet") even after the peer had closed, so the
+    worker re-polled a closed socket at the throttle rate forever. Under libfte
+    0.4 every mismatched peer (a 0.3 client, a wrong key, a wrong
+    --record-layer-mode, a port scanner) takes this path.
+    """
+
+    def _server_wrap(self, fake):
+        return fteproxy.wrap_socket(fake)  # no formats given: server role
+
+    def test_close_without_data_returns_eof(self):
+        fake = FakeSocket([])
+        assert self._server_wrap(fake).recv(65536) == b''
+        assert fake.eof_reads == 1
+
+    def test_garbage_then_close_returns_eof(self):
+        import socket
+        fake = FakeSocket([b'not a negotiation cell'])
+        wrapper = self._server_wrap(fake)
+        with pytest.raises(socket.timeout):  # cell incomplete: keep waiting
+            wrapper.recv(65536)
+        assert wrapper.recv(65536) == b''    # peer gone: EOF, not another wait
+        assert fake.eof_reads == 1
+
+
 class TestRecvEOF:
     """recv() must report EOF (return b'') once the peer has closed."""
 


### PR DESCRIPTION
## Summary

Fixes from the pre-release security and dependency reviews of the 0.4 record layer. **Part 6** of the #221 split, stacked on #228; each commit stands alone and can be dropped independently.

## Changes

1. **Warn when the public built-in key is in use** (`cli.py`, `conf.py`). libfte 0.4 requires a key, and fteproxy silently fell back to the constant in `fteproxy/conf.py` when neither `--key` nor `--key-file` was given. That key is in the source, so anyone on the path can read and forge the tunnel. Both `--mode client` and `--mode server` now print `WARN: using the built-in default key, which is public: ...` at startup. The constant is exposed as `fteproxy.conf.DEFAULT_KEY`. (Review finding C1; pre-existing, but 0.4 removed the only keyless alternative.)

2. **Sequence number inside every sealed covertext** (`record_layer.py`). `format` mode had no sequence number at all, so an on-path attacker could reorder, replay, drop, or splice sealed covertexts undetected (demonstrated by the review), and the hybrid header (which carries the body length) was not bound to its position either. Every sealed covertext now carries the record's stream position next to the length prefix, and the decoder only unseals a record at the position it expects. Both modes now reject a record moved, replayed, or dropped within its stream. Costs 8 bytes of per-record capacity. (Finding M1.)

3. **Cap the body length a hybrid header may announce.** The header is authenticated, but its 4-byte length was unbounded, so a key holder could make the decoder buffer up to 4 GiB waiting for a body. Anything above the encoder's own record limit (`_AEADBody.max_framed_bytes`, 1 MiB + framing) is refused. (Finding M2.)

4. **Replace the dead fatal branch.** The `fte.MessageTooLargeError` → `fatal_error` path in the decoder could never run: in libfte 0.4 that error is raised only on encrypt, and decrypt reports every bad covertext as `InvalidCovertextError`. Keep 0.3's "unrecoverable → exit" semantics for the one condition that is a bug rather than input, `fte.FormatContractError` (a broken format provider); the regression test that guards `SystemExit` propagation now uses it. (Finding I1.)

5. **Report EOF when the peer closes before negotiation** (`_FTESocketWrapper.recv`). A server-role wrapper turned every negotiation failure into `socket.timeout` even after the peer had closed; since `recv()` on a closed socket returns `b''` immediately, the relay worker re-polled it at the throttle rate forever (two leaked threads per failed connection, and the negotiate timeout never fired). 0.3 escaped this by accident (its `UnrecoverableDecryptionError` exited the worker); under 0.4 every mismatched peer (a 0.3 client, wrong key, different `--record-layer-mode`, a port scanner) took the leak path. Now returns EOF, with a warning naming the likely mismatches when bytes were received. (Dependency-review finding 4.)

## Not changed (needs a design decision)

The key is shared by every connection and both directions, so a hybrid body or sealed covertext captured from one stream still authenticates at the **same position of another stream** (whole-stream replay into a fresh connection, or splicing record *i* of stream A into stream B). The review rated this HIGH. Preventing it needs per-connection key material: e.g. a random stream id carried in the first sealed header and mixed into the body subkeys (blocks cross-stream splicing, not whole-stream replay), or receiver-contributed randomness in a real handshake round trip (blocks both, costs an RTT and a protocol change). A direction label in the KDF (`c2s`/`s2c`) is cheap on top of either. The `_AEADBody` docstring and `SECURITY.md` (in the release PR) state the limitation.

## Validation

104 tests pass against PyPI `fte==0.4.0`, including new tests for the default-key warning, format-mode reorder/replay rejection, the oversized body length, and the pre-negotiation EOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
