### PR TITLE
Bound what the server buffers from peers that never authenticate

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,23 @@ first. This section covers what fteproxy adds on top of it.
   the first bytes as each known request format until one succeeds (the
   configured `--upstream-format` first). A failed attempt is rejected before
   the tag check when the bytes are not in the format, as in libfte; a full scan
-  over the built-in formats costs a few milliseconds of CPU.
+  over the built-in formats costs a few milliseconds of CPU. A peer that never
+  negotiates cannot make the server hold or scan more than one negotiation
+  record's worth of bytes: the longest request format's `length`, plus the
+  framed 64-byte cell in `hybrid` mode (1124 bytes with the built-in
+  definitions). Once more than that has arrived without a record decoding, the
+  server drops the bytes and closes the connection. (fteproxy 0.4.0 buffered
+  everything such a peer sent and rescanned all of it on every read, so one
+  connection sending 100 MB of garbage grew the process past 5 GB.)
+
+- **Fail-closed streams.** After negotiation, the first record that does not
+  authenticate (wrong key, corruption, replay, reorder, or a peer on the other
+  `--record-layer-mode`) ends the stream: the decoder drops its buffer, refuses
+  further input, and the connection is closed. Nothing after a bad record could
+  ever decode, since the sequence number cannot advance past it. Between reads
+  the decoder holds at most one incomplete record (`length` + 1 MiB + 28 bytes
+  in `hybrid` mode, `length` in `format` mode), so a connection's buffered
+  input is bounded whatever the peer sends.
 
 ## Reporting a Vulnerability
 

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -74,12 +74,14 @@ class _AEADBody:
     _NONCE = 12
     _TAG = 16
     _COUNTER = 16  # AES block: 12-byte nonce || 4-byte block counter
+    # Bytes a framed body (nonce || ciphertext || tag) adds to its plaintext.
+    framing_overhead = _NONCE + _TAG
     # Largest body a single record carries. Bounds memory and amortizes the one
     # formatted header per record over a large payload.
     max_plaintext_bytes = 2 ** 20
-    # Largest framed body (nonce || ciphertext || tag) a header may announce;
-    # the decoder refuses to buffer more than this for one record.
-    max_framed_bytes = max_plaintext_bytes + _NONCE + _TAG
+    # Largest framed body a header may announce; the decoder refuses to buffer
+    # more than this for one record.
+    max_framed_bytes = max_plaintext_bytes + framing_overhead
 
     def __init__(self, key):
         self._enc_key = hashlib.sha256(key + b'fteproxy/record-layer/body/enc/v3').digest()[:16]
@@ -219,6 +221,7 @@ class NegotiationManager(object):
         self._negotiationComplete = False
         self._K1 = K1
         self._K2 = K2
+        self._maxNegotiationBytes = None
 
     def _key(self):
         # libfte 0.4 requires an explicit 32-byte key; the old "key=None means
@@ -230,6 +233,27 @@ class NegotiationManager(object):
 
     def getNegotiationComplete(self):
         return self._negotiationComplete
+
+    def getMaxNegotiationBytes(self):
+        """The most bytes a client's negotiation record can occupy on the wire.
+
+        The record is one sealed covertext of the request format's fixed
+        ``length`` (the 64-byte cell fits in a single covertext of every
+        built-in format), followed in hybrid mode by the framed cell. Whatever
+        the client's format, its record therefore fits in this many bytes, so
+        a server only ever needs to scan, or keep, that much from a peer that
+        has not negotiated: once more has arrived without a record decoding,
+        the peer never will.
+        """
+        if self._maxNegotiationBytes is None:
+            languages = fteproxy.defs.load_definitions()
+            longest = max(fteproxy.defs.getLength(language)
+                          for language in languages
+                          if language.endswith('-request'))
+            if _hybrid_mode():
+                longest += NegotiateCell._CELL_SIZE + _AEADBody.framing_overhead
+            self._maxNegotiationBytes = longest
+        return self._maxNegotiationBytes
 
     def _acceptNegotiation(self, data):
 
@@ -331,17 +355,38 @@ class FTEHelper(object):
     def _processRecv(self, data):
         retval = data
         if self._isServer and not self._negotiationComplete:
+            limit = self._negotiation_manager.getMaxNegotiationBytes()
+            # A valid negotiation record fits in the first ``limit`` bytes, so
+            # only those are ever scanned or kept between reads: the per-read
+            # scan (a decoder per candidate format, each copying its input)
+            # and the buffer stay bounded whatever the peer sends, instead of
+            # growing with every byte an unauthenticated peer pushes.
+            buffered = self._preNegotiationBuffer_incoming + data
+            head, tail = buffered[:limit], buffered[limit:]
             try:
-                self._preNegotiationBuffer_incoming += data
-                [encoder, decoder] = self._negotiation_manager.doServerSideNegotiation(
-                    self._preNegotiationBuffer_incoming)
-                self._encoder = encoder
-                self._decoder = decoder
-                self._preNegotiationBuffer_incoming = b''
-                self._negotiationComplete = True
-                retval = b''
-            except Exception as e:
+                [encoder, decoder] = self._negotiation_manager.doServerSideNegotiation(head)
+            except NegotiationFailedException:
+                if tail:
+                    # More than a whole negotiation record has arrived and none
+                    # of it decoded as one: nothing later can, so drop the lot
+                    # and tell the caller to close.
+                    raise NegotiationFailedException(
+                        str(len(buffered)) + ' bytes arrived and none decoded '
+                        'as a negotiation record')
+                # A record may still be in flight; keep waiting for it.
+                self._preNegotiationBuffer_incoming = head
                 raise ChannelNotReadyException()
+            except Exception as e:
+                # The cell decoded but names a format this server cannot serve
+                # (a mismatched definitions release). Waiting cannot fix that.
+                raise NegotiationFailedException(str(e))
+            self._encoder = encoder
+            self._decoder = decoder
+            # Bytes past the record are the start of the negotiated stream.
+            decoder.push(tail)
+            self._preNegotiationBuffer_incoming = b''
+            self._negotiationComplete = True
+            retval = b''
 
         return retval
 
@@ -384,6 +429,10 @@ class _FTESocketWrapper(FTEHelper, object):
         self._incoming_buffer = b''
         self._preNegotiationBuffer_outgoing = b''
         self._preNegotiationBuffer_incoming = b''
+        # Set once the peer can never deliver another byte (negotiation refused
+        # or a record failed authentication); recv then reports EOF and reads
+        # nothing more from the socket.
+        self._failed = False
 
         if negotiate:
             # Standard relay mode: client sends negotiation cell, server waits for it
@@ -410,6 +459,11 @@ class _FTESocketWrapper(FTEHelper, object):
             return self._socket.getsockopt(level, optname)
         return self._socket.getsockopt(level, optname, buflen)
 
+    def _streamFailed(self):
+        """Whether this connection can never deliver another byte: the peer
+        failed to negotiate, or a record failed authentication after it."""
+        return self._failed or (self._negotiationComplete and self._decoder.failed)
+
     def recv(self, bufsize):
         # <HACK>
         # Required to deal with case when client attempts to recv
@@ -420,6 +474,11 @@ class _FTESocketWrapper(FTEHelper, object):
             numbytes = self._socket.send(to_send)
             assert numbytes == len(to_send)
         # </HACK>
+
+        if self._streamFailed():
+            # Report EOF without reading: whatever the peer sends now can never
+            # decode, and reading it would only buffer it.
+            return b''
 
         try:
             while True:
@@ -452,6 +511,15 @@ class _FTESocketWrapper(FTEHelper, object):
                         break
                     self._incoming_buffer += frag
 
+                if self._decoder.failed:
+                    # Deliver whatever decoded before the bad record; the next
+                    # recv reports EOF and the caller closes the connection.
+                    fteproxy.warn(
+                        'closing connection: a record failed authentication '
+                        '(wrong key, corrupted or replayed stream, or a peer on '
+                        'a different --record-layer-mode)')
+                    break
+
                 if self._incoming_buffer:
                     break
 
@@ -467,6 +535,15 @@ class _FTESocketWrapper(FTEHelper, object):
             self._incoming_buffer = b''
         except ChannelNotReadyException:
             raise socket.timeout
+        except NegotiationFailedException as e:
+            self._failed = True
+            self._preNegotiationBuffer_incoming = b''
+            fteproxy.warn(
+                'closing connection: negotiation failed: ' + str(e) + ' (check '
+                'that both endpoints share the key, --record-layer-mode, and '
+                'the same fteproxy/libfte line; or the peer is not an fteproxy '
+                'client)')
+            return b''
 
         return retval
     

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -23,6 +23,13 @@ so it reads as random format text and only unseals at stream position
 ``seq`` is the record's position in its stream, counted from 0 by each
 ``Encoder``/``Decoder`` pair, so a record moved, replayed, or dropped within
 a stream is rejected. See SECURITY.md for what is not covered.
+
+A stream fails closed: the first record that does not authenticate (or is
+malformed) marks the :class:`Decoder` as failed, which drops its buffer and
+refuses further input. Nothing later in the stream could ever decode, since
+the sequence number cannot advance past the bad record, so the connection
+should be closed. Between calls to :meth:`Decoder.pop` the decoder therefore
+never holds more than one incomplete record.
 """
 
 import os
@@ -32,6 +39,11 @@ import fte
 from cryptography.exceptions import InvalidTag
 
 import fteproxy.conf
+
+
+class StreamFailedError(Exception):
+    """Data was pushed into a :class:`Decoder` after one of its records
+    failed authentication. The stream cannot resume; close the connection."""
 
 
 # Length prefix inside a sealed (random-padded) covertext plaintext.
@@ -151,18 +163,49 @@ class Decoder:
         # the header covertext plus the ``body_len`` raw bytes the header carries.
         # Either way a trailing partial record stays buffered.
         self._frame_size = cipher.output_format.max_length
+        # The largest record this decoder can be asked to hold: one header
+        # covertext plus, in hybrid mode, the largest framed body a header may
+        # announce. After every ``pop`` the buffer is shorter than this: a
+        # complete record is consumed or fails the stream, so only an incomplete
+        # one stays buffered.
+        self.max_record_bytes = self._frame_size
+        if body_cipher is not None:
+            self.max_record_bytes += body_cipher.max_framed_bytes
         self._buffer = b''
         self._seq = 0
+        self._failed = False
         # Body length from a hybrid header that was decrypted and verified but
         # whose body had not fully arrived. While set, that header is the first
         # ``_frame_size`` bytes of ``_buffer`` (the buffer only grows).
         self._pending_body_len = None
 
+    @property
+    def failed(self):
+        """True once a record failed authentication. The decoder then holds
+        nothing, ``pop`` returns nothing, and ``push`` raises
+        :class:`StreamFailedError`."""
+        return self._failed
+
     def push(self, data):
         """Push data onto the FIFO buffer."""
+        if self._failed:
+            raise StreamFailedError(
+                "record layer stream failed at seq " + str(self._seq))
         if isinstance(data, str):
             data = data.encode('utf-8')
         self._buffer += data
+
+    def _fail(self, reason):
+        """Mark the stream failed and drop everything buffered. Once a record
+        at ``self._seq`` does not authenticate, no later bytes can: the
+        sequence number cannot advance, so keeping them would only let a peer
+        grow the buffer without bound."""
+        fteproxy.info(
+            "fteproxy.record_layer: " + reason + " at seq " + str(self._seq)
+            + "; stream failed")
+        self._failed = True
+        self._buffer = b''
+        self._pending_body_len = None
 
     def _decrypt(self, cipher, covertext):
         """Decrypt one covertext, mapping libfte errors to fteproxy semantics.
@@ -191,15 +234,23 @@ class Decoder:
             return None
 
     def pop(self, oneCell=False):
-        """Pop decrypted messages off the FIFO buffer, one record at a time."""
+        """Pop decrypted messages off the FIFO buffer, one record at a time.
+
+        Every complete record is consumed: decoded, or, if it does not
+        authenticate, the stream fails (see :attr:`failed`) and the buffer is
+        dropped. Messages decoded before the failure are still returned. With
+        ``oneCell`` the drain stops after the first decoded record and the
+        rest stays buffered (the negotiation path, whose input is capped).
+        """
 
         # Consume whole records from a local buffer and join the messages once at
         # the end; ``+= msg`` per record would be quadratic. ``self._buffer`` is
-        # written back once, and the offset never advances past a record that
-        # cannot (yet) be decoded, so the undecodable remainder is preserved.
+        # written back once, and the offset never advances past an incomplete
+        # record, so a partial tail is preserved for the next push.
         buffer = self._buffer
         messages = []
         offset = 0
+        failure = None
 
         while len(buffer) - offset >= self._frame_size:
             if self._body_cipher is not None and self._pending_body_len is not None:
@@ -212,16 +263,14 @@ class Decoder:
                 header = buffer[offset:offset + self._frame_size]
                 head = self._decrypt(self._cipher, header)
                 if head is None:
+                    failure = "header failed authentication"
                     break
                 head = _unseal(head, self._seq)
                 if head is None:
                     # Authenticated but not a sealed record at this stream
                     # position: a peer on a different mode, corruption, or a
-                    # record replayed, reordered, or dropped. Treat it as
-                    # undecodable.
-                    fteproxy.info(
-                        "fteproxy.record_layer: malformed or out-of-order sealed "
-                        "record at seq " + str(self._seq))
+                    # record replayed, reordered, or dropped.
+                    failure = "malformed or out-of-order sealed record"
                     break
 
                 if self._body_cipher is None:
@@ -237,17 +286,14 @@ class Decoder:
                 # header is authenticated, so a successful decrypt means we
                 # wrote it and the length is trustworthy.
                 if len(head) != _OVERFLOW_LEN.size:
-                    fteproxy.info(
-                        "fteproxy.record_layer: unexpected header width "
-                        + str(len(head)))
+                    failure = "unexpected header width " + str(len(head))
                     break
                 body_len = _OVERFLOW_LEN.unpack(head)[0]
                 if body_len > self._body_cipher.max_framed_bytes:
                     # The header authenticates, so only a key holder can send
                     # this, but never buffer up to 4 GiB on its say-so.
-                    fteproxy.info(
-                        "fteproxy.record_layer: body length " + str(body_len)
-                        + " exceeds the record limit")
+                    failure = ("body length " + str(body_len)
+                               + " exceeds the record limit")
                     break
 
             body_start = offset + self._frame_size
@@ -262,10 +308,8 @@ class Decoder:
                 msg = self._body_cipher.decrypt(body, self._seq)
             except InvalidTag:
                 # Wrong key, corruption, or a record out of its stream
-                # position (reorder/drop/replay). Stop draining.
-                fteproxy.info(
-                    "fteproxy.record_layer: body auth failed at seq "
-                    + str(self._seq))
+                # position (reorder/drop/replay).
+                failure = "body failed authentication"
                 break
             self._seq += 1
             messages.append(msg)
@@ -278,5 +322,8 @@ class Decoder:
             if oneCell:
                 break
 
-        self._buffer = buffer[offset:]
+        if failure is not None:
+            self._fail(failure)
+        else:
+            self._buffer = buffer[offset:]
         return b''.join(messages)

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -4,6 +4,7 @@
 Tests for the FTE record layer encoding/decoding.
 """
 
+import os
 import struct
 
 import pytest
@@ -245,15 +246,16 @@ class TestHybridRecordLayer:
         assert len(calls) == 2
 
     def test_oversized_body_length_is_rejected(self, capsys):
-        """A header announcing a body larger than any record can carry is
-        refused instead of buffering up to 4 GiB waiting for it."""
+        """A header announcing a body larger than any record can carry fails
+        the stream instead of buffering up to 4 GiB waiting for it."""
         encoder, decoder = self._pair()
         header = fteproxy.record_layer._seal(
             encoder._cipher, fteproxy.record_layer._OVERFLOW_LEN.pack(2 ** 32 - 1), 0)
         decoder.push(header + b'x' * 64)
         assert decoder.pop() == b''
         assert 'exceeds the record limit' in capsys.readouterr().out
-        assert len(decoder._buffer) == len(header) + 64
+        assert decoder.failed
+        assert decoder._buffer == b''
 
     def test_reordered_record_is_rejected(self):
         """A record moved out of its stream position fails the body auth."""
@@ -271,6 +273,7 @@ class TestHybridRecordLayer:
         d2 = self._pair()[1]
         d2.push(r1 + r0)
         assert d2.pop() == b''
+        assert d2.failed
 
 
 class TestFormatModeRecordLayer:
@@ -300,7 +303,8 @@ class TestFormatModeRecordLayer:
         replayed = self._pair()[1]
         replayed.push(r0 + r0)
         assert replayed.pop() == b'first'          # the replay is refused
-        assert replayed._buffer == r0
+        assert replayed.failed                      # and ends the stream
+        assert replayed._buffer == b''
 
     def test_multi_record_message_roundtrips(self):
         encoder, decoder = self._pair()
@@ -334,3 +338,102 @@ def test_seal_fills_covertext_with_random_not_padding():
     for path in (fmt_path, hyb_path):
         assert len(path) > 100        # the path fills the covertext capacity
         assert len(set(path)) > 15    # random-looking, not a single-char run
+
+
+def _mode_pair(mode, language='manual-http-request'):
+    """An encoder/decoder pair for ``mode`` ('hybrid' or 'format')."""
+    fteproxy.conf.setValue('runtime.mode', 'client')
+    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+    header = fteproxy._make_cipher(
+        fteproxy.defs.getRegex(language), fteproxy.defs.getLength(language), key)
+    body = fteproxy._make_body_cipher(key) if mode == 'hybrid' else None
+    return (fteproxy.record_layer.Encoder(cipher=header, body_cipher=body),
+            fteproxy.record_layer.Decoder(cipher=header, body_cipher=body))
+
+
+def _wire(encoder, payload):
+    encoder.push(payload)
+    return encoder.pop()
+
+
+@pytest.mark.parametrize('mode', ['hybrid', 'format'])
+class TestDecoderFailsClosed:
+    """A record that fails authentication ends the stream and frees its buffer.
+
+    Regression tests for a memory exhaustion: the decoder used to ``break`` on
+    a bad record and keep it (and everything pushed afterwards) buffered for as
+    long as the connection lived, so a peer holding a valid negotiation could
+    grow the server without bound by sending garbage.
+    """
+
+    def test_max_record_bytes(self, mode):
+        _, decoder = _mode_pair(mode)
+        length = fteproxy.defs.getLength('manual-http-request')
+        if mode == 'hybrid':
+            assert decoder.max_record_bytes == length + fteproxy._AEADBody.max_framed_bytes
+        else:
+            assert decoder.max_record_bytes == length
+
+    def test_garbage_fails_the_stream_and_refuses_more(self, mode):
+        _, decoder = _mode_pair(mode)
+        decoder.push(os.urandom(decoder._frame_size))
+        assert decoder.pop() == b''
+        assert decoder.failed
+        assert decoder._buffer == b''
+        with pytest.raises(fteproxy.record_layer.StreamFailedError):
+            decoder.push(b'anything')
+        assert decoder._buffer == b''
+        assert decoder.pop() == b''
+
+    def test_records_before_the_bad_one_are_delivered(self, mode):
+        encoder, decoder = _mode_pair(mode)
+        good = _wire(encoder, b'first')
+        bad = bytearray(_wire(encoder, b'second'))
+        bad[-1] ^= 0x01                      # hybrid: the body tag; format: the covertext
+        decoder.push(good + bytes(bad) + os.urandom(1000))
+        assert decoder.pop() == b'first'
+        assert decoder.failed
+        assert decoder._buffer == b''
+
+    def test_buffer_holds_less_than_one_record_between_pops(self, mode):
+        """Delivering a multi-record stream in arbitrary chunks never leaves
+        more than one incomplete record buffered after a pop."""
+        encoder, decoder = _mode_pair(mode)
+        # Hybrid records carry up to 1 MiB, so cross a few record boundaries;
+        # format records are a couple of hundred bytes, so a smaller stream
+        # already spans hundreds of them.
+        payload = os.urandom(2 * 2 ** 20 + 12345 if mode == 'hybrid' else 40000)
+        wire = _wire(encoder, payload)
+        out = b''
+        chunk = 100000 if mode == 'hybrid' else 1000
+        for i in range(0, len(wire), chunk):
+            decoder.push(wire[i:i + chunk])
+            out += decoder.pop()
+            assert len(decoder._buffer) < decoder.max_record_bytes
+        assert out == payload
+        assert decoder._buffer == b''
+
+    def test_garbage_stream_never_accumulates(self, mode):
+        """Random data is dropped at the first complete frame instead of being
+        kept while more arrives."""
+        _, decoder = _mode_pair(mode)
+        decoder.push(os.urandom(256 * 1024))
+        assert decoder.pop() == b''
+        assert decoder.failed
+        assert decoder._buffer == b''
+        with pytest.raises(fteproxy.record_layer.StreamFailedError):
+            decoder.push(os.urandom(256 * 1024))
+        assert decoder._buffer == b''
+
+
+def test_hybrid_body_tamper_fails_the_stream():
+    """A hybrid body whose ciphertext is altered fails its MAC and ends the
+    stream even though its header authenticated."""
+    encoder, decoder = _mode_pair('hybrid')
+    record = bytearray(_wire(encoder, b'Z' * 5000))
+    record[decoder._frame_size + 100] ^= 0x55
+    decoder.push(bytes(record))
+    assert decoder.pop() == b''
+    assert decoder.failed
+    assert decoder._buffer == b''
+    assert decoder._pending_body_len is None

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -5,8 +5,12 @@ Tests for _FTESocketWrapper.recv() connection-close (EOF) semantics.
 
 These exercise a gap in the existing suite: what recv() does when the peer
 closes the TCP connection while undecodable bytes remain buffered in the
-decoder (e.g. the peer was cut off part-way through a covertext cell).
+decoder (e.g. the peer was cut off part-way through a covertext cell), and
+what it does with a peer that keeps sending bytes that can never decode.
 """
+
+import os
+import socket
 
 import pytest
 
@@ -25,13 +29,13 @@ def _defs():
     fteproxy.defs.load_definitions()
 
 
-def _regex_length():
-    return (fteproxy.defs.getRegex(FORMAT), fteproxy.defs.getLength(FORMAT))
+def _regex_length(language=FORMAT):
+    return (fteproxy.defs.getRegex(language), fteproxy.defs.getLength(language))
 
 
-def _make_cell(payload):
+def _make_cell(payload, language=FORMAT):
     """Encode ``payload`` into one covertext record-layer cell."""
-    pattern, length = _regex_length()
+    pattern, length = _regex_length(language)
     key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
     header = fteproxy._make_cipher(pattern, length, key)
     # Build through _record_encoder so the cell matches the configured mode (the
@@ -39,6 +43,19 @@ def _make_cell(payload):
     encoder = fteproxy._record_encoder(header, key)
     encoder.push(payload)
     return encoder.pop()
+
+
+def _negotiation_record(language=FORMAT):
+    """The record an fteproxy client opens a ``language`` stream with."""
+    previous = fteproxy.conf.getValue('runtime.state.upstream_language')
+    fteproxy.conf.setValue('runtime.state.upstream_language', language)
+    try:
+        response = language[:-len('-request')] + '-response'
+        manager = fteproxy.NegotiationManager(None, None)
+        return manager.makeClientNegotiationCell(
+            *_regex_length(language), *_regex_length(response))
+    finally:
+        fteproxy.conf.setValue('runtime.state.upstream_language', previous)
 
 
 class FakeSocket:
@@ -103,7 +120,6 @@ class TestServerNegotiationEOF:
         assert fake.eof_reads == 1
 
     def test_garbage_then_close_returns_eof(self):
-        import socket
         fake = FakeSocket([b'not a negotiation cell'])
         wrapper = self._server_wrap(fake)
         with pytest.raises(socket.timeout):  # cell incomplete: keep waiting
@@ -146,3 +162,151 @@ class TestRecvEOF:
         wrapper = _wrap(fake)
         assert wrapper.recv(65536) == b'hello'
         assert wrapper.recv(65536) == b''
+
+
+class TestServerNegotiationCap:
+    """A peer that never negotiates cannot make the server hoard its bytes.
+
+    Regression tests for a memory exhaustion: the server used to append every
+    byte an unauthenticated peer sent to its pre-negotiation buffer and rescan
+    the whole buffer against every request format on each read, so one
+    connection sending 100 MB of garbage grew the process past 5 GB. Only the
+    first negotiation-record's worth of bytes can ever decode, so that is all
+    the wrapper keeps or scans, and past it the peer is refused.
+    """
+
+    def _server_wrap(self, fake):
+        return fteproxy.wrap_socket(fake)  # no formats given: server role
+
+    def _cap(self, wrapper):
+        return wrapper._negotiation_manager.getMaxNegotiationBytes()
+
+    def test_cap_is_the_longest_negotiation_record(self):
+        """The bound is exactly the record of the longest built-in request
+        format ('binary-request', 1032 bytes), so nothing valid is refused."""
+        cap = self._cap(self._server_wrap(FakeSocket([])))
+        assert cap == len(_negotiation_record('binary-request'))
+        assert cap >= len(_negotiation_record(FORMAT))
+
+    def test_garbage_past_the_cap_returns_eof_and_stops_reading(self, capsys):
+        small = [os.urandom(200) for _ in range(20)]
+        big = [os.urandom(256 * 1024) for _ in range(4)]
+        fake = FakeSocket(small + big)
+        wrapper = self._server_wrap(fake)
+        cap = self._cap(wrapper)
+
+        waits = 0
+        while True:
+            try:
+                out = wrapper.recv(2 ** 18)
+                break
+            except socket.timeout:              # a record may still be coming
+                waits += 1
+                assert len(wrapper._preNegotiationBuffer_incoming) <= cap
+        assert out == b''
+        assert 'closing connection: negotiation failed' in capsys.readouterr().out
+
+        # It gave up on the first read that took it past one record's worth...
+        consumed = sum(map(len, small + big)) - sum(map(len, fake._chunks))
+        assert cap < consumed <= cap + 200
+        assert waits == consumed // 200 - 1
+        assert wrapper._preNegotiationBuffer_incoming == b''
+        # ...and reads nothing more from the socket afterwards.
+        assert wrapper.recv(2 ** 18) == b''
+        assert len(fake._chunks) == len(small + big) - consumed // 200
+        assert fake.eof_reads == 0
+
+    def test_one_large_garbage_read_returns_eof(self):
+        """The relay reads 256 KiB at a time; a single such read of garbage is
+        refused outright rather than buffered."""
+        fake = FakeSocket([os.urandom(256 * 1024)] * 3)
+        wrapper = self._server_wrap(fake)
+        assert wrapper.recv(2 ** 18) == b''
+        assert wrapper._preNegotiationBuffer_incoming == b''
+        assert len(fake._chunks) == 2
+
+    def test_record_filling_the_cap_still_negotiates(self):
+        """The cap is exact: a negotiation record of the longest format is
+        exactly cap bytes and, arriving a byte short and then complete, is
+        accepted rather than refused."""
+        language = 'binary-request'
+        cell = _negotiation_record(language)
+        data = _make_cell(b'hello', language)
+        fake = FakeSocket([cell[:-1], cell[-1:], data])
+        wrapper = self._server_wrap(fake)
+        assert len(cell) == self._cap(wrapper)
+
+        with pytest.raises(socket.timeout):     # one byte short of a record
+            wrapper.recv(2 ** 18)
+        assert len(wrapper._preNegotiationBuffer_incoming) == len(cell) - 1
+        assert wrapper.recv(2 ** 18) == b'hello'
+        assert wrapper._negotiationComplete
+        assert fake.eof_reads == 0
+
+    def test_bytes_past_the_record_open_the_stream(self):
+        """Only the first cap bytes are scanned; data behind them in the same
+        read (and behind the record inside the scanned prefix) is fed to the
+        negotiated decoder, not lost."""
+        cell = _negotiation_record()
+        payload = os.urandom(3000)
+        data = _make_cell(payload)
+        fake = FakeSocket([cell + data])
+        wrapper = self._server_wrap(fake)
+        assert len(cell) + len(data) > self._cap(wrapper)
+        assert wrapper.recv(2 ** 18) == payload
+        assert wrapper._preNegotiationBuffer_incoming == b''
+
+    def test_garbage_after_negotiation_returns_eof(self):
+        """A replayed negotiation record followed by garbage is cut off at the
+        first frame that fails, instead of accumulating for the connection's
+        lifetime."""
+        fake = FakeSocket([_negotiation_record()] + [os.urandom(256 * 1024)] * 4)
+        wrapper = self._server_wrap(fake)
+        assert wrapper.recv(2 ** 18) == b''
+        assert wrapper._negotiationComplete
+        assert wrapper._decoder.failed
+        assert wrapper._decoder._buffer == b''
+        assert wrapper.recv(2 ** 18) == b''
+        assert len(fake._chunks) == 3               # nothing more was read
+        assert fake.eof_reads == 0
+
+
+class TestRecvAuthFailure:
+    """Once a record fails authentication, recv() reports EOF and the wrapper
+    reads nothing more: the decoder can never resume, so buffering later bytes
+    would only grow without bound."""
+
+    def test_bad_record_after_good_one(self, capsys):
+        good = _make_cell(b'hello')
+        bad = bytearray(_make_cell(b'world'))
+        bad[-1] ^= 0x01
+        fake = FakeSocket([good, bytes(bad), os.urandom(65536), os.urandom(65536)])
+        wrapper = _wrap(fake)
+        assert wrapper.recv(65536) == b'hello'
+        assert wrapper.recv(65536) == b''
+        assert 'a record failed authentication' in capsys.readouterr().out
+        assert wrapper._decoder.failed
+        assert wrapper._decoder._buffer == b''
+        assert wrapper.recv(65536) == b''
+        assert len(fake._chunks) == 2
+        assert fake.eof_reads == 0
+
+    def test_good_and_bad_in_one_read(self):
+        """What decoded before the bad record is delivered, then EOF."""
+        good = _make_cell(b'hello')
+        bad = bytearray(_make_cell(b'world'))
+        bad[-1] ^= 0x01
+        fake = FakeSocket([good + bytes(bad), os.urandom(65536)])
+        wrapper = _wrap(fake)
+        assert wrapper.recv(65536) == b'hello'
+        assert wrapper.recv(65536) == b''
+        assert len(fake._chunks) == 1
+        assert fake.eof_reads == 0
+
+    def test_garbage_stream_is_dropped_at_the_first_read(self):
+        chunks = [os.urandom(256 * 1024) for _ in range(4)]
+        fake = FakeSocket(list(chunks))
+        wrapper = _wrap(fake)
+        assert wrapper.recv(2 ** 18) == b''
+        assert wrapper._decoder._buffer == b''
+        assert len(fake._chunks) == 3


### PR DESCRIPTION
## Problem

Measured on macOS / Python 3.14 against 0.4.0 (master 923aa67): one TCP connection sending 100 MB of random bytes to the server port in 256 KiB chunks took the server from 36 MB to **5.9 GB RSS**, superlinearly (10 MB → 132 MB, 50 MB → 2.6 GB), and the memory was never released after the peer closed. A connection that sent a valid negotiation record and then 50 MB of garbage reached **2.8 GB**.

Two causes:

1. `FTEHelper._processRecv` appended every received chunk to `_preNegotiationBuffer_incoming` with no cap, and `NegotiationManager._acceptNegotiation` re-ran the full scan over the whole buffer on every read: a `Decoder` per request format, each `push` copying the entire buffer.
2. After negotiation, `record_layer.Decoder.pop` `break`-ed on a record that failed to decrypt, unseal, or MAC and left it (and everything pushed afterwards) in `_buffer` for as long as the connection lived.

## Fix

**Pre-negotiation cap.** Only the first negotiation record's worth of bytes can ever decode, so `NegotiationManager.getMaxNegotiationBytes()` computes that bound from the definitions: the longest request format's `length`, plus the framed 64-byte cell in hybrid mode (1124 bytes with the built-in definitions; the cell fits in one covertext of every built-in format). `_processRecv` scans and keeps only that prefix. Once more has arrived without a record decoding it raises `NegotiationFailedException`; `recv` warns, marks the wrapper failed, returns `b''` (EOF), and never reads the socket again. Bytes past the record in the same read are handed to the negotiated decoder. The quadratic concatenation is gone as a side effect, since the buffer never exceeds the cap. A cell that decodes but names a format the server cannot serve (mismatched definitions release) now also ends the connection instead of looping on `socket.timeout` until the peer gives up.

**Fail-closed decoder.** Any record that does not authenticate (bad header, unseal mismatch, wrong header width, oversized body length, body MAC failure) sets `Decoder.failed`, drops the buffer, and makes `push` raise `record_layer.StreamFailedError`. Nothing after a bad record can decode because the sequence number cannot advance, so the wrapper delivers what decoded before it and reports EOF on the next `recv`. After every `pop` the buffer holds less than one record; the bound is exposed as `Decoder.max_record_bytes` (`frame_size + body_cipher.max_framed_bytes` in hybrid mode, `frame_size` in format mode).

The wire format is unchanged. `SECURITY.md` describes both bounds under "Negotiation cost" and a new "Fail-closed streams" bullet.

## Verification

Re-measured end to end with a real server subprocess:

| Case | Before | After |
|---|---|---|
| 100 MB garbage, no negotiation | 5.9 GB RSS, never released | 35 MB, connection closed after the first read |
| Valid negotiation record + 50 MB garbage | 2.8 GB RSS | 36 MB, connection closed after the first read |

`python -m pytest fteproxy/tests/ -q` run alone: 126 passed.

New tests:
- `test_record_layer.py::TestDecoderFailsClosed` (both modes): garbage fails the stream and refuses more, records before the bad one are delivered, the buffer stays under one record across a chunked valid stream, a garbage stream never accumulates; plus a hybrid body-tamper test. Two existing tests that asserted the old keep-the-bad-bytes behavior were updated.
- `test_socket_wrapper.py::TestServerNegotiationCap`: the cap equals the longest built-in negotiation record (`binary-request`); garbage past the cap returns EOF with the buffer never exceeding the cap and no further socket reads; a record exactly filling the cap still negotiates (no off-by-one); data behind the record in the same read opens the stream; a replayed negotiation record followed by garbage is cut off at the first frame.
- `test_socket_wrapper.py::TestRecvAuthFailure`: EOF after a bad record, with what decoded before it delivered and nothing more read.

## Reviewer notes

- The unmerged seq-reset branch (`claude/optimistic-engelbart-521db8`) changes `makeClientNegotiationCell` and `_acceptNegotiation`; it will conflict with `_processRecv` here and with the `_negotiation_record()` test helper (which builds seq-0 data). The designs are compatible; only the helper needs "data starts at seq 1" once both land.
- Out of scope: a refused peer that then idles keeps its relay worker until the socket times out, since the wrapper reports EOF but does not shut the socket down itself. Each unauthenticated connection still costs two threads and an eager upstream connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
