### PR TITLE
Negotiation record is seq 0 of the client stream; reject a duplicated one

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,10 @@ first. This section covers what fteproxy adds on top of it.
   from the shared key. Every record carries its position in its stream (sealed
   inside the covertext and, in `hybrid` mode, bound into the body tag), so a
   record that is reordered, replayed, or dropped within a connection fails
-  authentication and the stream stops.
+  authentication and the stream stops. This includes the negotiation record:
+  it is record 0 of the client-to-server stream and the first data record is
+  1, so a duplicated or replayed negotiation record is rejected the same way
+  and nothing from it reaches the destination.
 
 - **Known limitation: cross-stream replay.** Because the key is static and shared
   by all connections and both directions, a record captured from one stream is

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -232,6 +232,14 @@ class NegotiationManager(object):
         return self._negotiationComplete
 
     def _acceptNegotiation(self, data):
+        """Decode the negotiation cell at the head of ``data``.
+
+        Returns ``[negotiate_cell, decoder]``: the cell's plaintext and the
+        decoder that unsealed it. That decoder has consumed record 0 of the
+        client's stream and holds whatever followed the cell in its buffer, so
+        the caller keeps it as the data decoder; rebuilding one at seq 0 would
+        let a duplicated negotiation record decode again as data.
+        """
 
         languages = fteproxy.defs.load_definitions()
 
@@ -262,7 +270,7 @@ class NegotiationManager(object):
                 negotiate_cell = decoder.pop(oneCell=True)
                 NegotiateCell().fromBytes(negotiate_cell)
 
-                return [negotiate_cell, decoder._buffer]
+                return [negotiate_cell, decoder]
             except Exception as e:
                 fteproxy.info('Failed to decode first message as '+incoming_language+': '+str(e))
 
@@ -287,7 +295,14 @@ class NegotiationManager(object):
 
         return [encoder, decoder]
 
-    def _makeNegotiationCell(self, encoder):
+    def makeClientNegotiationCell(self, encoder):
+        """Encode the negotiation cell as record 0 of ``encoder``'s stream.
+
+        ``encoder`` must be the encoder the socket goes on to send data with,
+        so the first data record is sealed at seq 1. Encoding the cell with a
+        throw-away encoder left both it and the first data record at seq 0,
+        which is what let a duplicated negotiation record decode as data.
+        """
         negotiate_cell = NegotiateCell()
         def_file = fteproxy.conf.getValue('fteproxy.defs.release')
         negotiate_cell.setDefFile(def_file)
@@ -298,30 +313,23 @@ class NegotiationManager(object):
         data = encoder.pop()
         return data
 
-    def makeClientNegotiationCell(self,
-                                  outgoing_regex, outgoing_length,
-                                  incoming_regex, incoming_length):
-        [encoder, decoder] = self._init_encoders(
-            outgoing_regex, outgoing_length, incoming_regex, incoming_length)
-        return self._makeNegotiationCell(encoder)
-
     def doServerSideNegotiation(self, data):
-        [negotiate_cell, remaining_buffer] = self._acceptNegotiation(data)
+        [negotiate_cell, decoder] = self._acceptNegotiation(data)
 
         negotiate = NegotiateCell().fromBytes(negotiate_cell)
 
         outgoing_language = negotiate.getLanguage() + '-response'
-        incoming_language = negotiate.getLanguage() + '-request'
 
         outgoing_regex = fteproxy.defs.getRegex(outgoing_language)
         outgoing_length = fteproxy.defs.getLength(outgoing_language)
-        incoming_regex = fteproxy.defs.getRegex(incoming_language)
-        incoming_length = fteproxy.defs.getLength(incoming_language)
 
-        [encoder, decoder] = self._init_encoders(
-            outgoing_regex, outgoing_length, incoming_regex, incoming_length)
-
-        decoder.push(remaining_buffer)
+        # The decoder that unsealed the negotiation cell is the data decoder:
+        # it is at seq 1 and still holds the bytes that followed the cell. Only
+        # the encoder for the response direction is new. (The cell can only
+        # have unsealed under the request format the client encoded it with,
+        # so that decoder is the one the client's data stream needs.)
+        [encoder, _] = self._init_encoders(
+            outgoing_regex, outgoing_length, None, -1)
 
         return [encoder, decoder]
 
@@ -355,9 +363,9 @@ class FTEHelper(object):
                 self._incoming_length)
             self._encoder = encoder
             self._decoder = decoder
+            # The cell is record 0 of this socket's stream; data starts at 1.
             negotiation_cell = self._negotiation_manager.makeClientNegotiationCell(
-                self._outgoing_regex, self._outgoing_length,
-                self._incoming_regex, self._incoming_length)
+                self._encoder)
             retval = negotiation_cell
             self._negotiationComplete = True
         return retval

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -22,7 +22,9 @@ so it reads as random format text and only unseals at stream position
 
 ``seq`` is the record's position in its stream, counted from 0 by each
 ``Encoder``/``Decoder`` pair, so a record moved, replayed, or dropped within
-a stream is rejected. See SECURITY.md for what is not covered.
+a stream is rejected. The client's negotiation cell is record 0 of its stream
+(its first data record is seq 1), so a duplicated negotiation record is
+rejected like any other. See SECURITY.md for what is not covered.
 """
 
 import os

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -146,3 +146,99 @@ class TestRecvEOF:
         wrapper = _wrap(fake)
         assert wrapper.recv(65536) == b'hello'
         assert wrapper.recv(65536) == b''
+
+
+class CapturingSocket(FakeSocket):
+    """A FakeSocket that also records everything the wrapper sends."""
+
+    def __init__(self, chunks=()):
+        super().__init__(chunks)
+        self.sent = []
+
+    def send(self, data):
+        self.sent.append(data)
+        return len(data)
+
+    def sendall(self, data):
+        self.sent.append(data)
+
+
+@pytest.fixture(params=['hybrid', 'format'])
+def record_layer_mode(request):
+    key = 'runtime.fteproxy.record_layer.mode'
+    prev = fteproxy.conf.getValue(key)
+    fteproxy.conf.setValue(key, request.param)
+    yield request.param
+    fteproxy.conf.setValue(key, prev)
+
+
+def _client_wire(payload):
+    """What a negotiating client puts on the wire to send ``payload``: the
+    negotiation record, then the first data record, as two byte strings."""
+    up = fteproxy.conf.getValue('runtime.state.upstream_language')
+    down = fteproxy.conf.getValue('runtime.state.downstream_language')
+    sock = CapturingSocket()
+    client = fteproxy.wrap_socket(
+        sock,
+        outgoing_regex=fteproxy.defs.getRegex(up),
+        outgoing_length=fteproxy.defs.getLength(up),
+        incoming_regex=fteproxy.defs.getRegex(down),
+        incoming_length=fteproxy.defs.getLength(down))
+    client.send(payload)
+    negotiation, data = sock.sent
+    return negotiation, data
+
+
+class TestNegotiationRecordReplay:
+    """The negotiation cell is record 0 of the client's stream, so a duplicated
+    negotiation record is rejected like any other replayed record.
+
+    Regression tests. The client used to encode the negotiation cell with a
+    throw-away encoder and the server to decode it with a throw-away decoder,
+    so the cell and the first data record were both sealed at seq 0. A stream
+    ``[nego][nego][data0]`` then delivered the second cell's 64-byte plaintext
+    to the destination as application data before stalling on ``data0``.
+    """
+
+    def test_first_data_record_is_sealed_at_seq_1(self, record_layer_mode):
+        """On the wire, the negotiation record is seq 0 and data starts at 1."""
+        negotiation, data = _client_wire(b'payload')
+        up = fteproxy.conf.getValue('runtime.state.upstream_language')
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        cipher = fteproxy._make_cipher(
+            fteproxy.defs.getRegex(up), fteproxy.defs.getLength(up), key)
+
+        decoder = fteproxy._record_decoder(cipher, key)
+        decoder.push(negotiation + data)
+        cell = fteproxy.NegotiateCell().fromBytes(decoder.pop(oneCell=True))
+        assert cell.getLanguage() == up[:-len('-request')]
+        assert decoder.pop() == b'payload'
+        assert decoder._seq == 2
+
+        # The data record alone does not unseal at position 0.
+        fresh = fteproxy._record_decoder(cipher, key)
+        fresh.push(data)
+        assert fresh.pop() == b''
+
+    def test_server_continues_stream_after_negotiation(self, record_layer_mode):
+        """The server's data decoder carries on from the negotiation cell."""
+        negotiation, data = _client_wire(b'payload')
+        for chunks in ([negotiation + data], [negotiation, data]):
+            server = fteproxy.wrap_socket(FakeSocket(chunks))
+            assert server.recv(65536) == b'payload'
+            assert server._decoder._seq == 2
+
+    def test_duplicated_negotiation_record_delivers_nothing(self, record_layer_mode):
+        negotiation, data = _client_wire(b'payload')
+        for chunks in ([negotiation + negotiation + data],
+                       [negotiation, negotiation + data]):
+            server = fteproxy.wrap_socket(FakeSocket(chunks))
+            # Negotiation succeeds on the first cell. The duplicate is then a
+            # record out of its stream position, so nothing decodes and the
+            # stream stops: recv() reports EOF once the peer is gone, having
+            # delivered no application data (not the cell's plaintext, and
+            # not data0, which is sealed at seq 1).
+            assert server.recv(65536) == b''
+            assert server._negotiationComplete
+            assert server._decoder._seq == 1
+            assert server._decoder._buffer == negotiation + data

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -126,6 +126,95 @@ def transfer_through_proxy(test_data, attempts=3, client_port=CLIENT_PORT, proxy
     return received_data
 
 
+def client_wire_bytes(payload):
+    """Capture what a negotiating fteproxy client sends for ``payload``.
+
+    Returns ``(negotiation, data)``: the negotiation record and the first data
+    record, built in-process with the default key and record-layer mode, which
+    are what a server process started without ``--key`` or
+    ``--record-layer-mode`` runs with.
+    """
+    import fteproxy
+    import fteproxy.conf
+    import fteproxy.defs
+
+    class Capture:
+        def __init__(self):
+            self.sent = []
+
+        def send(self, data):
+            self.sent.append(data)
+            return len(data)
+
+        def sendall(self, data):
+            self.sent.append(data)
+
+    mode_key = 'runtime.fteproxy.record_layer.mode'
+    prev_mode = fteproxy.conf.getValue(mode_key)
+    fteproxy.conf.setValue(mode_key, 'hybrid')
+    try:
+        fteproxy.defs.load_definitions()
+        up = fteproxy.conf.getValue('runtime.state.upstream_language')
+        down = fteproxy.conf.getValue('runtime.state.downstream_language')
+        sock = Capture()
+        client = fteproxy.wrap_socket(
+            sock,
+            outgoing_regex=fteproxy.defs.getRegex(up),
+            outgoing_length=fteproxy.defs.getLength(up),
+            incoming_regex=fteproxy.defs.getRegex(down),
+            incoming_length=fteproxy.defs.getLength(down))
+        client.send(payload)
+    finally:
+        fteproxy.conf.setValue(mode_key, prev_mode)
+    negotiation, data = sock.sent
+    return negotiation, data
+
+
+def send_raw_to_server(wire, server_port=SERVER_PORT, proxy_port=PROXY_PORT):
+    """Send ``wire`` verbatim to the fteproxy server port, half-close, and
+    return every byte the destination on ``proxy_port`` received before EOF.
+
+    Bypasses the fteproxy client entirely, so the caller controls the exact
+    record sequence the server sees.
+    """
+    received = b''
+    dest_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    dest_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    dest_server.bind((BIND_IP, proxy_port))
+    dest_server.listen(1)
+    dest_server.settimeout(DATA_TIMEOUT)
+
+    raw = None
+    proxy_conn = None
+    try:
+        raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw.connect((BIND_IP, server_port))
+        raw.settimeout(DATA_TIMEOUT)
+
+        # The server dials the destination as soon as it accepts.
+        proxy_conn, _ = dest_server.accept()
+        proxy_conn.settimeout(DATA_TIMEOUT)
+
+        raw.sendall(wire)
+        # EOF on the covert side: the server relays whatever decoded, then
+        # closes the destination side, which ends the loop below.
+        raw.shutdown(socket.SHUT_WR)
+
+        while True:
+            chunk = proxy_conn.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+        return received
+    finally:
+        for sock in (raw, proxy_conn, dest_server):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+
 class TestSystemEndToEnd:
     """End-to-end system tests with actual client/server processes."""
 
@@ -220,6 +309,38 @@ class TestSystemEndToEnd:
             received_data = transfer_through_proxy(test_data)
             assert received_data == test_data, f"Connection {i} failed"
             time.sleep(0.5)  # Brief pause between connections
+
+    def test_duplicated_negotiation_record_delivers_nothing(self, fteproxy_server):
+        """A replayed negotiation record must not reach the destination.
+
+        Sends captured client wire bytes straight to the server port. The
+        control stream ``[nego][data0]`` delivers the payload. With the
+        negotiation record duplicated, ``[nego][nego][data0]``, the server
+        accepts the first cell and the duplicate is then out of its stream
+        position, so the destination must see no bytes at all before EOF: not
+        the cell's plaintext (which a server that restarted its sequence
+        counter after negotiation relayed as application data) and not
+        ``data0``.
+        """
+        payload = b'Hello, fteproxy!'
+        negotiation, data = client_wire_bytes(payload)
+
+        # Control first; it also absorbs a still-settling server, as
+        # transfer_through_proxy does.
+        control = b''
+        for attempt in range(3):
+            try:
+                control = send_raw_to_server(negotiation + data)
+            except (socket.timeout, OSError):
+                control = b''
+            if control == payload:
+                break
+            time.sleep(1)
+        assert control == payload, f"control stream failed: {control!r}"
+
+        delivered = send_raw_to_server(negotiation + negotiation + data)
+        assert delivered == b'', \
+            f"duplicated negotiation record leaked {delivered!r} to the destination"
 
 
 class TestCLI:


### PR DESCRIPTION
## What

The negotiation record now occupies position 0 of the client-to-server stream on both sides, so a duplicated or replayed negotiation record is rejected like any other record instead of being delivered as application data.

- `makeClientNegotiationCell` takes the encoder the socket keeps (instead of building a throw-away one), so the cell is sealed at seq 0 and the first data record at seq 1.
- `_acceptNegotiation` returns the scan decoder itself (already at seq 1, holding the bytes that followed the cell) and `doServerSideNegotiation` keeps it as the data decoder, building only the response encoder.
- SECURITY.md and the `record_layer` docstring say the in-stream ordering guarantee covers the negotiation record.

## Why

SECURITY.md says every record carries its position in its stream, so a replayed or duplicated record fails. The negotiation record was exempt by accident: the client encoded it with a second, throw-away encoder (seq 0) and then sent its first data record at seq 0 too; the server decoded the cell with a scan decoder at seq 0 and then created a fresh decoder at seq 0 for the data.

Verified on master by sending the captured wire bytes `[nego][nego][data0]` straight to the server port: the destination received the second cell's plaintext (`b"\x00"*45 + b"20260110manual-http"`, 64 bytes) as application data before the stream stalled at the real `data0`. Cross-stream replay remains the separately documented limitation.

## Reviewer notes

- **Wire change, no upgrade note.** A fixed client cannot talk to an unfixed server or vice versa. There is no `v0.4.0` tag and PyPI's latest release is 0.3.2, so this lands inside the 0.4.0 wire format. If 0.4.0 is published before this merges, the README "Upgrading to 0.4.0" section needs a line saying the two builds cannot negotiate with each other.
- The server keeps the decoder for whichever request format the cell actually unsealed under, rather than rebuilding one from the language named inside the cell. Those are the same format in every case except a MAC forgery, and the cell's named language still selects the response format as before.
- `makeClientNegotiationCell`'s signature changed (it now takes an encoder). It has no callers outside `fteproxy/__init__.py`.

## Tests

- `TestNegotiationRecordReplay` in `test_socket_wrapper.py`, parametrized over hybrid and format modes: data starts at seq 1 on the wire, the server continues the stream after negotiation (single and split reads), and `[nego][nego][data0]` delivers nothing and leaves the decoder stuck at the replay.
- `test_duplicated_negotiation_record_delivers_nothing` in `test_system.py`: sends captured client wire bytes to a real server process. The control stream `[nego][data0]` delivers the payload; the duplicated stream delivers zero bytes to the destination before EOF.
- All seven fail on the previous code (the system test fails with the exact 64-byte leak) and pass with the fix.
- `.venv/bin/python -m pytest fteproxy/tests/ -q`: 113 passed in 31 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
