### PR TITLE
Prepare the 0.4.0 release: version, packaging, Dependabot gate, docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      # libfte is 0.x: a minor bump is a wire-format break (0.3 -> 0.4 was),
+      # and Dependabot would rewrite the fte>=0.4.0,<0.5.0 cap to admit it.
+      # Moving the fte line is a coordinated release, never a bot PR.
+      - dependency-name: "fte"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # GitHub Actions used in workflows (grouped into a single PR)
   - package-ecosystem: "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,13 +19,34 @@ jobs:
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only patch and minor bumps are approved and merged unattended. A major
+      # bump can change a package's or an action's behaviour, a bump of the
+      # fte line is a wire-format change (see dependabot.yml), and
+      # pypa/gh-action-pypi-publish receives the PyPI trusted-publishing OIDC
+      # token and is never exercised by CI, so those need a human review.
       - name: Approve pull request
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !contains(steps.metadata.outputs.dependency-names, 'fte') &&
+          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
         run: gh pr review --approve "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 
       - name: Enable auto-merge
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !contains(steps.metadata.outputs.dependency-names, 'fte') &&
+          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include LICENSE
 include README.md
 include PYPI_README.md
+include requirements.txt
 include fteproxy/defs/*.json
+recursive-include fteproxy/tests *.py

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,238 +1,172 @@
 # fteproxy performance analysis
 
-Companion to [`benchmark.py`](benchmark.py). All numbers below were produced by that
-script on loopback (macOS, Python 3.14, `fte` 0.2.1), comparing fteproxy against a
-**plain-TCP relay of identical two-hop topology** so the cost of Format-Transforming
-Encryption is isolated from the cost of the network conditions. The "network" is an
-in-process link shaper (one-way delay + jitter + bandwidth cap); see the note in
-`benchmark.py` on why that faithfully models what TCP loss/reorder look like to the
-application layer.
+Companion to [`benchmark.py`](benchmark.py). The numbers below were produced by
+that script on loopback (Apple M3 Pro, macOS, Python 3.14.7) on 2026-09-02 for
+**fteproxy 0.4.0 with `fte` 0.4.0** (the tree of the 0.4 release stack), with
+**fteproxy 0.3.1 + `fte` 0.3.0** measured the same day on the same machine for
+comparison, and a **plain-TCP relay of identical two-hop topology** so the cost
+of Format-Transforming Encryption is isolated from the network. Everything here
+was measured unless marked *estimated*.
 
 Reproduce:
 
 ```bash
-pip install -e .                       # needs the `fte` dependency
+pip install -e .                       # needs fte>=0.4.0,<0.5.0
 python3 benchmark.py --baseline        # default 6 scenarios
-python3 benchmark.py --scenarios lan broadband dsl --sizes 1M 8M --baseline --no-latency --no-setup
+python3 benchmark.py --scenarios lan --sizes 64K 1M 8M --repeat 2 --baseline
+python3 benchmark.py --scenarios lan --sizes 8M --direction upload --no-latency --no-setup
+python3 benchmark.py --scenarios lan --sizes 64K 1M --record-layer-mode format
 ```
 
 ---
 
 ## TL;DR
 
-1. **On any real-world link (≤ ~25 Mbit), fteproxy is as fast as raw TCP.** For bulk
-   transfers it reaches **99%** of the plain-TCP baseline on the 5 Mbit and 25 Mbit
-   links — the network is the bottleneck and FTE overhead is invisible.
-2. **fteproxy's own ceiling is CPU, not the network: ~300 Mbit/s of FTE per stream.**
-   This only becomes the limiter on LAN/datacenter-speed links, where fteproxy is
-   ~25× slower than raw TCP.
-3. **The dominating cost is a large FIXED per-call cost in FTE (~0.7 ms/encode).**
-   Throughput is entirely determined by how much plaintext is packed into each cell:
-   a 64-byte message runs at 0.7 Mbit/s and **expands 4×**; a 32 KB cell runs at
-   ~300 Mbit/s with ~0% expansion.
-4. **Interactive latency overhead is a small, roughly constant few milliseconds** (two
-   encodes + two decodes per round trip) — negligible on any link with real latency,
-   but 10× the raw RTT on loopback.
-5. **Abrupt link drops are *usually* detected fast (~0.5 s) but not reliably.** In ~10–20%
-   of trials the application connection wedges instead — a real robustness bug rooted in
-   the relay's polling design (see below). fteproxy's nominal 30 s socket timeout does
-   **not** rescue it, because the poll loop never lets that timeout fire.
+1. **On any real-world link (≤ ~25 Mbit) fteproxy is as fast as raw TCP.** That was
+   true on 0.3 and is unchanged: the network is the bottleneck and FTE is invisible.
+   Everything below is about LAN/datacenter-speed links and interactive latency.
+2. **The 0.4 record layer is 5–7x faster than 0.3.1 in bulk on LAN** (8 MB echo
+   0.7 → 4.6 Gbit/s, ~75% of plain TCP) and **3x lower in interactive overhead**
+   (64 B RTT 1.5 → 0.5 ms). The per-record fixed cost fell from ~0.9 ms to ~0.17 ms
+   (round trip), and the body is OpenSSL AES-CTR+HMAC instead of a big-integer frame.
+3. **The ceiling is now the relay loop and the GIL, not FTE.** The record layer alone
+   runs 650–950 MB/s (5–7.5 Gbit/s) per direction; the two-thread-per-connection
+   relay gets ~4.6 Gbit/s echo out of it.
+4. **`format` mode (every byte in the target format) is interactive-only:** same RTT
+   class as `hybrid` (0.7 vs 0.5 ms) but 4–7 Mbit/s bulk, because the DFA runs on
+   every ~140 bytes instead of once per record. Its cost is inherent to the mode.
+5. **libfte 0.4 caches nothing.** 0.3 cached its DFA tables globally, so building an
+   encoder was free; 0.4 compiles a DFA per `RegexFormat` (0.5–1.5 ms). fteproxy
+   therefore caches ciphers itself (`_make_cipher`, one per pattern/length/key),
+   which brings connection setup to ~1 ms. Without the cache it was 8–12 ms, and a
+   connection closed before negotiating pinned the server at 64–100% CPU.
+6. **The relay's `select`+throttle poll loop is unchanged** and still carries the
+   caveats from 0.3: do not delete the throttle, and a dropped link can still wedge
+   an application connection (see *Resilience*).
 
 ---
 
-## Measured data
+## Measured data (LAN, loopback)
 
-### Bulk throughput — 8 MB echo (round trip, exercises both FTE directions)
+| metric | plain TCP | 0.3.1 | **0.4 hybrid (default)** | 0.4 format |
+|---|---:|---:|---:|---:|
+| connection setup p50 | – | 2.7–3.3 ms | **1.1 ms** | ~1 ms |
+| RTT 64 B p50 (p90) | 0.15 (0.28) ms | 1.5–1.7 ms | **0.51 (0.55) ms** | 0.73 (0.92) ms |
+| 64 KB echo | 413–1225 Mbit/s | 113–144 Mbit/s | **557 Mbit/s** | 4.4 Mbit/s |
+| 1 MB echo | 2596 Mbit/s | 452–522 Mbit/s | **2540 Mbit/s** | 7.3 Mbit/s |
+| 8 MB echo | 6071 Mbit/s | 655–700 Mbit/s | **4626 Mbit/s** | – |
+| 8 MB upload (one direction) | – | 1069–1275 Mbit/s | **4412 Mbit/s** | – |
 
-| Link (shaper)      | fteproxy | plain-TCP | fteproxy / baseline |
-|--------------------|---------:|----------:|--------------------:|
-| LAN (loopback)     | 210 Mbit/s | 5553 Mbit/s | 3.8% |
-| broadband (25 Mbit)| 24.5 Mbit/s | 24.8 Mbit/s | **99%** |
-| dsl (5 Mbit)       | 4.94 Mbit/s | 4.98 Mbit/s | **99%** |
+Ranges are run-to-run spread across two runs; the 64 KB transfer window
+includes connection setup and negotiation, so it is the noisiest row (the
+plain-TCP 64 KB figure varied 3x between runs). On the shaped links
+(broadband 25 Mbit and slower) fteproxy matches plain TCP within measurement
+noise, as it did on 0.3; those rows are omitted.
 
-> On a constrained link the two lines are on top of each other; on LAN the FTE CPU
-> ceiling (~300 Mbit/s single stream) is the wall.
+### Record layer alone (no sockets), `manual-http-request`/`-response`
 
-### Interactive latency — 64 B request/response, connection reused
+Median encrypt+decrypt round trip through `fteproxy.record_layer`, from the
+release review (same machine):
 
-| Link            | fteproxy RTT | plain-TCP RTT | FTE overhead |
-|-----------------|-------------:|--------------:|-------------:|
-| LAN             | 1.70 ms | 0.19 ms | +1.5 ms |
-| broadband       | 32.2 ms | 24.5 ms | +7.7 ms |
-| dsl             | 59.9 ms | 56.0 ms | +3.9 ms |
-| 3g (200 ms)     | 219.6 ms | 215.9 ms | +3.7 ms |
-| edge (400 ms)   | 424.8 ms | 401.2 ms | +23 ms* |
-| satellite (1200 ms) | 1215 ms | 1213 ms | +2 ms |
+| message | 0.3.1 | 0.4 hybrid | 0.4 format | wire expansion 0.3.1 → 0.4 hybrid / format |
+|---|---:|---:|---:|---:|
+| 64 B | 0.07–0.21 MB/s (0.9 ms/record) | 0.38–0.53 MB/s (0.17 ms) | 0.40–0.65 MB/s | 4.0x → 5.4x / 4.0x |
+| 4 KiB | 4.5–11.7 MB/s | 23–33 MB/s | 0.9–1.9 MB/s | 1.03x → 1.07x / 1.81x |
+| 256 KiB | 75–88 MB/s | 657–713 MB/s | 0.9–1.8 MB/s | 1.001x → 1.001x / 1.75x |
+| 1 MiB | 75–89 MB/s | 920–960 MB/s | 1.0–1.8 MB/s | 1.000x → 1.000x / 1.75x |
 
-> \*edge has ±60 ms of injected jitter, so its overhead figure is mostly noise. The
-> real signal: fteproxy adds a small **constant** delay, so its relative cost vanishes
-> as link latency grows.
-
-### Connection setup (open → first byte back), fteproxy
-
-Tracks **~1 RTT + a few ms** (the FTE negotiation cell rides on the first data segment,
-so setup is one round trip): LAN 2.8 ms, broadband 32 ms, dsl 64 ms, satellite 1221 ms.
-
-### Raw FTE cost by cell size (the root cause)
-
-| plaintext | ciphertext | expansion | encode | decode |
-|----------:|-----------:|----------:|-------:|-------:|
-| 64 B    | 256 B  | 4.0× | 0.7 Mbit/s | 1.0 Mbit/s |
-| 1 KB    | 1.1 KB | 1.1× | 11.8 Mbit/s | 13.6 Mbit/s |
-| 4 KB    | 4.2 KB | 1.0× | 46 Mbit/s | 54 Mbit/s |
-| 16 KB   | 16.5 KB| 1.0× | 168 Mbit/s | 193 Mbit/s |
-| 32 KB   | 32.9 KB| 1.0× | **299 Mbit/s** | **347 Mbit/s** |
-
-Single-call latency is ~0.69 ms/encode and ~0.62 ms/decode regardless of size in the
-small range — i.e. a **fixed per-call cost** that amortizes only when cells are large.
-
-### Resilience — link dropped mid-transfer (bidirectional app: sends and receives)
-
-Most of the time the app is freed within ~0.5 s of the drop (the relay worker reading the
-severed side sees EOF and closes the app connection). **But intermittently — ~10–20% of
-runs in this harness, across both fast and slow links — the app instead hangs past the
-12 s observation window.** This is not a shaper artifact; it is a real behavior:
-
-- A relay `worker` blocked in `sendall` to one peer never checks whether its *other* peer
-  disconnected, so the drop goes unnoticed until it happens to return from that write.
-- The nominal 30 s `runtime.fteproxy.relay.socket_timeout` cannot save it: the worker
-  reads via `select(timeout=0.1)` + a `throttle` sleep, so a blocking `recv` never runs
-  long enough to hit the socket timeout. The backstop is effectively dead code.
-
-See improvement #2 — this is a correctness issue, not only a performance one.
+(Request/response formats differ in capacity, hence the pairs.)
 
 ---
 
-## Where the time goes
+## Where the time goes (0.4, `hybrid`)
 
 ```
 app → [client relay] ──FTE──→ [server relay] → dest
-        │                         │
-        │ worker thread pair      │ worker thread pair
-        │ poll+relay              │ negotiate + poll+relay
-        └─ _FTESocketWrapper.send └─ _FTESocketWrapper.recv
-             = record_layer.Encoder  = record_layer.Decoder
-             = fte.Encoder.encode     = fte.Encoder.decode  ← ~0.7 ms/call, the hot spot
+        worker thread pair         worker thread pair
+        _FTESocketWrapper.send     _FTESocketWrapper.recv
+        = record_layer.Encoder     = record_layer.Decoder
+          per record:                per record:
+          1 sealed header            1 header rank+verify   ~0.07–0.08 ms
+            (DFA unrank, AE)         + body HMAC-SHA256 verify + AES-CTR
+          + body AES-CTR + HMAC        ~0.43 ms/MiB (HMAC is ~78% of it)
 ```
 
-Per interactive round trip the payload is FTE-**encoded twice** (client→server request,
-server→client response) and **decoded twice** — ~2.6 ms of pure CPU on top of the wire
-RTT. For bulk transfer the same CPU is the throughput ceiling (~300 Mbit/s) because a
-single stream's encode/decode is serialized (Python, one core).
+- A record is one 256-byte formatted header plus a raw body. The relay hands
+  at most `2**18` bytes to `send()` per read (`network_io.recvall_from_socket`),
+  so records are ≤ 256 KiB and each pays one header (~0.08 ms ≈ 0.33 ms/MiB,
+  *estimated* ~40% of encode-side record-layer time). The 1 MiB body cap is
+  never reached in the relay.
+- Sealing (random pad to capacity), per-record `Cipher` construction, buffer
+  concatenation and the body/remainder slices are each under 1% of a record.
+- Interactive traffic: one 64 B message costs one 256-byte header plus a
+  92-byte body (348 B, 5.4x; 0.3 and `format` mode send 256 B).
+- In `format` mode every ~140 bytes of payload is one DFA rank/unrank
+  (~0.16 ms), which is the 4–7 Mbit/s.
 
 ---
 
-## Recommended improvements, ranked by impact ÷ effort
+## Improvements landed in 0.4
 
-### 1. Set `TCP_NODELAY` on relay sockets — *low effort, clear win for latency* — ✅ IMPLEMENTED
+1. **Hybrid record layer with an OpenSSL AE body** (the redesign): per-record cost
+   0.9 → 0.17 ms; bulk 75 → 650–950 MB/s in the record layer.
+2. **Cipher cache** (`_make_cipher` is memoized on pattern, length and key): setup
+   8–12 ms → ~1 ms, and the negotiation scan on a failed connection 6 ms → free.
+3. **A pending header is decrypted once.** A 256 KiB record arrives in ~3 reads;
+   the decoder used to re-rank and re-verify the same header on each partial
+   delivery (two wasted header decrypts per record, more than the body itself).
+   +30% on 8 MB echo.
+4. **A peer that closes before negotiating gets EOF** instead of being polled
+   forever. On 0.4 without this, one dead connection (a port scan, a health
+   check, an active probe) cost 64% of a core; five saturated it and pushed
+   RTT p50 to 65 ms.
+5. Carried over from 0.3: `TCP_NODELAY` on both relay hops, O(n) buffer handling
+   in the record layer, the configured `--upstream-format` tried first in the
+   negotiation scan.
 
-The relay used to leave Nagle's algorithm enabled. `_FTESocketWrapper` passes small encoded
-cells straight to the kernel, so on a real network Nagle can hold a small segment up to
-~40 ms waiting to coalesce — exactly the wrong behavior for an interactive, latency-sensitive
-tunnel. `listener.run()` now disables Nagle on both hops right after `accept()`/`connect()`:
+## Remaining levers, ranked by impact ÷ effort
 
-```python
-# fteproxy/relay.py listener.run(), after accept()/connect():
-conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-new_stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-```
+1. **Rework the polling relay loop** (large effort; fixes idle CPU, a latency
+   ripple, and the hang on link drop). The 0.3 caveat stands and was re-verified:
+   simply deleting `time.sleep(throttle)` in `worker.run()` regresses the real
+   subprocess deployment ~13x (a GIL-scheduling convoy between the two workers),
+   and a naive blocking-`recv` rework races the in-band negotiation between the
+   two workers. The loop must first make negotiation single-threaded (a
+   dedicated handshake phase, or one `selectors` loop per connection handling
+   both directions). Not a drive-by.
+2. **Carry small messages inline in the sealed header** (medium effort). A message
+   of ≤ ~140 bytes fits in the header's capacity, so it could travel as one
+   256-byte covertext instead of header + 92-byte body: 5.4x → 4.0x expansion
+   for interactive traffic, at the CPU cost `format` mode already pays per
+   record (identical for one record).
+3. **AES-GCM for the body** would roughly halve body CPU (*estimated*; HMAC-SHA256
+   runs at ~3 GB/s vs 16 GB/s for AES-CTR), but the body is now under 10% of
+   end-to-end time and it would be a wire change. Not worth it today.
+4. **`format` mode throughput is inherent** to transforming every byte; the only
+   lever is a faster ranker (a C extension releasing the GIL).
 
-Neutral on loopback (no Nagle delay to remove there, so the benchmark is unchanged), but it
-removes the coalescing stall on real links.
+---
 
-### 2. Rework the polling relay loop — *fixes latency, idle CPU, AND a hang bug* — ⚠️ NEEDS FULL REWORK (not a quick tweak)
+## Resilience — link dropped mid-transfer
 
-> **Empirical caveat (measured on this branch).** The tempting shortcut — just deleting the
-> redundant-looking `time.sleep(throttle)` in `worker.run()`, since `recvall_from_socket`
-> already blocks in `select` when idle — makes things **dramatically worse** in the real
-> subprocess deployment: LAN throughput fell **217 → 16 Mbit/s (~13×)** and interactive RTT
-> rose **1.3 → 32 ms**, reproducibly, even for the throughput path in isolation. (An
-> *in-process* relay is unaffected — it is a subprocess/GIL-scheduling interaction.) The
-> throttle is therefore **load-bearing** under the current `select`-based design; it must stay
-> until the loop is properly reworked as below (blocking `recv` governed by the socket timeout,
-> or a `selectors` event loop). **Do not simply delete the sleep.**
+Unchanged from 0.3, and still real: when a bidirectional application's link is
+cut, the relay usually frees the app within ~0.5 s, but in a minority of runs a
+worker blocked in `sendall` to one peer never checks its other peer and the
+connection wedges past the observation window. The nominal 30 s
+`runtime.fteproxy.relay.socket_timeout` cannot rescue it because the poll loop
+never issues a blocking `recv` that lasts long enough. Lever #1 above is the fix.
 
-This is the highest-value change because it has a **correctness** payoff on top of
-performance. Today `fteproxy/network_io.py:recvall_from_socket` blocks up to
-`select_timeout` (0.1 s) in `select()`, and the worker *also* sleeps
-`runtime.fteproxy.relay.throttle` (10 ms, `conf.py:95`) on every empty poll (`relay.py:47`).
-Three problems:
-
-- **Latency / ripple**: the extra sleep adds delay at every flow transition.
-- **Idle CPU**: every idle connection's *two* threads wake on a fixed 100 ms cadence.
-- **Hang on drop (correctness)**: because the loop never issues a blocking `recv` that
-  lasts, the 30 s `socket_timeout` never fires — so when a peer half-closes/blackholes and
-  the paired worker is stuck in `sendall`, the connection can wedge indefinitely (the
-  intermittent "hung" result above).
-
-Fix: replace the `select`+`sleep` poll with a plain blocking `recv` governed by the
-socket's own timeout (so the 30 s backstop becomes real), and make the worker treat a
-timeout as "tear down both sockets" so a stalled peer can't wedge the pair. A `selectors`
-event loop (see #7) subsumes this.
-
-### 3. Coalesce small writes into fewer FTE cells — *medium effort, big win for chatty traffic*
-
-Because each FTE cell pays ~0.7 ms and (for tiny payloads) expands 4×, throughput for
-chatty/interactive protocols is dominated by cell **count**, not bytes. The record layer
-already buffers (`fteproxy/record_layer.py`), but `_FTESocketWrapper.send` flushes on
-every `send()` call, so N small application writes become N tiny cells. A small
-coalescing window on the encode side (accumulate until ~a few KB **or** ~1–2 ms elapse,
-then flush) would collapse many tiny cells into one, cutting both CPU and the 4×
-expansion. This is a latency/throughput trade-off, so gate it behind a config flag and a
-short timer so interactive latency isn't harmed.
-
-### 4. Fix the O(n²) buffer slicing in the record layer — *low effort, bulk CPU* — ✅ IMPLEMENTED
-
-`record_layer.Encoder.pop` used to do `self._buffer = self._buffer[MAX_CELL_SIZE:]` and
-`retval += covertext` in a loop; `Decoder.pop` was similar. Each iteration re-copied the
-whole remaining buffer, so a single large `push` was quadratic in the number of cells. This
-is now a moving `range()` offset over the buffer with the cells joined once at the end (and
-the decoder writes `self._buffer` back a single time). Isolated buffer-management cost for a
-16 MB push fell **208 ms → 2.0 ms (~105×)**; end-to-end (real FTE) an 8 MB single-push encode
-went **296 → 360 Mbit/s (+22%)** with the large-buffer degradation tail removed. Behavior is
-unchanged and the record-layer round-trip tests pass across all languages.
-
-### 5. Short-circuit the negotiation scan — *low effort, connection-setup CPU at scale* — ✅ IMPLEMENTED (ordering, not caching)
-
-`NegotiationManager._acceptNegotiation` (`fteproxy/__init__.py`) linearly tries to decode the
-first cell against **every** request-language (~23 of them) until one succeeds. The default
-upstream language sits at position **21 of 23** in definition order, so every connection paid
-~20 failed decodes before matching. The scan now tries the configured
-`runtime.state.upstream_language` first (**~0.55 → ~0.39 ms/connection** for the common
-shared-config case), falling through to the full scan for non-default clients — same set of
-languages, just the expected one first.
-
-> The originally-suggested *object caching* was measured to be a non-starter: constructing all
-> 23 `fte.Encoder`s costs **0.01 ms** (the DFA tables are already cached globally by `fte`), so
-> there is nothing worth caching. The only remaining lever beyond ordering is an explicit
-> format id to make the common case truly O(1).
-
-### 6. The single-stream FTE ceiling is fundamental — *large effort, only matters on fast links*
-
-~300 Mbit/s per stream is a CPU limit: FTE ranking/unranking runs in Python and a single
-connection's encode/decode is serialized by the GIL (only the AES step in pycryptodome
-releases it). This is irrelevant for censorship-circumvention over real Internet paths,
-but if datacenter-speed throughput is ever a goal, the levers are: parallelize
-encode/decode across cores (process pool per connection, or offload the ranking to a C
-extension that releases the GIL), and/or raise `record_layer.max_cell_size`
-(`conf.py:103`, currently 32 KB) so fewer, larger cells are encoded.
-
-### 7. Scalability of the thread-per-connection model — *large effort, many-connection servers*
-
-Every proxied connection uses **two** OS threads that poll on a 100 ms cadence
-(`relay.py` `worker`). This is fine for a handful of streams but caps out well before
-C10k and burns CPU on idle-connection wakeups. A `selectors`-based event loop (or
-`asyncio`) would scale to far more concurrent tunnels with far less overhead — but it's a
-real rearchitecture of the relay core.
+What is new in 0.4 is that the *other* stuck state, a connection closed before
+negotiation, is fixed: the server logs `peer closed before negotiation completed`
+and releases both workers.
 
 ---
 
 ## What did *not* turn out to be a problem
 
-- **Slow / high-latency / low-bandwidth links.** fteproxy matches raw TCP there (99% on
-  bulk). The user's instinct was right: TCP absorbs loss/reorder below the app layer, and
-  fteproxy's constant few-ms overhead is lost in the network's own latency.
-- **DFA table build cost.** Expensive per language (~17 ms cold) but cached globally by
-  `fte` and pre-built once at server startup — not a per-connection cost.
-- **The record layer itself.** Its throughput (298 Mbit/s) equals raw 32 KB FTE, so it
-  adds no measurable overhead on top of FTE today (see #4 for the latent quadratic).
+- **Slow, high-latency or low-bandwidth links.** fteproxy matches raw TCP there.
+- **Server startup.** Building ciphers for all 46 formats takes ~23 ms cold.
+- **Random padding.** `os.urandom` for the seal pad is ~1 µs of an ~80 µs header.
+- **The 1 MiB body cap.** Never reached; records are bounded by the relay's read size.
+- **Cell/buffer size tuning.** As on 0.3, `network_io`'s `2**18` read size is the
+  right balance; larger buffers trade small-transfer latency for little bulk gain.

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -13,6 +13,10 @@
 pip install fteproxy
 ```
 
+> **0.4 is not wire-compatible with 0.3.x.** Upgrade both endpoints together,
+> and give both the same `--key`/`--key-file` (the built-in default key is
+> public) and the same `--record-layer-mode`.
+
 ## Quick Start
 
 ### Server
@@ -33,7 +37,7 @@ python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --ser
 [Application] <-> [fteproxy client] <--FTE encoded--> [fteproxy server] <-> [Destination]
 ```
 
-fteproxy encodes traffic to match user-specified regular expressions, making it appear as allowed traffic (e.g., HTTP) to network filters.
+fteproxy encodes traffic to match user-specified regular expressions, making it appear as allowed traffic (e.g., HTTP) to network filters. By default each record starts with a covertext in the chosen format and carries the rest as raw authenticated ciphertext (`--record-layer-mode hybrid`); `--record-layer-mode format` puts every byte in the format at much lower throughput.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ Its job is to relay datastreams, such as web browsing traffic, by encoding the s
 
 fteproxy is powered by Format-Transforming Encryption [1] and was presented at CCS 2013.
 
+> **fteproxy 0.4 is not wire-compatible with 0.3.x.** Upgrade both endpoints
+> together, give both the same key, and see [Upgrading to 0.4.0](#upgrading-to-040).
+
 [1] [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf), Kevin P. Dyer, Scott E. Coull, Thomas Ristenpart and Thomas Shrimpton
 
 ## Requirements
 
 - Python 3.10 or higher
+- [libfte](https://github.com/kpdyer/libfte) 0.4.x (`fte>=0.4.0,<0.5.0`) and
+  `cryptography>=42.0`, both installed automatically by `pip`. `cryptography`
+  is a compiled package; wheels exist on PyPI for every supported platform.
 
 ## Installation
 
@@ -69,20 +75,41 @@ python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --ser
 
 This listens for plaintext connections on port 8079 and forwards FTE-encoded traffic to the server.
 
+Both sides must use the same key (`--key` or `--key-file`; the built-in default
+is public and fteproxy warns when it is in use) and the same
+`--record-layer-mode`.
+
+### Record-layer modes
+
+Every record on the wire starts with a covertext in the chosen format. What
+follows depends on `--record-layer-mode`, which must match on both endpoints:
+
+- `hybrid` (default): the covertext is a fixed-length header and the rest of
+  the record is raw authenticated ciphertext. Fast (hundreds of MB/s), but only
+  the header blends in with the target protocol.
+- `format`: every byte is transformed into the format, so the whole stream is
+  indistinguishable from the protocol. Much slower (well under 1 MB/s), for
+  deployments facing entropy or statistical detectors.
+
 ### Command Line Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--mode` | Relay mode: client or server | client |
+| `--upstream-format` | Client-to-server format name (see `fteproxy/defs/20260110.json`) | manual-http-request |
+| `--downstream-format` | Server-to-client format name | manual-http-response |
+| `--record-layer-mode` | `hybrid` or `format` (see [Record-layer modes](#record-layer-modes)); must match on both endpoints | hybrid |
+| `--release` | Definitions file to use, as YYYYMMDD | 20260110 |
 | `--client_ip` | Client-side listening IP | 127.0.0.1 |
 | `--client_port` | Client-side listening port | 8079 |
 | `--server_ip` | Server-side listening IP | 127.0.0.1 |
 | `--server_port` | Server-side listening port | 8080 |
 | `--proxy_ip` | Forwarding-proxy listening IP | 127.0.0.1 |
 | `--proxy_port` | Forwarding-proxy listening port | 8081 |
-| `--key` | Cryptographic key (64 hex characters) | (default key) |
+| `--key` | Shared secret (64 hex characters); must match on both endpoints. The built-in default is public and gives no protection. | (public default; warns) |
 | `--key-file` | Path to a file containing the key (64 hex characters). Mutually exclusive with `--key`. | |
 | `--quiet` | Suppress output | false |
+| `--stop` | Shut down the running daemon for `--mode` | |
 | `--version` | Show version and exit | |
 
 ### Supplying the Key from a File
@@ -107,6 +134,41 @@ python3 -m fteproxy --mode client --key-file fteproxy.key --client_ip 127.0.0.1 
 
 The file must contain exactly 64 hexadecimal characters (a trailing newline is
 ignored). `--key` and `--key-file` cannot be used together.
+
+### Python API
+
+`fteproxy.wrap_socket(sock, outgoing_regex=..., outgoing_length=..., incoming_regex=..., incoming_length=...)`
+turns any TCP socket into an FTE socket. The [`examples/`](examples/README.md)
+directory has programmatic, chat, file-transfer and integration examples.
+
+## Upgrading to 0.4.0
+
+fteproxy 0.4.0 moves to libfte 0.4 (`fte.FTE`) and its wire format is **not
+compatible with 0.3.x**. A 0.3 client and a 0.4 server (or the reverse) fail at
+negotiation (the server logs a warning, the client times out), so upgrade both
+endpoints together.
+
+- **Key.** libfte 0.4 requires a 32-byte key. If you pass neither `--key` nor
+  `--key-file`, fteproxy uses a built-in default key that is public and warns at
+  startup. Generate one (`python3 -c "import secrets; print(secrets.token_hex(32))"`)
+  and use the same key on both sides.
+- **Record-layer mode.** New `--record-layer-mode` (`hybrid`, the default, or
+  `format`). Both endpoints must use the same mode.
+- **API renames.** `wrap_socket(outgoing_fixed_slice=, incoming_fixed_slice=)`
+  are now `outgoing_length=` / `incoming_length=`; `fteproxy.defs.getFixedSlice`
+  is `getLength`; the definitions JSON key `"fixed_slice"` is `"length"`. Code
+  that used `fte.Encoder` directly must move to `fte.FTE` (see
+  [libfte's README](https://github.com/kpdyer/libfte#readme)).
+- **Formats.** Twenty low-capacity formats got longer covertexts (`binary`
+  256 to 1032, `ip-address` and `timestamp` 64 to 312, and so on; see
+  `fteproxy/defs/20260110.json`). Four patterns were rewritten for libfte
+  0.4's stricter regex dialect (`\C` is now `.`; `manual-http-request` paths
+  no longer admit a backslash). The default `manual-http-*` formats still use
+  length 256 and carry 150 (request) and 192 (response) bytes per covertext.
+- **Requires** `fte>=0.4.0,<0.5.0` and `cryptography>=42.0`.
+
+See [SECURITY.md](SECURITY.md) for the security model, including what the
+record layer does and does not authenticate.
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,72 @@ supported version before reporting an issue.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.x   | :white_check_mark: |
-| < 0.3   | :x:                |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
+
+## Security model
+
+fteproxy 0.4 is built on libfte 0.4; read
+[libfte's security model](https://github.com/kpdyer/libfte/blob/master/SECURITY.md)
+first. This section covers what fteproxy adds on top of it.
+
+- **Threat model.** Format-Transforming Encryption is designed to get past an
+  on-path observer that classifies traffic with protocol signatures (regular
+  expressions, DPI rules). The shared key protects the confidentiality and
+  integrity of the tunnelled bytes against that observer. fteproxy is not a
+  general-purpose VPN: it does not hide traffic volume or timing, and the
+  limitations below apply.
+
+- **The key.** One 32-byte key, shared by both endpoints, every connection, and
+  both directions (`--key` or `--key-file`). Without one, fteproxy uses the
+  public constant in `fteproxy/conf.py` and prints a warning at startup; that
+  configuration gives no confidentiality or integrity against anyone who has
+  read the source. Rotate the key before the number of records sent under it
+  approaches 2^32 (every covertext and every hybrid body carries a fresh random
+  12-byte nonce; at 2^32 records the chance of a repeat is about 2^-33, and a
+  repeat exposes only the two colliding records' contents, never integrity).
+
+- **Authentication and ordering.** Every formatted covertext is a libfte frame:
+  AES-128-CTR then HMAC-SHA256 (Encrypt-then-MAC, 128-bit tag). In `hybrid`
+  mode the raw record body uses the same construction under subkeys derived
+  from the shared key. Every record carries its position in its stream (sealed
+  inside the covertext and, in `hybrid` mode, bound into the body tag), so a
+  record that is reordered, replayed, or dropped within a connection fails
+  authentication and the stream stops.
+
+- **Known limitation: cross-stream replay.** Because the key is static and shared
+  by all connections and both directions, a record captured from one stream is
+  still valid at the same position of another stream under the same key. An
+  active on-path attacker can replay a whole captured stream into a fresh
+  connection, or splice record *i* of stream A into stream B. Tunnelled
+  protocols with their own authentication (SSH, TLS) detect this themselves;
+  plaintext protocols do not. Closing this needs per-connection key material in
+  the negotiation and is planned as a protocol change.
+
+- **What an observer sees.** In `hybrid` mode (the default) only the first
+  `length` bytes of each record are in the target format; the rest of the
+  record is high-entropy ciphertext, and its length (the plaintext length plus
+  28 bytes) is visible. In `format` mode every byte on the wire is in the
+  target format. Sealed covertexts are always exactly `length` bytes and use
+  the format's whole rank space, so a short message neither shortens the
+  covertext nor leaves a run of the format's lowest character.
+
+- **No protocol-version handshake.** The 0.4 wire format is not compatible with
+  0.3.x, and the record-layer mode must match on both endpoints. A mismatch is
+  a failed negotiation: the server logs a warning when the peer closes, and
+  the client sees a timeout. Nothing is sent in the clear in either case.
+
+- **Patterns and lengths are trusted input.** The server compiles only the
+  formats in its own definitions file; a client's negotiation cell can name one
+  of them but cannot supply a pattern. Never load a definitions file (`--release`)
+  from an untrusted source: as libfte documents, a hostile pattern can make DFA
+  construction take exponential time and memory.
+
+- **Negotiation cost.** For every new connection the server tries to decrypt
+  the first bytes as each known request format until one succeeds (the
+  configured `--upstream-format` first). A failed attempt is rejected before
+  the tag check when the bytes are not in the format, as in libfte; a full scan
+  over the built-in formats costs a few milliseconds of CPU.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,8 +46,10 @@ first. This section covers what fteproxy adds on top of it.
   active on-path attacker can replay a whole captured stream into a fresh
   connection, or splice record *i* of stream A into stream B. Tunnelled
   protocols with their own authentication (SSH, TLS) detect this themselves;
-  plaintext protocols do not. Closing this needs per-connection key material in
-  the negotiation and is planned as a protocol change.
+  plaintext protocols do not. Closing this would need per-connection key
+  material in the negotiation (a protocol change); the shared key is a known
+  limitation of the 0.4 line, so tunnel protocols that authenticate themselves
+  where this matters.
 
 - **What an observer sees.** In `hybrid` mode (the default) only the first
   `length` bytes of each record are in the target format; the rest of the

--- a/benchmark.py
+++ b/benchmark.py
@@ -401,12 +401,14 @@ class FteProxyTunnel:
     """
 
     def __init__(self, dest_port, upstream_format=None, downstream_format=None,
+                 record_layer_mode=None,
                  shaper_kwargs=None, verbose=False):
         self.dest_port = dest_port
         self.entry_port = free_port()
         self.server_port = free_port()
         self.upstream_format = upstream_format
         self.downstream_format = downstream_format
+        self.record_layer_mode = record_layer_mode
         self.verbose = verbose
         self.procs = []
         self.shaper = None
@@ -419,6 +421,8 @@ class FteProxyTunnel:
         server_cmd = [py, '-m', 'fteproxy', '--mode', 'server', '--quiet',
                       '--server_ip', '127.0.0.1', '--server_port', str(self.server_port),
                       '--proxy_ip', '127.0.0.1', '--proxy_port', str(self.dest_port)]
+        if self.record_layer_mode:
+            server_cmd += ['--record-layer-mode', self.record_layer_mode]
         self.procs.append(subprocess.Popen(server_cmd, stdout=out, stderr=out))
 
         # Client connects either straight to the server, or via the shaper.
@@ -437,6 +441,8 @@ class FteProxyTunnel:
             client_cmd += ['--upstream-format', self.upstream_format]
         if self.downstream_format:
             client_cmd += ['--downstream-format', self.downstream_format]
+        if self.record_layer_mode:
+            client_cmd += ['--record-layer-mode', self.record_layer_mode]
         self.procs.append(subprocess.Popen(client_cmd, stdout=out, stderr=out))
 
         if not wait_listening(self.server_port):
@@ -734,6 +740,7 @@ def run_matrix(args):
                 tunnel = TunnelCls(dest.port, shaper_kwargs=shaper_kwargs,
                                    upstream_format=args.upstream_format,
                                    downstream_format=args.downstream_format,
+                                   record_layer_mode=args.record_layer_mode,
                                    verbose=args.verbose)
             except TypeError:
                 tunnel = TunnelCls(dest.port, shaper_kwargs=shaper_kwargs)
@@ -856,6 +863,9 @@ def main():
     ap.add_argument('--upstream-format', default=None,
                     help="fteproxy --upstream-format (e.g. manual-http-request)")
     ap.add_argument('--downstream-format', default=None)
+    ap.add_argument('--record-layer-mode', choices=['hybrid', 'format'], default=None,
+                    help="fteproxy --record-layer-mode for both endpoints "
+                         "(default: fteproxy's own default, hybrid)")
     ap.add_argument('--json', default=None, metavar='PATH',
                     help="write raw results as JSON")
     ap.add_argument('--verbose', action='store_true',

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,11 @@ Traffic between client and server looks like:
 - anything you want!
 ```
 
+By default (`--record-layer-mode hybrid`) each record *starts* with a
+covertext in the chosen format and carries the rest as raw authenticated
+ciphertext. Use `--record-layer-mode format` on both endpoints to put every
+byte in the format (much slower). See the main README.
+
 ## Directory Structure
 
 ```
@@ -159,19 +164,28 @@ Shows all formats side-by-side:
 python3 comparison_demo.py
 ```
 
-Output:
+Output (the first 50 characters of each 1024-byte covertext):
 ```
 Secret message: Hello, World!
 
-Format       | Sample Output                                          
+Format       | Sample Output                                      | Status
 ----------------------------------------------------------------------
-Lowercase    | cgkotttxwgupqyhdtosnixzyooehpzlgzejthseolfvlkrwcjksxquz
-Uppercase    | CKOOJBEQIDKHJKTZFJSBNJASAQLYUSQHLWXZVAYJEXYQCQJYUFUQKFE
-Digits       | 0231945802172231145855818304822631859446838418075470674
-Hex          | 00af2703420aa54af5d8eb6214085183553156b9761d9acb6d2d334
-Words        | aamfyleiuih umiepyivwfxjnwqwnedqswfq ztpualumddmayzbziz
-Binary       | 0000000010111000100101111011110111011100000111111101001
+Lowercase    | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | [OK]
+Uppercase    | AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA | [OK]
+Digits       | 00000000000000000000000000000000000000000000000000 | [OK]
+Hex          | 00000000000000000000000000000000000000000000000000 | [OK]
+Words        | a a a a a a a a a a a a a a a a a a a a a a a a a  | [OK]
+Binary       | 00000000000000000000000000000000000000000000000000 | [OK]
+Base64       | ++++++++++++++++++++++++++++++++++++++++++++++++++ | [OK]
+URL Path     | /0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0 | [OK]
+CSV          | 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, | [OK]
 ```
+
+The leading run is the format's spare capacity: a raw libfte covertext is
+always exactly `length` bytes, and a 13-byte message only fills its tail.
+fteproxy's record layer random-pads every message to capacity, so proxied
+covertexts read as random format text end to end; see
+[`formats/README.md`](formats/README.md).
 
 ### words_demo.py
 
@@ -181,7 +195,8 @@ Encodes traffic as space-separated words:
 python3 words_demo.py
 ```
 
-Your "Secret message" becomes: `hello world foo bar qux baz...`
+Your "Secret message" becomes 256 bytes of space-separated words
+(`a a a ... a xkq mfj ...`; see the note above about the leading run).
 
 ### http_demo.py
 
@@ -191,7 +206,8 @@ Encodes traffic to look like HTTP:
 python3 http_demo.py
 ```
 
-Your "Secret message" becomes: `GET /a8Kj2mNp HTTP/1.1\r\n\r\n`
+Your "Secret message" becomes a 256-byte `GET /...0009tD5BiJuMayS7XNqfFDcgvFHK3UbyIuRDkYSpg5Y1 HTTP/1.1\r\n\r\n`
+(see the note above about the leading run).
 
 ---
 
@@ -206,11 +222,13 @@ Learn the Python API with these examples.
 Direct FTE encoding without network sockets. Perfect for understanding the basics:
 
 ```python
+import os
 import fte
 
-encoder = fte.Encoder("^[a-z]+$", 256)
-ciphertext = encoder.encode(b"Secret!")
-plaintext, _ = encoder.decode(ciphertext)
+key = os.urandom(32)  # share a real secret between endpoints
+cipher = fte.FTE(output_format=fte.RegexFormat("^[a-z]+$", length=256), key=key)
+ciphertext = cipher.encrypt(b"Secret!")   # 256 lowercase letters
+plaintext = cipher.decrypt(ciphertext)
 ```
 
 ```bash
@@ -349,7 +367,12 @@ You --> :8079 --> [FTE encode] --> :8080 --> [FTE decode] --> :8081 --> netcat
 
 ## Available Formats
 
-fteproxy includes these built-in formats:
+fteproxy includes these built-in formats. Each exists as `<name>-request`
+(client to server) and `<name>-response` (server to client) in
+`fteproxy/defs/20260110.json`; pass them to `--upstream-format` and
+`--downstream-format`. Every covertext of a format is a fixed number of bytes
+(its `length`): 256 for most, 1032 for `binary`, 312 for `ip-address` and
+`timestamp`, and between 176 and 232 for the other structured formats.
 
 | Format | Output Looks Like | Example |
 |--------|------------------|---------|

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -52,5 +52,9 @@ Your Traffic Flow:
                      patterns
 ```
 
-The traffic between the fteproxy client and server looks like HTTP requests/responses,
-making it difficult for network monitors to identify as proxy traffic.
+Each record between the fteproxy client and server starts with a covertext
+shaped like an HTTP request (client to server) or an HTTP response (server to
+client). With the default `--record-layer-mode hybrid` the rest of the record is
+raw authenticated ciphertext; with `--record-layer-mode format` on both sides
+the whole stream is in the format. Either way, give both sides the same
+`--key-file`: the built-in default key is public.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -62,8 +62,18 @@ Even though the conversation looks normal, the actual network traffic is encoded
 
 | Direction | What You See | What's On The Wire |
 |-----------|-------------|-------------------|
-| Client -> Server | "Hi there!" | `0101101011101010110...` |
-| Server -> Client | "Hello!" | `ABBAABABBAABBABA...` |
+| Client -> Server | "Hi there!" | `0101101011101010110...` (520 bytes) + raw ciphertext |
+| Server -> Client | "Hello!" | `ABBAABABBAABBABA...` (520 bytes) + raw ciphertext |
+
+With fteproxy's default record-layer mode (`hybrid`), each record starts with
+a 520-character covertext in the format and carries the message itself as raw
+authenticated ciphertext after it. To make the whole stream binary or letters,
+select `format` mode on both sides before wrapping the socket (there is no
+`wrap_socket` argument for it):
+
+```python
+fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'format')
+```
 
 ## Traffic Flow
 

--- a/examples/formats/README.md
+++ b/examples/formats/README.md
@@ -1,39 +1,60 @@
 # FTE Output Format Examples
 
-This directory contains shell scripts that demonstrate different output formats.
-Each format makes your traffic look like different types of data.
+Three self-contained scripts that call libfte directly (no sockets, no proxy)
+to show what the same data looks like in different covertext formats:
 
-## Available Formats
-
-| Format | Description | Example Output |
-|--------|-------------|----------------|
-| `lowercase` | Random lowercase letters | `xkcdpqmwrtyghasdf...` |
-| `uppercase` | Random UPPERCASE letters | `XKCDPQMWRTYGHASDF...` |
-| `words` | Space-separated words | `hello world foo bar...` |
-| `hex` | Hexadecimal string | `a1b2c3d4e5f6...` |
-| `digits` | Numeric digits | `8675309420...` |
-| `base64` | Base64-like characters | `aGVsbG8gd29ybGQ...` |
-| `binary` | Binary (0s and 1s) | `01101000011001...` |
-
-## Usage
-
-Each script starts a server-client pair using a specific format:
+| Script | What it shows |
+|--------|---------------|
+| `comparison_demo.py` | One message in nine formats side by side (lowercase, uppercase, digits, hex, words, binary, base64, URL path, CSV) |
+| `words_demo.py` | Messages as space-separated lowercase words |
+| `http_demo.py` | Messages as `GET /... HTTP/1.1` requests |
 
 ```bash
-# Terminal 1 - Start server
-./words_server.sh
-
-# Terminal 2 - Start client  
-./words_client.sh
+python3 comparison_demo.py
+python3 words_demo.py
+python3 http_demo.py
 ```
 
-Then connect to port 8079 to send data through the FTE tunnel.
+Each script builds a cipher with `fte.FTE(output_format=fte.RegexFormat(pattern, length=N), key=key)`,
+encrypts a message, checks that it decrypts, and prints the covertext.
 
-## Why Different Formats?
+## Reading the output
 
-Different formats help evade different types of traffic analysis:
+A raw libfte covertext is always exactly `length` bytes, and a short message
+does not fill it, so the unused capacity comes out as a run of the format's
+lowest-ranked character: `aaaa...` for letters, `0000...` for digits, `a a a`
+for words, `GET /000...0<random tail> HTTP/1.1` for the HTTP format. That is
+what these scripts print. It is expected, and it is not what fteproxy puts on
+the wire: fteproxy's record layer random-pads every message to the format's
+capacity before encryption, so a proxied covertext reads as random format text
+end to end (`GET /0ECRjVCS...`).
 
-- **HTTP-like**: Mimics web traffic
-- **Words**: Appears as natural text
-- **Hex/Base64**: Looks like encoded data (common in APIs)
-- **Digits**: Could pass as numeric data
+To see a covertext without the run in a script like these, choose a `length`
+close to what the message needs (libfte's README does this), or pad the
+plaintext to `cipher.max_plaintext_bytes` yourself.
+
+## Using a format with the proxy
+
+Every built-in format has a `-request` (client to server) and a `-response`
+(server to client) definition in `fteproxy/defs/20260110.json`. Pick them on
+the client; the server negotiates the matching pair automatically:
+
+```bash
+python3 -m fteproxy --mode client --upstream-format words-request --downstream-format words-response ...
+```
+
+By default (`--record-layer-mode hybrid`) only a fixed-length header per record
+is in the chosen format and the rest of the record is raw ciphertext. Add
+`--record-layer-mode format` on both endpoints to put every byte in the format,
+at much lower throughput. See the main README's "Upgrading to 0.4.0" section.
+
+## Why different formats?
+
+Different formats blend in with different traffic:
+
+- **HTTP-like** (`http-simple`, `manual-http`): web traffic
+- **Words / sentences**: natural text
+- **Hex / base64**: encoded data, common in APIs
+- **Digits, IP addresses, timestamps**: numeric fields
+
+The full list is in [`../README.md`](../README.md#available-formats).

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -44,7 +44,7 @@ python3 -m fteproxy --mode server --server_port 8080 --proxy_port 8888
 python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
 
 # Use curl with the proxy
-curl -x socks5://localhost:8079 https://example.com
+curl -x http://localhost:8079 https://example.com
 ```
 
 ## Netcat File Transfer
@@ -71,20 +71,22 @@ python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --s
 cat myfile.txt | nc localhost 8079
 ```
 
-## Custom Key
+## Key
 
-For additional security, use a custom encryption key:
+The built-in default key is public (fteproxy warns at startup when it is in
+use), so always supply your own. Both sides must use the same key. Prefer
+`--key-file`, which keeps the key out of shell history and `ps` output:
 
 ```bash
 # Generate a random 64-character hex key
-KEY=$(openssl rand -hex 32)
-echo "Using key: $KEY"
+openssl rand -hex 32 > fteproxy.key
+chmod 600 fteproxy.key
 
 # Server
-python3 -m fteproxy --mode server --key $KEY --server_port 8080 --proxy_port 8081
+python3 -m fteproxy --mode server --key-file fteproxy.key --server_port 8080 --proxy_port 8081
 
-# Client (use the SAME key)
-python3 -m fteproxy --mode client --key $KEY --server_ip <server-ip> --server_port 8080
+# Client (the SAME key file)
+python3 -m fteproxy --mode client --key-file fteproxy.key --server_ip <server-ip> --server_port 8080
 ```
 
 ## Chaining with socat

--- a/examples/programmatic/simple_encoder.py
+++ b/examples/programmatic/simple_encoder.py
@@ -16,7 +16,11 @@ def main():
     # This one produces lowercase letters only
     regex = "^[a-z]+$"
 
-    # Length determines the capacity (bits encoded per output character)
+    # Every covertext is exactly `length` bytes. How many plaintext bytes it can
+    # carry (cipher.max_plaintext_bytes) follows from the pattern's alphabet
+    # and this length; a short message leaves the format's spare capacity as a
+    # run of its lowest character ('a'). fteproxy's record layer random-pads
+    # to capacity so that run never appears on the wire.
     length = 256
 
     # libfte 0.4 requires an explicit 32-byte key (there is no random-key path)

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 import os
 import sys

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -47,10 +47,11 @@ def _make_cipher(pattern, length, key):
 def _hybrid_mode():
     """Whether the record layer runs in 'hybrid' (fast bulk) mode.
 
-    'format' (default) transforms every covertext byte into the target format
-    for maximum unobservability. 'hybrid' formats only a fixed-length header per
-    record and carries the body as raw authenticated bytes: much faster for
-    bulk transfer, but everything past the header looks like random data.
+    'hybrid' (the default) formats only a fixed-length header per record and
+    carries the body as raw authenticated bytes: much faster for bulk transfer,
+    but everything past the header looks like random data. 'format' (opt-in)
+    transforms every covertext byte into the target format for full-stream
+    realism. See ``runtime.fteproxy.record_layer.mode`` in ``fteproxy.conf``.
     """
     return fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode') == 'hybrid'
 
@@ -526,14 +527,24 @@ def wrap_socket(sock,
 
     The input parameter ``sock`` is the socket to wrap.
     The parameter ``outgoing_regex`` specifies the format of the messages
-    to send via the socket. The ``outgoing_length`` parameter specifies the
-    maximum length of the strings in ``outgoing_regex``.
+    to send via the socket. The ``outgoing_length`` parameter is the exact
+    length, in bytes, of every formatted covertext sent (libfte 0.4 emits
+    fixed-length covertexts; the capacity of one covertext follows from the
+    pattern and the length, and building the cipher raises
+    ``fte.FormatCapacityError`` if the format cannot hold even an empty
+    message at that length).
     The parameters ``incoming_regex`` and ``incoming_length`` are defined
     similarly.
     The optional parameters ``K1`` and ``K2`` specify 128-bit keys to be used
     in FTE's underlying AE scheme. If specified, these values must be 16-byte
-    strings.
-    
+    strings. If omitted, the key from ``fteproxy.conf`` is used, which is the
+    public built-in default unless the application has set
+    ``runtime.fteproxy.encrypter.key``; always share a secret key.
+
+    The record-layer mode (``hybrid`` or ``format``) comes from
+    ``runtime.fteproxy.record_layer.mode`` in ``fteproxy.conf`` and must be the
+    same on both endpoints.
+
     The ``negotiate`` parameter controls whether the client sends a negotiation
     cell to establish the format. Set to ``False`` when both sides already know
     the formats (e.g., in symmetric client/server examples). Default is ``True``

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -290,7 +290,10 @@ def get_args():
                             'runtime.fteproxy.record_layer.mode'))
     key_group = parser.add_mutually_exclusive_group()
     key_group.add_argument('--key', action=setConfValue,
-                        help='Cryptographic key, hex, must be exactly 64 characters',
+                        help='Shared secret, hex, exactly 64 characters; must '
+                             'match on both endpoints. The built-in default '
+                             'is public and gives no protection: always '
+                             'supply your own (see --key-file).',
                         default=fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'
                                                   ).hex())
     key_group.add_argument('--key-file', action=setConfValue, dest='key_file',

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -109,7 +109,7 @@ high-entropy ciphertext. This is the behavior fteproxy shipped on libfte 0.3.
 
 'format' transforms every covertext byte into the target format, so the whole
 stream is indistinguishable from the protocol: stronger against entropy or
-statistical detectors, but much slower. Turn it up when you want full-stream
+statistical detectors, but much slower. Turn it on when you want full-stream
 realism and can spend the throughput. Both endpoints must use the same mode."""
 conf['runtime.fteproxy.record_layer.mode'] = 'hybrid'
 
@@ -129,7 +129,8 @@ DEFAULT_KEY = b'\xFF' * 16 + b'\x00' * 16
 conf['runtime.fteproxy.encrypter.key'] = DEFAULT_KEY
 
 
-"""The default length parameter to use for buildTable."""
+"""Covertext length for definitions that carry no "length" key (the manual-*
+and dummy-* formats)."""
 conf['fteproxy.default_length'] = 2 ** 8
 
 

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -1,7 +1,29 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""The record layer: frames a byte stream as a sequence of libfte covertexts.
 
+libfte 0.4 encrypts one message into exactly one fixed-length covertext and
+has no stream framing of its own, so this module defines the wire layout.
+Every record starts with a *sealed* covertext of exactly ``length`` bytes (the
+format's fixed covertext length): its plaintext is
+``len(4) || seq(8) || message || random pad`` filled to the format's capacity,
+so it reads as random format text and only unseals at stream position
+``seq``. The two modes differ in what the sealed covertext carries:
 
+``format``
+    The message itself. The stream is a sequence of covertexts, all in the
+    target format.
+
+``hybrid`` (the default)
+    A 4-byte body length, followed on the wire by that many raw bytes:
+    ``nonce(12) || AES-128-CTR ciphertext || HMAC-SHA256 tag(16)`` from
+    :class:`fteproxy._AEADBody`, with ``seq`` bound into the tag. Only the
+    header blends in with the format; the body is high-entropy ciphertext.
+
+``seq`` is the record's position in its stream, counted from 0 by each
+``Encoder``/``Decoder`` pair, so a record moved, replayed, or dropped within
+a stream is rejected. See SECURITY.md for what is not covered.
+"""
 
 import os
 import struct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+# >=77 for PEP 639 license metadata (license = "MIT" + license-files); that
+# also covers PEP 660 editable installs without a setup.py shim (>=64).
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +9,8 @@ name = "fteproxy"
 dynamic = ["version"]
 description = "Format-Transforming Encryption proxy for censorship circumvention"
 readme = "PYPI_README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
     {name = "Kevin P. Dyer", email = "kpdyer@gmail.com"}
@@ -20,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Security :: Cryptography",
@@ -29,7 +31,9 @@ classifiers = [
 ]
 dependencies = [
     "fte>=0.4.0,<0.5.0",
-    "cryptography>=41.0",
+    # The hybrid record body (AES-CTR + HMAC-SHA256). libfte 0.4 needs >=42
+    # transitively, so that is the effective floor.
+    "cryptography>=42.0",
 ]
 
 [project.urls]
@@ -46,6 +50,12 @@ version = {attr = "fteproxy.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["fteproxy*"]
+# The test suite ships in the sdist (MANIFEST.in) but not in the wheel: it
+# needs the examples/ tree, which is not packaged.
+exclude = ["fteproxy.tests*"]
+
+[tool.setuptools.exclude-package-data]
+fteproxy = ["tests/*"]
 
 [tool.setuptools.package-data]
 fteproxy = ["defs/*.json"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fte>=0.4.0,<0.5.0
-cryptography>=41.0
+cryptography>=42.0
 pytest>=9.1.1
 pytest-timeout>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,60 +1,7 @@
 #!/usr/bin/env python3
+# All project metadata lives in pyproject.toml (PEP 621). This shim only keeps
+# ``python setup.py ...`` invocations working; there is nothing to edit here.
 
 from setuptools import setup
-import glob
-import re
 
-# Read version from __init__.py without importing (avoids dependency issues)
-with open('fteproxy/__init__.py') as fh:
-    version_match = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fh.read(), re.MULTILINE)
-    FTEPROXY_RELEASE = version_match.group(1) if version_match else '0.0.0'
-
-package_data_files = []
-for filename in glob.glob('fteproxy/defs/*.json'):
-    jsonFile = filename.split('/')[-1]
-    package_data_files += ['defs/' + jsonFile]
-package_data = {'fteproxy': package_data_files}
-
-with open('PYPI_README.md', encoding='utf-8') as file:
-    long_description = file.read()
-
-setup(
-    name='fteproxy',
-    version=FTEPROXY_RELEASE,
-    description='Format-Transforming Encryption proxy for censorship circumvention',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Kevin P. Dyer',
-    author_email='kpdyer@gmail.com',
-    url='https://github.com/kpdyer/fteproxy',
-    project_urls={
-        'Homepage': 'https://github.com/kpdyer/fteproxy',
-        'Documentation': 'https://github.com/kpdyer/fteproxy',
-        'Source': 'https://github.com/kpdyer/fteproxy',
-        'Bug Tracker': 'https://github.com/kpdyer/fteproxy/issues',
-    },
-    packages=['fteproxy', 'fteproxy.defs', 'fteproxy.tests'],
-    package_data=package_data,
-    install_requires=['fte>=0.4.0,<0.5.0', 'cryptography>=41.0'],
-    python_requires='>=3.10',
-    classifiers=[
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
-        'License :: OSI Approved :: MIT License',
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Topic :: Security :: Cryptography',
-        'Topic :: Internet :: Proxy Servers',
-        'Operating System :: OS Independent',
-    ],
-    entry_points={
-        'console_scripts': [
-            'fteproxy = fteproxy.cli:main'
-        ]
-    },
-    keywords='fte, encryption, proxy, censorship, privacy',
-)
+setup()


### PR DESCRIPTION
## Summary

Prepares the fteproxy **0.4.0** release: the version bump, packaging cleanup, a Dependabot gate for the `fte` line, and documentation for the new record layer and the upgrade path. **Part 9 (last)** of the #221 split, stacked on #231.

## Changes

- **release:** `__version__` 0.3.2 → 0.4.0.
- **packaging:** metadata is single-sourced in `pyproject.toml` (`setup.py` is a shim; the 0.3.2 stopgap had to edit three files for one pin); PEP 639 license metadata with `setuptools>=77` (the old form is deprecated for removal in 2027); `cryptography>=42.0` (libffx, a hard dependency of fte 0.4, already needs 42); the test suite ships in the sdist but not in the wheel (it needs the unpackaged `examples/` tree). Verified: `python -m build` + `twine check` pass, the wheel installs into a fresh venv and runs `fteproxy --version` → `0.4.0`, `pip install -e .` (the CI path) still works.
- **ci:** Dependabot ignores major/minor `fte` updates and the auto-merge workflow only approves patch/minor bumps that touch neither `fte` nor the PyPI publish action. Without this, Dependabot would have rewritten `fte>=0.4.0,<0.5.0` to admit a libfte 0.5 and the workflow would have merged that wire-format change unattended.
- **docs:** README (wire-incompatibility warning, requirements, a "Record-layer modes" section, the missing CLI rows, an honest `--key` row, a Python API pointer, "Upgrading to 0.4.0"); PYPI_README; SECURITY.md (supported versions and a security model section, including the cross-stream replay limitation left open by #229); examples READMEs (the `fte.Encoder` snippet, what hybrid mode actually puts on the wire, real sample outputs, `curl -x http://`, the key section; `examples/formats/README.md` described shell scripts that do not exist); docstrings and help text (`_hybrid_mode` said `format` was the default; `wrap_socket`; a record-layout module docstring; `--key`).
- **benchmark:** `--record-layer-mode` passthrough so both modes can be measured with one harness.
- **PERFORMANCE.md:** rewritten from measurements of the final tree on loopback (setup 1.1 ms, 64 B RTT 0.51 ms, 8 MB echo 4.6 Gbit/s vs 0.7 on 0.3.1; format mode 4–7 Mbit/s), keeping the still-valid relay-loop and link-drop caveats.

## Release checklist

1. Merge #224, #225, #226, #227, #228, #229 in order (squash), retargeting each next PR to `master` as its base merges.
2. Merge this PR.
3. Create GitHub release `v0.4.0` with the notes below; `publish.yml` pushes to PyPI.
4. Close #221 (superseded by this stack).

## Draft release notes

```markdown
## fteproxy 0.4.0

Migrates to libfte 0.4 (`fte.FTE`) and redesigns the record layer. **Both endpoints must upgrade together.**

### Highlights
- **Two record-layer modes.** `hybrid` (default) sends one FTE-formatted header per record and a raw AES-CTR+HMAC-SHA256 body: 3-8x the bulk throughput of 0.3 (220 MB/s at 256 KiB and 500 MB/s at 4 MiB record-layer round trips, `http-simple-request`/256, Apple M3 Pro). `format` (`--record-layer-mode format`) transforms every byte into the target format for full-stream realism at about 0.15 MB/s.
- **Sealed covertexts.** Every formatted covertext is random-padded to capacity and stamped with its stream position: a short message no longer produces a `GET /0000...` run, covertexts do not leak message length, and a record reordered, replayed, or dropped within a connection is rejected in both modes.
- **All 46 built-in formats usable** under libfte 0.4's hard capacity. Twenty lengths were raised (`binary` 256 to 1032; `ip-address` and `timestamp` 64 to 312; `ftp-request` 64 to 208; `ftp-response` 128 to 232; `email-simple` 128 to 224; `smtp` 128 to 208; `tls-sni` and `domain` 128 to 200; `ssh` 128 to 184; `key-value` 128 to 176), each now carrying about 100 bytes per covertext. The default `manual-http-request`/`-response` keep length 256 (150/192 bytes).
- **Default-key warning.** fteproxy warns at startup when the public built-in key is in use.
- A server no longer leaks two relay threads for every connection whose negotiation fails.

### Breaking changes
- **Wire format.** Not compatible with fteproxy 0.3.x; a mismatched peer fails at negotiation. `--record-layer-mode` must also match on both endpoints.
- **Key required.** libfte 0.4 needs a 32-byte key; without `--key`/`--key-file`, fteproxy uses its public default and warns.
- **Renames.** `wrap_socket(outgoing_fixed_slice=, incoming_fixed_slice=)` are now `outgoing_length=`/`incoming_length=`; `fteproxy.defs.getFixedSlice` is `getLength`; the definitions JSON key `"fixed_slice"` is `"length"`.
- **Regex dialect.** libfte 0.4 rejects `\C`, backslashes inside character classes, and brace quantifiers. Four built-in patterns were rewritten (`\C` becomes `.`; `[a-zA-Z0-9\.\/]` becomes `[a-zA-Z0-9./]`); `manual-http-request` paths no longer admit a backslash.
- Requires `fte>=0.4.0,<0.5.0` and `cryptography>=42.0`; Python 3.10 to 3.14.

### Security
- Only the header of each `hybrid` record is in the target format; the body is high-entropy ciphertext. Use `format` mode against entropy-based detectors.
- Records are authenticated and ordered within a connection. The key is shared by all connections, so a captured stream can still be replayed into a new connection; see SECURITY.md.
- There is no protocol-version handshake; a 0.3 peer fails at negotiation.

### Install
pip install fteproxy==0.4.0

**Full changelog:** https://github.com/kpdyer/fteproxy/compare/v0.3.2...v0.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
