### PR TITLE
Perf: cache ciphers across connections; decrypt a pending header once

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -6,6 +6,7 @@ __version__ = "0.3.2"
 import os
 import sys
 import hmac
+import functools
 import socket
 import hashlib
 import traceback
@@ -20,6 +21,7 @@ from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 
+@functools.lru_cache(maxsize=256)
 def _make_cipher(pattern, length, key):
     """Build a libfte 0.4 cipher that hides bytes as one fixed-length covertext.
 
@@ -28,6 +30,13 @@ def _make_cipher(pattern, length, key):
     ``fte.Encoder(regex, fixed_slice, key)``. The
     cipher ``encrypt``/``decrypt`` one whole covertext per call; the record
     layer handles stream chunking and framing on top of it.
+
+    Cached. libfte 0.4 compiles the DFA afresh for every ``RegexFormat``
+    (0.5 to 1.5 ms per format, and libfte 0.3 cached it globally), while
+    fteproxy builds a cipher per socket and per negotiation attempt: that
+    turned connection setup from about 3 ms into about 9 ms. An ``fte.FTE``
+    holds only read-only tables and draws a fresh nonce on every call, so one
+    instance serves every connection and thread.
     """
     return fte.FTE(
         output_format=fte.RegexFormat(pattern, length=length),

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -131,6 +131,10 @@ class Decoder:
         self._frame_size = cipher.output_format.max_length
         self._buffer = b''
         self._seq = 0
+        # Body length from a hybrid header that was decrypted and verified but
+        # whose body had not fully arrived. While set, that header is the first
+        # ``_frame_size`` bytes of ``_buffer`` (the buffer only grows).
+        self._pending_body_len = None
 
     def push(self, data):
         """Push data onto the FIFO buffer."""
@@ -176,29 +180,40 @@ class Decoder:
         offset = 0
 
         while len(buffer) - offset >= self._frame_size:
-            header = buffer[offset:offset + self._frame_size]
-            head = self._decrypt(self._cipher, header)
-            if head is None:
-                break
-            head = _unseal(head, self._seq)
-            if head is None:
-                # Authenticated but not a sealed record at this stream position:
-                # a peer on a different mode, corruption, or a record replayed,
-                # reordered, or dropped. Treat it as undecodable.
-                fteproxy.info(
-                    "fteproxy.record_layer: malformed or out-of-order sealed "
-                    "record at seq " + str(self._seq))
-                break
-
-            if self._body_cipher is None:
-                # 'format' mode: the sealed covertext carried the message.
-                messages.append(head)
-                offset += self._frame_size
-                self._seq += 1
+            if self._body_cipher is not None and self._pending_body_len is not None:
+                # The header at the front of the buffer was decrypted and
+                # verified on an earlier pop whose body had not fully arrived.
+                # A large record arrives over several reads, so do not rank
+                # and verify the same header again for each partial delivery.
+                body_len = self._pending_body_len
             else:
+                header = buffer[offset:offset + self._frame_size]
+                head = self._decrypt(self._cipher, header)
+                if head is None:
+                    break
+                head = _unseal(head, self._seq)
+                if head is None:
+                    # Authenticated but not a sealed record at this stream
+                    # position: a peer on a different mode, corruption, or a
+                    # record replayed, reordered, or dropped. Treat it as
+                    # undecodable.
+                    fteproxy.info(
+                        "fteproxy.record_layer: malformed or out-of-order sealed "
+                        "record at seq " + str(self._seq))
+                    break
+
+                if self._body_cipher is None:
+                    # 'format' mode: the sealed covertext carried the message.
+                    messages.append(head)
+                    offset += self._frame_size
+                    self._seq += 1
+                    if oneCell:
+                        break
+                    continue
+
                 # 'hybrid' mode: the header carries the raw body's length. The
-                # header is authenticated, so a successful decrypt means we wrote
-                # it and the length is trustworthy.
+                # header is authenticated, so a successful decrypt means we
+                # wrote it and the length is trustworthy.
                 if len(head) != _OVERFLOW_LEN.size:
                     fteproxy.info(
                         "fteproxy.record_layer: unexpected header width "
@@ -212,22 +227,27 @@ class Decoder:
                         "fteproxy.record_layer: body length " + str(body_len)
                         + " exceeds the record limit")
                     break
-                body_start = offset + self._frame_size
-                if len(buffer) - body_start < body_len:
-                    break  # body not fully arrived; wait for more data
-                body = buffer[body_start:body_start + body_len]
-                try:
-                    msg = self._body_cipher.decrypt(body, self._seq)
-                except InvalidTag:
-                    # Wrong key, corruption, or a record out of its stream
-                    # position (reorder/drop/replay). Stop draining.
-                    fteproxy.info(
-                        "fteproxy.record_layer: body auth failed at seq "
-                        + str(self._seq))
-                    break
-                self._seq += 1
-                messages.append(msg)
-                offset = body_start + body_len
+
+            body_start = offset + self._frame_size
+            if len(buffer) - body_start < body_len:
+                # Body not fully arrived; wait for more data. The write-back
+                # below leaves this header at the front of the buffer.
+                self._pending_body_len = body_len
+                break
+            self._pending_body_len = None
+            body = buffer[body_start:body_start + body_len]
+            try:
+                msg = self._body_cipher.decrypt(body, self._seq)
+            except InvalidTag:
+                # Wrong key, corruption, or a record out of its stream
+                # position (reorder/drop/replay). Stop draining.
+                fteproxy.info(
+                    "fteproxy.record_layer: body auth failed at seq "
+                    + str(self._seq))
+                break
+            self._seq += 1
+            messages.append(msg)
+            offset = body_start + body_len
 
             # Stop after a single record only once one decoded successfully. This
             # must live here, not in a ``finally``: a ``break`` in ``finally``

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -204,6 +204,14 @@ class TestWrapSocket:
         assert received_data[0] == test_data
         assert echo_data == test_data
 
+    def test_make_cipher_is_cached(self):
+        """One cipher per (pattern, length, key); libfte 0.4 does not cache DFAs."""
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        a = fteproxy._make_cipher('^[a-z]+$', 64, key)
+        assert fteproxy._make_cipher('^[a-z]+$', 64, key) is a
+        assert fteproxy._make_cipher('^[a-z]+$', 96, key) is not a
+        assert fteproxy._make_cipher('^[a-z]+$', 64, bytes(range(32))) is not a
+
     def test_default_key_warns(self, capsys):
         """Starting with the public built-in key prints a warning; a real key does not."""
         import fteproxy.cli

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -217,6 +217,33 @@ class TestHybridRecordLayer:
             out += decoder.pop()
         assert out == payload
 
+    def test_pending_header_is_decrypted_once(self):
+        """A header whose body arrives over several reads is ranked and
+        verified once, not once per partial delivery."""
+        encoder, decoder = self._pair()
+        real = decoder._cipher
+        calls = []
+
+        class Counting:
+            output_format = real.output_format
+            max_plaintext_bytes = real.max_plaintext_bytes
+
+            def decrypt(self, covertext):
+                calls.append(1)
+                return real.decrypt(covertext)
+
+        decoder._cipher = Counting()
+        encoder.push(b'Q' * 5000)
+        wire = encoder.pop()                     # 256-byte header + 5028-byte body
+        decoder.push(wire[:300]); assert decoder.pop() == b''
+        decoder.push(wire[300:600]); assert decoder.pop() == b''
+        decoder.push(wire[600:]); assert decoder.pop() == b'Q' * 5000
+        assert len(calls) == 1
+        # And the next record is decrypted afresh.
+        encoder.push(b'R' * 10); decoder.push(encoder.pop())
+        assert decoder.pop() == b'R' * 10
+        assert len(calls) == 2
+
     def test_oversized_body_length_is_rejected(self, capsys):
         """A header announcing a body larger than any record can carry is
         refused instead of buffering up to 4 GiB waiting for it."""


### PR DESCRIPTION
## Summary

Two fixes from the pre-release performance review, which benchmarked the 0.4 tree against fteproxy 0.3.1 on loopback. **Part 8** of the #221 split, stacked on #229 (the release-prep PR is re-stacked on this one).

## What the review found

- **Connection setup regressed 3x** (p50 2.2–3.3 ms on 0.3.1 → 8.1–8.7 ms, 12 ms with a dead connection present). libfte 0.3 cached its DFA tables globally, so building an encoder was free; libfte 0.4 compiles the DFA afresh for every `RegexFormat` (0.5–1.5 ms per format), and fteproxy builds a cipher per socket and per negotiation attempt (four on the client, three on the server, per connection).
- The same uncached build turned the closed-before-negotiation loop that #229 fixes into a **CPU burn**: one dead connection pinned the server at 64%, five saturated a core and raised RTT p50 to 65 ms (0.3.1: 5%/15%). #229's EOF fix removes the loop; this PR removes the 6 ms-per-iteration cost behind it.
- **Bulk left 30% on the table**: a 256 KiB record arrives in about three reads, and `Decoder.pop` re-ranked and re-verified the same header on every partial delivery.
- Everything else measured as an improvement or a non-issue: the record layer is 5x cheaper per record and 9–12x faster in bulk than 0.3.1 (657–920 MB/s hybrid round trip at 256 KiB–1 MiB vs 75–88); `os.urandom` padding, per-record `Cipher` construction, buffer concatenation and slicing are all under 1% of a record.

## Changes

1. **`_make_cipher` is cached** on `(pattern, length, key)` with `functools.lru_cache`. An `fte.FTE` holds only read-only tables (everything mutable in libfte's DFA is written at construction) and draws a fresh nonce on every call, so one instance serves every connection and thread. Reviewer's measurement of this change: setup p50 **0.7–0.8 ms** (better than 0.3.1).
2. **A pending hybrid header is decrypted once.** The decoder remembers the decoded body length until the body arrives (the buffer only grows, so the header stays at its front). Reviewer's measurement: 8 MB echo +30%.

Reviewer's end-to-end numbers with #229's EOF fix plus both changes (Apple M3 Pro, loopback): setup p50 0.8 ms, RTT 64 B p50 0.43 ms (0.3.1: 1.46), 1 MB echo 2.6 Gbit/s (0.3.1: 0.5), 8 MB echo 4.1–4.4 Gbit/s (0.3.1: 0.66), 8 MB upload 5.3–6.3 Gbit/s (0.3.1: 1.1–1.3). PERFORMANCE.md is rewritten in the release-prep PR with measurements of the final tree.

## Validation

106 tests pass against PyPI `fte==0.4.0`, including new tests for cache identity and single header decrypt across partial reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
