### PR TITLE
Relay: forward TCP half-close instead of tearing the connection down

### DIFF
--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -493,6 +493,14 @@ class _FTESocketWrapper(FTEHelper, object):
         return self._socket.settimeout(val)
 
     def shutdown(self, flags):
+        if flags in (socket.SHUT_WR, socket.SHUT_RDWR):
+            # Negotiation is in-band: the client's negotiation cell goes out
+            # with its first send (or recv). Half-closing before either has
+            # happened would FIN an un-negotiated stream, which the server
+            # reports as a dead peer, so flush the cell ahead of the FIN.
+            to_send = self._processSend()
+            if to_send:
+                self._socket.sendall(to_send)
         return self._socket.shutdown(flags)
 
     def close(self):

--- a/fteproxy/relay.py
+++ b/fteproxy/relay.py
@@ -11,45 +11,115 @@ import fteproxy.conf
 import fteproxy.network_io
 
 
-class worker(threading.Thread):
+class _link(object):
 
-    """``fteproxy.relay.worker`` is responsible for relaying data between two sockets. Given ``socket1`` and
-    ``socket2``, the worker will forward all data
-    from ``socket1`` to ``socket2``, and ``socket2`` to ``socket1``. This class is a subclass of
-    threading.Thread and does not start relaying until start() is called. The run
-    method terminates when either ``socket1`` or ``socket2`` is detected to be closed.
+    """The state shared by the two ``worker`` threads that relay one
+    connection, one per direction. It counts the directions still open and
+    closes both sockets exactly once, so a half-close in one direction leaves
+    the other relaying and an error in either tears the whole connection down.
     """
 
-    def __init__(self, socket1, socket2):
+    def __init__(self, socket1, socket2, directions=2):
+        self._sockets = (socket1, socket2)
+        self._lock = threading.Lock()
+        self._open_directions = directions
+        self._closed = False
+
+    def direction_done(self):
+        """Record that one direction reached EOF. Returns ``True`` once every
+        direction has, i.e. when the connection can be closed.
+        """
+        with self._lock:
+            self._open_directions -= 1
+            return self._open_directions <= 0
+
+    def close(self):
+        """Close both sockets. Safe to call from both workers."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        for sock in self._sockets:
+            fteproxy.network_io.close_socket(sock)
+
+
+class worker(threading.Thread):
+
+    """``fteproxy.relay.worker`` is responsible for relaying data from
+    ``socket1`` to ``socket2``. A connection is relayed by two workers, one per
+    direction, created together with ``worker.pair`` so they share one
+    ``_link``. This class is a subclass of threading.Thread and does not start
+    relaying until start() is called.
+
+    When ``socket1`` reports EOF the worker forwards the half-close with
+    ``socket2.shutdown(SHUT_WR)`` and terminates, but the sockets stay open
+    while the sibling worker still relays the other direction; TCP half-close
+    (``shutdown(SHUT_WR)``, ``echo x | nc``, HTTP/1.0-style request/response)
+    therefore works through the relay. Both sockets are closed once both
+    directions have seen EOF, or as soon as either worker fails.
+
+    A worker constructed on its own (without ``pair``) owns the connection
+    alone and closes both sockets as soon as ``socket1`` reports EOF.
+    """
+
+    def __init__(self, socket1, socket2, link=None):
         threading.Thread.__init__(self)
         self._socket1 = socket1
         self._socket2 = socket2
+        if link is None:
+            link = _link(socket1, socket2, directions=1)
+        self._link = link
         self._running = False
+
+    @classmethod
+    def pair(cls, socket1, socket2):
+        """Return the two workers that relay one connection in both
+        directions, sharing the state that decides when it is closed.
+        """
+        link = _link(socket1, socket2)
+        return [cls(socket1, socket2, link), cls(socket2, socket1, link)]
 
     def run(self):
         """It's the responsibility of run to forward data from ``socket1`` to
-        ``socket2`` and from ``socket2`` to ``socket1``. The ``run()`` method
-        terminates and closes both sockets if ``fteproxy.network_io.recvall_from_socket``
-        returns a negative result for ``success``.
+        ``socket2``. When ``fteproxy.network_io.recvall_from_socket`` reports
+        that ``socket1`` is no longer alive, ``run()`` half-closes ``socket2``
+        and terminates; the sockets are closed once the sibling worker (if
+        any) has finished too. Any other failure closes both sockets at once.
         """
-        
+
         self._running = True
+        teardown = True
         try:
             throttle = fteproxy.conf.getValue('runtime.fteproxy.relay.throttle')
             while self._running:
                 [success, _data] = fteproxy.network_io.recvall_from_socket(
                     self._socket1)
                 if not success:
+                    # Every byte read before EOF has already been handed to
+                    # socket2, so the FIN lands after the data. The sibling
+                    # keeps relaying socket2 -> socket1 until it sees EOF too.
+                    self._half_close()
+                    teardown = self._link.direction_done()
                     break
                 if _data:
                     fteproxy.network_io.sendall_to_socket(self._socket2, _data)
                 else:
                     time.sleep(throttle)
         except Exception as e:
+            teardown = True
             fteproxy.warn("fteproxy.worker terminated prematurely: " + str(e))
         finally:
-            fteproxy.network_io.close_socket(self._socket1)
-            fteproxy.network_io.close_socket(self._socket2)
+            if teardown:
+                self._link.close()
+
+    def _half_close(self):
+        """Tell ``socket2``'s peer that this direction has no more data."""
+        try:
+            self._socket2.shutdown(socket.SHUT_WR)
+        except OSError:
+            # Already closed or reset; the sibling worker finds that out on
+            # its own the next time it touches the socket.
+            pass
 
     def stop(self):
         """Terminate the thread and stop listening on ``local_ip:local_port``.
@@ -119,8 +189,7 @@ class listener(threading.Thread):
                 new_stream.settimeout(
                     fteproxy.conf.getValue('runtime.fteproxy.relay.socket_timeout'))
 
-                w1 = worker(conn, new_stream)
-                w2 = worker(new_stream, conn)
+                w1, w2 = worker.pair(conn, new_stream)
                 w1.start()
                 w2.start()
             except socket.timeout:

--- a/fteproxy/tests/test_relay.py
+++ b/fteproxy/tests/test_relay.py
@@ -113,3 +113,187 @@ class TestRelay:
                 fteproxy.network_io.close_socket(client_socket)
 
         assert expected_msg == actual_msg
+
+
+def _read_until_eof(sock, timeout=10):
+    """Read from ``sock`` until the peer's EOF; fail instead of hanging."""
+    deadline = time.time() + timeout
+    received = b''
+    sock.settimeout(1)
+    while True:
+        if time.time() > deadline:
+            pytest.fail("no EOF within %ss; received %r" % (timeout, received))
+        try:
+            chunk = sock.recv(4096)
+        except socket.timeout:
+            continue
+        if not chunk:
+            return received
+        received += chunk
+
+
+class TestWorkerHalfClose:
+    """``relay.worker`` forwards a TCP half-close instead of tearing the
+    connection down (plain sockets, no FTE layer).
+
+    Regression test: a worker used to close BOTH sockets as soon as its own
+    read side reported EOF, so an application that sent a request and
+    ``shutdown(SHUT_WR)`` never got the reply flowing the other way.
+    """
+
+    def _relay(self):
+        app, conn = socket.socketpair()
+        new_stream, dest = socket.socketpair()
+        for s in (conn, new_stream):
+            s.settimeout(fteproxy.conf.getValue('runtime.fteproxy.relay.socket_timeout'))
+        w1, w2 = fteproxy.relay.worker.pair(conn, new_stream)
+        w1.start()
+        w2.start()
+        return app, dest, conn, new_stream, w1, w2
+
+    def test_half_close_keeps_reverse_direction_open(self):
+        app, dest, conn, new_stream, w1, w2 = self._relay()
+        try:
+            app.sendall(b'request-body')
+            app.shutdown(socket.SHUT_WR)
+
+            # The half-close arrives after every byte sent before it.
+            assert _read_until_eof(dest) == b'request-body'
+
+            # The reverse direction is still relaying.
+            dest.sendall(b'REPLY-TO:request-body')
+            dest.close()
+            assert _read_until_eof(app) == b'REPLY-TO:request-body'
+
+            # Now both directions are done: the workers exit and the relay
+            # sockets are closed.
+            w1.join(5)
+            w2.join(5)
+            assert not w1.is_alive() and not w2.is_alive()
+            assert conn.fileno() == -1 and new_stream.fileno() == -1
+        finally:
+            for s in (app, dest, conn, new_stream):
+                fteproxy.network_io.close_socket(s)
+
+    def test_error_closes_both_directions(self):
+        class _BrokenSend:
+            """socket2 stand-in whose sendall fails, like a peer that reset."""
+
+            def __init__(self, sock):
+                self._sock = sock
+
+            def sendall(self, data):
+                raise OSError('simulated send failure')
+
+            def __getattr__(self, name):
+                return getattr(self._sock, name)
+
+        app, conn = socket.socketpair()
+        new_stream, dest = socket.socketpair()
+        conn.settimeout(1)
+        new_stream.settimeout(1)
+        w1, w2 = fteproxy.relay.worker.pair(conn, _BrokenSend(new_stream))
+        w1.start()
+        w2.start()
+        try:
+            # The forward direction fails while the reverse one is idle: the
+            # failure must close the whole connection, both peers see EOF.
+            app.sendall(b'request-body')
+            assert _read_until_eof(app) == b''
+            assert _read_until_eof(dest) == b''
+            w1.join(5)
+            w2.join(5)
+            assert not w1.is_alive() and not w2.is_alive()
+            assert conn.fileno() == -1 and new_stream.fileno() == -1
+        finally:
+            for s in (app, dest, conn, new_stream):
+                fteproxy.network_io.close_socket(s)
+
+    def test_lone_worker_closes_both_on_eof(self):
+        """A worker without a sibling still owns the connection alone."""
+        app, conn = socket.socketpair()
+        new_stream, dest = socket.socketpair()
+        conn.settimeout(1)
+        new_stream.settimeout(1)
+        w = fteproxy.relay.worker(conn, new_stream)
+        w.start()
+        try:
+            app.sendall(b'one-way')
+            app.shutdown(socket.SHUT_WR)
+            assert _read_until_eof(dest) == b'one-way'
+            w.join(5)
+            assert not w.is_alive()
+            assert conn.fileno() == -1 and new_stream.fileno() == -1
+        finally:
+            for s in (app, dest, conn, new_stream):
+                fteproxy.network_io.close_socket(s)
+
+
+class TestRelayHalfClose:
+    """A request/response exchange that relies on TCP half-close works through
+    a real fteproxy client/server pair (``echo x | nc host port``, HTTP/1.0).
+    """
+
+    def test_half_close_round_trip(self, relay_setup):
+        request = b'request-body'
+        dest_listener = None
+        app = None
+        dest = None
+        try:
+            dest_listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            dest_listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            dest_listener.bind((LOCAL_INTERFACE, fteproxy.conf.getValue('runtime.proxy.port')))
+            dest_listener.listen(fteproxy.conf.getValue('runtime.fteproxy.relay.backlog'))
+            dest_listener.settimeout(10)
+
+            app = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            app.connect((LOCAL_INTERFACE, fteproxy.conf.getValue('runtime.client.port')))
+
+            dest, _ = dest_listener.accept()
+
+            # The application sends its request and half-closes, then waits
+            # for the reply; the destination reads to EOF before answering.
+            app.sendall(request)
+            app.shutdown(socket.SHUT_WR)
+
+            assert _read_until_eof(dest) == request
+            dest.sendall(b'REPLY-TO:' + request)
+            dest.close()
+
+            assert _read_until_eof(app) == b'REPLY-TO:' + request
+        finally:
+            for s in (app, dest, dest_listener):
+                if s is not None:
+                    fteproxy.network_io.close_socket(s)
+
+    def test_half_close_without_data(self, relay_setup):
+        """A half-close before any payload (``nc host port < /dev/null``) still
+        reaches the destination: the negotiation cell is flushed ahead of the
+        FIN, so the server side sees a live, negotiated stream.
+        """
+        dest_listener = None
+        app = None
+        dest = None
+        try:
+            dest_listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            dest_listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            dest_listener.bind((LOCAL_INTERFACE, fteproxy.conf.getValue('runtime.proxy.port')))
+            dest_listener.listen(fteproxy.conf.getValue('runtime.fteproxy.relay.backlog'))
+            dest_listener.settimeout(10)
+
+            app = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            app.connect((LOCAL_INTERFACE, fteproxy.conf.getValue('runtime.client.port')))
+
+            dest, _ = dest_listener.accept()
+
+            app.shutdown(socket.SHUT_WR)
+
+            assert _read_until_eof(dest) == b''
+            dest.sendall(b'banner-after-eof')
+            dest.close()
+
+            assert _read_until_eof(app) == b'banner-after-eof'
+        finally:
+            for s in (app, dest, dest_listener):
+                if s is not None:
+                    fteproxy.network_io.close_socket(s)

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -146,3 +146,68 @@ class TestRecvEOF:
         wrapper = _wrap(fake)
         assert wrapper.recv(65536) == b'hello'
         assert wrapper.recv(65536) == b''
+
+
+class RecordingSocket(FakeSocket):
+    """A FakeSocket that records what was sent and how it was shut down."""
+
+    def __init__(self, chunks=()):
+        super().__init__(chunks)
+        self.sent = []
+        self.shutdowns = []
+
+    def send(self, data):
+        self.sent.append(bytes(data))
+        return len(data)
+
+    def sendall(self, data):
+        self.sent.append(bytes(data))
+
+    def shutdown(self, flags):
+        self.shutdowns.append(flags)
+
+
+class TestClientShutdownFlushesNegotiation:
+    """``shutdown(SHUT_WR)`` on a client wrapper that has not sent anything yet
+    must put the negotiation cell on the wire before the FIN.
+
+    The relay half-closes the upstream socket when the application half-closes
+    without sending; negotiation is in-band with the first send/recv, so
+    without this the server would see EOF on an un-negotiated stream.
+    """
+
+    def _client_wrap(self, fake):
+        regex, length = _regex_length()
+        return fteproxy.wrap_socket(
+            fake,
+            outgoing_regex=regex, outgoing_length=length,
+            incoming_regex=regex, incoming_length=length)
+
+    def test_shut_wr_sends_negotiation_cell_first(self):
+        import socket
+        fake = RecordingSocket()
+        sock = self._client_wrap(fake)
+        sock.shutdown(socket.SHUT_WR)
+        assert len(fake.sent) == 1, "negotiation cell was not flushed before FIN"
+        assert fake.shutdowns == [socket.SHUT_WR]
+        # Nothing more to negotiate on a later send: the cell goes out once.
+        sock.send(b'late')
+        assert len(fake.sent) == 2
+
+    def test_shut_rd_does_not_negotiate(self):
+        import socket
+        fake = RecordingSocket()
+        sock = self._client_wrap(fake)
+        sock.shutdown(socket.SHUT_RD)
+        assert fake.sent == []
+        assert fake.shutdowns == [socket.SHUT_RD]
+
+    def test_shut_wr_after_send_does_not_renegotiate(self):
+        import socket
+        fake = RecordingSocket()
+        sock = self._client_wrap(fake)
+        sock.send(b'request-body')
+        sent_before = len(fake.sent)
+        sock.shutdown(socket.SHUT_WR)
+        assert len(fake.sent) == sent_before
+        assert fake.shutdowns == [socket.SHUT_WR]


### PR DESCRIPTION
## What

`fteproxy.relay.worker` closed **both** sockets as soon as its own read side reported EOF. Since a connection is relayed by two workers (one per direction), a one-sided `shutdown(SHUT_WR)` from the application tore down the whole connection and the reply flowing the other way was lost. Reproduced on 0.4.0 (master 923aa67): an application that sends `request-body`, half-closes, and waits for `REPLY-TO:request-body` gets it over direct TCP but receives `b''` through fteproxy. This breaks `echo x | nc host port`, HTTP/1.0-style clients, and any request/response protocol that half-closes.

## Fix

- **`fteproxy/relay.py`**: the two workers of a connection share a per-connection `_link`, created via `worker.pair(conn, new_stream)`. On EOF a worker forwards the half-close with `socket2.shutdown(SHUT_WR)` and exits, so the FIN lands after every byte already forwarded. Both sockets are closed only when the second direction has also seen EOF, or immediately when either worker raises (unchanged error semantics). A worker constructed without `pair` keeps the old close-both-on-EOF behaviour. The `select` + `time.sleep(throttle)` poll loop is untouched (see the caveat in PERFORMANCE.md).
- **`fteproxy/__init__.py`**: `_FTESocketWrapper.shutdown` flushes the client's negotiation cell before a `SHUT_WR`/`SHUT_RDWR`. Negotiation is in-band with the first `send`/`recv`, so without this an application that half-closes without sending anything would FIN an un-negotiated stream, which the server reports as a dead peer.

## Tests

- `test_relay.py`: three worker-level tests on plain `socketpair`s (half-close keeps the reverse direction open; a send error closes everything; a lone worker still closes both), plus two end-to-end tests through in-process `fteproxy.client`/`fteproxy.server` listeners: the request/half-close/reply round trip, and a half-close with no payload followed by a reply.
- `test_socket_wrapper.py`: the client wrapper sends the negotiation cell exactly once ahead of `SHUT_WR`, and not for `SHUT_RD` or after a prior send.

`python -m pytest fteproxy/tests/ -q` run alone: 114 passed in 33 s. Also verified against real subprocess client/server pairs: before the fix the Python `SHUT_WR` client and `echo x | nc` both received `b''`; after, both get their `REPLY-TO:` response.

## Reviewer notes

- Side effect: the spurious `WARN: worker terminated prematurely: file descriptor cannot be a negative integer (-1)` on a peer that connects to the server and closes before negotiating is gone. Clean closes no longer pull a socket out from under the sibling's `select()`; that warning now only appears after a genuine worker error.
- `recvall_from_socket` folds socket errors into "not alive", so a connection reset on the read side looks like EOF to the worker and is forwarded as a half-close rather than an instant teardown. The sibling's next write to the dead socket fails and closes everything, and a peer that sees the FIN normally closes on its own.
- Pre-existing and out of scope: if the destination sends a banner before the client has sent anything, the server-side wrapper's `send` runs before negotiation and fails on the missing encoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
