### PR TITLE
Flush log output, send WARN/ERROR to stderr, handle SIGTERM like SIGINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ python3 -m fteproxy --mode client --key-file fteproxy.key --client_ip 127.0.0.1 
 The file must contain exactly 64 hexadecimal characters (a trailing newline is
 ignored). `--key` and `--key-file` cannot be used together.
 
+### Running as a Service
+
+Status lines (`Client ready!`, `Server ready!`, `INFO:`) go to stdout and
+`WARN:` / `ERROR:` lines to stderr. Every line is flushed as it is written, so
+output appears immediately under systemd, docker, `nohup`, or a shell redirect
+such as `> server.log 2>&1`, not only when the process exits. SIGTERM (what
+`systemctl stop`, `docker stop`, and `kill` send) and SIGINT (Ctrl-C, `--stop`)
+both shut the relay down cleanly and remove its pid file.
+
 ### Python API
 
 `fteproxy.wrap_socket(sock, outgoing_regex=..., outgoing_length=..., incoming_regex=..., incoming_length=...)`

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -143,20 +143,25 @@ class NegotiateTimeoutException(Exception):
     pass
 
 
+# Every line is flushed as it is written. Python block-buffers stdout when it
+# is not a terminal (systemd, docker, ``> server.log``), so a bare ``print``
+# would hold diagnostics, including the default-key warning, until the process
+# exited. INFO shares stdout with the CLI status lines; WARN and ERROR go to
+# stderr.
 def fatal_error(msg):
     if fteproxy.conf.getValue('runtime.loglevel') in [1,2,3]:
-        print('ERROR:', msg)
+        print('ERROR:', msg, file=sys.stderr, flush=True)
     sys.exit(1)
 
 
 def warn(msg):
     if fteproxy.conf.getValue('runtime.loglevel') in [2,3]:
-        print('WARN:', msg)
+        print('WARN:', msg, file=sys.stderr, flush=True)
 
 
 def info(msg):
     if fteproxy.conf.getValue('runtime.loglevel') in [3]:
-        print('INFO:', msg)
+        print('INFO:', msg, flush=True)
 
 
 class NegotiateCell(object):

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -35,7 +35,7 @@ class FTEMain(threading.Thread):
                 print("""fteproxy Copyright (C) 2012-2026 Kevin P. Dyer <kpdyer@gmail.com>
     This program comes with ABSOLUTELY NO WARRANTY.
     This is free software, and you are welcome to redistribute it under certain conditions.
-    """)
+    """, flush=True)
 
             if self._args.stop:
                 FTEMain.do_stop(self)
@@ -116,7 +116,7 @@ class FTEMain(threading.Thread):
         warn_if_default_key()
 
         if not self._args.quiet:
-            print('Client ready!')
+            print('Client ready!', flush=True)
 
         self._client = FTEMain.init_listener(self, 'client')
         self._client.daemon = True
@@ -134,7 +134,7 @@ class FTEMain(threading.Thread):
         self._server.daemon = True
         self._server.start()
         if not self._args.quiet:
-            print('Server ready!')
+            print('Server ready!', flush=True)
         self._server.join()
 
 
@@ -316,10 +316,16 @@ def main():
     global running
     running = True
 
-    def signal_handler(signal, frame):
+    def signal_handler(signum, frame):
         global running
         running = False
+    # SIGINT is what Ctrl-C and ``--stop`` send; SIGTERM is what systemd,
+    # docker and a plain ``kill`` send. Both take the same orderly path: the
+    # loop below stops the listener and ``finally`` removes this process's
+    # pid file. Left to its default action, SIGTERM killed the process with
+    # the pid file still on disk, so a later ``--stop`` signalled stale pids.
     signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     try:
         args = get_args()

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -220,10 +220,13 @@ class TestWrapSocket:
         try:
             fteproxy.conf.setValue(key, fteproxy.conf.DEFAULT_KEY)
             fteproxy.cli.warn_if_default_key()
-            assert 'default key' in capsys.readouterr().out
+            captured = capsys.readouterr()
+            assert 'default key' in captured.err
+            assert captured.out == ''
             fteproxy.conf.setValue(key, bytes(range(32)))
             fteproxy.cli.warn_if_default_key()
-            assert capsys.readouterr().out == ''
+            captured = capsys.readouterr()
+            assert captured.err == '' and captured.out == ''
         finally:
             fteproxy.conf.setValue(key, prev)
 

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -18,8 +18,11 @@ import signal
 import subprocess
 import random
 import string
+import threading
 
 import pytest
+
+import fteproxy.conf
 
 
 # Test configuration
@@ -372,3 +375,129 @@ class TestKeyFileEndToEnd:
         )
         assert received_data == test_data, \
             f"Data mismatch: {received_data!r} != {test_data!r}"
+
+
+# Ports for the daemon-output and shutdown tests below.
+OUTPUT_SERVER_PORT = 18280
+OUTPUT_PROXY_PORT = 18281
+SIGTERM_SERVER_PORT = 18380
+SIGTERM_PROXY_PORT = 18381
+
+
+class _PipeReader(threading.Thread):
+    """Drain one subprocess pipe on a daemon thread.
+
+    Lets a test wait for a line with a deadline. A plain ``readline`` on the
+    test thread would block forever if the child never flushed its buffer,
+    which is exactly the failure these tests exist to catch.
+    """
+
+    def __init__(self, stream):
+        threading.Thread.__init__(self, daemon=True)
+        self._stream = stream
+        self._cond = threading.Condition()
+        self.text = ''
+        self.start()
+
+    def run(self):
+        for raw in iter(self._stream.readline, b''):
+            with self._cond:
+                self.text += raw.decode('utf-8', 'replace')
+                self._cond.notify_all()
+
+    def wait_for(self, needle, timeout):
+        """Block until ``needle`` has been read or ``timeout`` seconds pass."""
+        deadline = time.time() + timeout
+        with self._cond:
+            while needle not in self.text:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return False
+                self._cond.wait(remaining)
+            return True
+
+
+class TestDaemonOutput:
+    """Startup lines must reach a non-terminal stdout/stderr while the process
+    is still running.
+
+    Under systemd, docker, or ``> server.log`` Python block-buffers stdout, so
+    an unflushed ``print`` (including the default-key security warning) stays
+    invisible until the process exits. The test therefore reads the pipes
+    while the server is listening and only terminates it afterwards.
+    """
+
+    @pytest.fixture
+    def running_server(self):
+        """A server with both pipes captured, plus readers draining them."""
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'server',
+            '--server_ip', BIND_IP,
+            '--server_port', str(OUTPUT_SERVER_PORT),
+            '--proxy_ip', BIND_IP,
+            '--proxy_port', str(OUTPUT_PROXY_PORT),
+        ]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = _PipeReader(proc.stdout), _PipeReader(proc.stderr)
+        try:
+            if not wait_for_port(BIND_IP, OUTPUT_SERVER_PORT):
+                pytest.fail("Server failed to start. stdout: %r, stderr: %r"
+                            % (out.text, err.text))
+            yield proc, out, err
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_startup_lines_readable_while_running(self, running_server):
+        """Banner and readiness on stdout, the default-key warning on stderr,
+        all readable before the process is terminated."""
+        proc, out, err = running_server
+        assert err.wait_for('default key', 10), \
+            "default-key warning not flushed to stderr; stderr so far: %r" % err.text
+        assert out.wait_for('Server ready!', 10), \
+            "readiness line not flushed to stdout; stdout so far: %r" % out.text
+        assert 'fteproxy Copyright' in out.text
+        assert proc.poll() is None, "server exited before its output was read"
+
+
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='SIGTERM cannot be caught on Windows')
+class TestSigterm:
+    """SIGTERM (systemd stop, docker stop, plain ``kill``) must take the same
+    orderly path as SIGINT: exit 0 and remove the pid file, instead of leaving
+    a stale ``.server-<pid>.pid`` for a later ``--stop`` to signal."""
+
+    def test_sigterm_removes_pid_file_and_exits_cleanly(self):
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'server',
+            '--quiet',
+            '--server_ip', BIND_IP,
+            '--server_port', str(SIGTERM_SERVER_PORT),
+            '--proxy_ip', BIND_IP,
+            '--proxy_port', str(SIGTERM_PROXY_PORT),
+        ]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        pid_file = os.path.join(fteproxy.conf.getValue('general.pid_dir'),
+                                '.server-%d.pid' % proc.pid)
+        try:
+            if not wait_for_port(BIND_IP, SIGTERM_SERVER_PORT):
+                pytest.fail("Server failed to start")
+            assert os.path.exists(pid_file), "server did not write " + pid_file
+            proc.send_signal(signal.SIGTERM)
+            try:
+                returncode = proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                pytest.fail("server did not exit within 15 s of SIGTERM")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            leftover = os.path.exists(pid_file)
+            if leftover:
+                os.unlink(pid_file)
+        assert returncode == 0, "expected a clean exit, got %d" % returncode
+        assert not leftover, "SIGTERM left the pid file behind: " + pid_file


### PR DESCRIPTION
## Summary

All logging went through bare `print()` calls in `fteproxy/__init__.py` (`fatal_error`, `warn`, `info`) and `fteproxy/cli.py` (banner, `Client ready!`, `Server ready!`). When stdout is not a terminal (systemd/journald, docker, `nohup ... > file`, subprocess pipes) Python block-buffers it, so nothing appeared until the buffer filled or the process exited normally. Reproduced on master: `python -m fteproxy --mode server ... > server.log` had a 0-byte log after 3 s while listening and still 0 bytes after SIGTERM. The default-key security warning that README and SECURITY.md promise was therefore invisible in every daemonized deployment. SIGTERM also left `.server-<pid>.pid` files in the temp dir, which a later `--stop` globs and signals.

## Changes

- **Flushed output.** `fatal_error`, `warn`, `info` and the CLI status prints pass `flush=True`. `WARN:` and `ERROR:` now go to stderr; `INFO:` and the status lines stay on stdout.
- **SIGTERM handled like SIGINT.** `main()` registers both on the same handler, so `systemctl stop`, `docker stop`, and `kill` stop the listener, exit 0, and remove the pid file via the existing `finally`.
- **Tests** in `fteproxy/tests/test_system.py`, on new fixed ports (18280-81, 18380-81):
  - `TestDaemonOutput` starts a server with stdout and stderr piped, waits for the listening port, and asserts the default-key warning is readable on stderr and `Server ready!` on stdout while the process is still alive.
  - `TestSigterm` sends SIGTERM and asserts exit status 0 with the pid file gone (skipped on Windows).
  - The existing default-key unit test in `test_python3.py` reads the warning from stderr.
- **README** gains a short "Running as a Service" note on streams, flushing, and signals.

## Reviewer notes

- Behaviour change: WARN/ERROR move from stdout to stderr. Nothing in the repo parsed them from stdout; the record-limit message in the decoder is an INFO line and stays on stdout.
- Both new tests fail on master (10 s wait for the warning; exit status -15 from SIGTERM) and pass with the fix.
- `--stop` still sends SIGINT and still globs every pid file in the temp dir. Stale files created before this fix are not cleaned up.
- `fatal_error` raised from the `FTEMain` thread only ends that thread (the process then exits 0). Pre-existing and out of scope; the message is at least visible now.

## Test plan

- [x] `python -m pytest fteproxy/tests/ -q`: 108 passed (macOS, Python 3.14)
- [x] Manual: `python -m fteproxy --mode server > server.log 2>&1 &` logs banner, warning, and `Server ready!` within 3 s; `kill -TERM` exits 0 and removes the pid file
- [x] Manual: `--stop` still stops a running server and removes its pid file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
