### PR TITLE
Packaging: drop setup.py and requirements.txt for pyproject.toml alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 # Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  # Python dependencies (requirements.txt / setup.py / pyproject.toml)
+  # Python dependencies (pyproject.toml: dependencies + the test extra)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
+        pip install -e ".[test]"
 
     - name: Run unit tests
       run: |
@@ -60,8 +59,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
+        pip install -e ".[test]"
 
     - name: Run system tests (client/server)
       run: |
@@ -91,8 +89,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
+        pip install -e ".[test]"
 
     - name: Run example tests
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
-include LICENSE
-include README.md
-include PYPI_README.md
-include requirements.txt
-include fteproxy/defs/*.json
+# Packaging metadata lives in pyproject.toml. This file only exists because
+# setuptools has no pyproject.toml equivalent for sdist contents, and the one
+# thing the sdist needs beyond the defaults is the test suite: it is excluded
+# from the wheel (see [tool.setuptools.packages.find]) but downstream packagers
+# building from the sdist still want it. Everything else -- LICENSE, README.md,
+# PYPI_README.md, pyproject.toml, the package sources and fteproxy/defs/*.json
+# via [tool.setuptools.package-data] -- setuptools includes on its own.
 recursive-include fteproxy/tests *.py

--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ pip install fteproxy
 ```bash
 git clone https://github.com/kpdyer/fteproxy.git
 cd fteproxy
-pip install -r requirements.txt
-pip install -e .
+pip install -e ".[test]"
 ```
+
+The `[test]` extra adds `pytest` and `pytest-timeout`; drop it (`pip install -e .`)
+if you only want to run fteproxy. Every dependency, including that extra, is
+declared in `pyproject.toml` -- there is no `requirements.txt`.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-# >=77 for PEP 639 license metadata (license = "MIT" + license-files); that
-# also covers PEP 660 editable installs without a setup.py shim (>=64).
+# >=77 for PEP 639 license metadata (license = "MIT" + license-files). That
+# floor also clears >=64, the release where PEP 660 editable installs stopped
+# needing a setup.py shim -- which is why this repo no longer has one.
 requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
@@ -34,6 +35,16 @@ dependencies = [
     # The hybrid record body (AES-CTR + HMAC-SHA256). libfte 0.4 needs >=42
     # transitively, so that is the effective floor.
     "cryptography>=42.0",
+]
+
+[project.optional-dependencies]
+# Everything needed to run the test suite against a checkout:
+#     pip install -e ".[test]"
+# These live here rather than in a requirements.txt so there is one dependency
+# list to keep current, and so Dependabot's pip ecosystem sees them.
+test = [
+    "pytest>=9.1.1",
+    "pytest-timeout>=2.4.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-fte>=0.4.0,<0.5.0
-cryptography>=42.0
-pytest>=9.1.1
-pytest-timeout>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-# All project metadata lives in pyproject.toml (PEP 621). This shim only keeps
-# ``python setup.py ...`` invocations working; there is nothing to edit here.
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
## What

Removes the two packaging files that no longer carry anything pyproject.toml
doesn't already express.

- **`setup.py`** — a no-op `setup()` shim. All metadata already lived in
  pyproject.toml (PEP 621), and the declared `setuptools>=77` floor clears the
  `>=64` where PEP 660 editable installs stopped needing a shim.
- **`requirements.txt`** — duplicated the two runtime pins already in
  `[project] dependencies` and added the two test-only ones. Those move to a
  `test` extra, so there is one dependency list to keep current and Dependabot's
  pip ecosystem still sees the test pins.

CI (all three matrix jobs) and the README's from-source instructions replace
`pip install -r requirements.txt` + `pip install -e .` with a single
`pip install -e ".[test]"`. The Dependabot comment that named the deleted files
is updated.

## What stays, and why

`MANIFEST.in` remains, trimmed from six lines to one and commented. setuptools
has no pyproject.toml equivalent for sdist contents, and the sdist deliberately
ships the test suite that the wheel excludes — dropping the file silently
removes `fteproxy/tests/**` from the sdist. Everything else it used to list
(LICENSE, both READMEs, `fteproxy/defs/*.json` via `package-data`) setuptools
includes on its own; I verified that rather than assuming it.

If you'd rather have zero non-pyproject packaging files, the way there is
switching the build backend to hatchling, which expresses sdist includes in
pyproject.toml. That's a separate, larger call about release tooling, so I
didn't make it here.

## Verification

Built the dists before and after the change and diffed them:

- **Wheel** — file list byte-identical.
- **Sdist** — differs only by the two deleted files. Tests, defs JSON, LICENSE
  and both READMEs still present.
- `twine check` passes on both artifacts; wheel `METADATA` carries
  `Provides-Extra: test` with both pytest pins.
- `uv pip install --dry-run -e ".[test]"` resolves to exactly what
  requirements.txt used to provide (pytest 9.1.1, pytest-timeout 2.4.0) plus the
  runtime deps.
- Full suite passes locally on Python 3.14: unit, record layer, system, relay,
  examples — 50 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)