### PR TITLE
Plan + PR1: parser hygiene, exit statuses, logging, formats subcommand

### DIFF
--- a/docs/plan-0.4.md
+++ b/docs/plan-0.4.md
@@ -1,0 +1,508 @@
+# fteproxy 0.4: one-argument client, no-argument server
+
+Status: proposal, 2026-09-02. Target release: 0.4.0, which has not been cut yet
+(master carries the 0.4.0 preparation; the latest published release is 0.3.2).
+Wire format: not compatible with 0.3.x (see Decision D1). Nothing on master's
+current wire format has shipped, so there is nothing to preserve.
+
+This plan combines the CLI redesign with the protocol work it depends on. It
+is written to be implemented PR by PR, in order; each PR leaves `pytest`
+green. Sections 1 through 4 are the design. Section 5 is the PR sequence with
+file lists and acceptance checks. Section 6 lists the decisions that need a
+maintainer's sign-off before the corresponding PR starts.
+
+## 0. Why the CLI is long today, and what removes the reason
+
+The current command line is long because the operator must keep four things
+identical on both endpoints (key, upstream format, downstream format,
+record-layer mode) and because each role takes two `ip` + `port` pairs.
+
+The negotiation code already does most of the work to remove this:
+
+- The server accepts any format. It wraps incoming sockets with no format and
+  learns the format from the client's first record (`fteproxy/server.py`,
+  `NegotiationManager._acceptNegotiation`).
+- Formats are a pair by protocol. The client sends the base name and the
+  server appends `-request` and `-response` itself
+  (`NegotiationManager.doServerSideNegotiation`). Two flags expose a
+  combination the wire cannot carry.
+- Record-layer mode is the only setting not negotiated. It is a global read
+  from config on both sides (`fteproxy._hybrid_mode`).
+- The key is the only true shared secret, and it is static and shared by every
+  connection and both directions, which is the cross-stream replay limitation
+  documented in `SECURITY.md`.
+
+The plan therefore has three parts that only work together:
+
+1. A handshake that authenticates the server with a keypair and derives
+   per-connection keys, so the connection string carries a public key instead
+   of a shared secret and every other parameter is a client-side choice.
+2. In-band destinations, so the server needs no forward address and the client
+   can offer SOCKS5. This is what every comparable tool (shadowsocks, chisel,
+   wstunnel, hysteria, gost) does.
+3. A CLI with two subcommands and one connection string.
+
+Non-goals for 0.4.0: traffic shaping or padding policy, UDP, stream
+multiplexing, an asyncio rewrite of the relay, a config file, decoy responses
+to failed probes. The record layer's framing, sealing and hybrid body carrier
+stay as they are apart from a one-byte record type.
+
+## 1. Target user experience
+
+```
+# server, once per host (key is generated on first start)
+$ fteproxy server
+listening on [::]:8080
+key: ~/.local/state/fteproxy/server.key
+clients connect with:
+  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080
+(also written to ~/.local/state/fteproxy/connection.txt)
+
+# client
+$ fteproxy client fte://Qm3s…ZzE@203.0.113.5:8080
+checking 203.0.113.5:8080 … ok (protocol 1, manual-http, hybrid)
+SOCKS5 on 127.0.0.1:1080
+$ curl --socks5-hostname 127.0.0.1:1080 https://example.com/
+```
+
+Same host, no arguments at all: `fteproxy server` then `fteproxy client`. The
+client finds `connection.txt` in the state directory.
+
+Port forward instead of SOCKS, ssh syntax:
+
+```
+$ fteproxy client fte://… -L 2222:127.0.0.1:22
+```
+
+Wrong connection string, old client, or the server is not fteproxy:
+
+```
+$ fteproxy client fte://…
+checking 203.0.113.5:8080 … failed: no valid handshake reply within 5s
+  (wrong connection string, or the server is not running fteproxy 0.4)
+exit status 1
+```
+
+### 1.1 Command line
+
+```
+fteproxy server  [--listen [HOST]:PORT] [--allow RULE]... [--advertise HOST[:PORT]]
+                 [--state-dir DIR] [--defs RELEASE] [-q | -v]
+fteproxy client  [URI] [-D [BIND:]PORT] [-L [BIND:]PORT:HOST:PORT]...
+                 [--format NAME] [--mode hybrid|format] [--no-check]
+                 [--state-dir DIR] [-q | -v]
+fteproxy keygen  [--state-dir DIR] [--advertise HOST[:PORT]]
+fteproxy formats [--defs RELEASE]
+fteproxy --version
+```
+
+Rules:
+
+- All long flags use hyphens. Ports are integers, validated at parse time.
+- `HOST:PORT` everywhere. `:PORT` means all interfaces. IPv6 in brackets.
+  `--listen :8080` binds `::` dual-stack where the OS allows it and falls back
+  to `0.0.0.0`.
+- `server` defaults: listen `:8080`, allow policy per Decision D3, state
+  directory per 1.3, definitions release: newest shipped file.
+- `client` defaults: SOCKS5 on `127.0.0.1:1080` when neither `-D` nor `-L`
+  is given. `-D` is the ssh spelling of `--socks`. `--format manual-http`,
+  `--mode hybrid`, unless the URI says otherwise (flags beat the URI).
+- The URI may come from the argument, from `FTEPROXY_URI`, or from
+  `connection.txt` in the state directory, in that order. A missing URI is a
+  usage error with the three sources listed.
+- `keygen` creates `server.key` if absent and prints the connection string.
+  `server` does the same on first start, so `keygen` exists for provisioning
+  (containers, configuration management), not for the manual path.
+- `formats` lists every base name in the definitions file with its covertext
+  length and capacity, and marks the default.
+- A bare `fteproxy` prints usage and exits 2. Every flag of the current command line (`--mode`,
+  `--server_ip`, `--client_port`, `--proxy_ip`, `--key`, `--key-file`,
+  `--upstream-format`, `--downstream-format`, `--record-layer-mode`,
+  `--release`, `--stop`, `--quiet`) is recognised only to print one line
+  pointing at the upgrade section of the README and exit 2. No aliases: the
+  meaning changed (the destination is now chosen client-side), so a silent
+  alias would run a different topology than the operator asked for.
+- Exit status: 0 clean shutdown, 1 runtime failure, 2 usage.
+- Logs go to stderr through the `logging` module. Default level INFO, `-q`
+  ERROR, `-v` DEBUG. The licence banner is gone; `--version` prints it.
+- Nothing ever logs a key, a URI, or handshake material. The URI is redacted
+  to `fte://…@host:port` in every message.
+- `--stop` and the PID files are removed. The process runs in the foreground
+  and exits on SIGINT and SIGTERM.
+
+### 1.2 Connection string
+
+```
+fte://<server-id>@<host>:<port>[?format=<base>&mode=<hybrid|format>&defs=<YYYYMMDD>]
+```
+
+`server-id` is the server's X25519 public key, base64url without padding
+(43 characters). `host` is a name, an IPv4 address, or a bracketed IPv6
+address. Query parameters are hints the server operator recommends; the client
+applies them unless overridden by a flag. Unknown parameters are ignored so
+later versions can add some (a `pk2=` for a second key during rotation, for
+example).
+
+Treat the string like a Tor bridge line: whoever holds it can connect, and its
+secrecy is what stops an active prober from confirming the server. It does
+not let the holder impersonate the server or decrypt other clients' traffic
+(see 2.4).
+
+### 1.3 State directory
+
+Resolution order: `--state-dir`, `FTEPROXY_STATE_DIR`,
+`$XDG_STATE_HOME/fteproxy`, `~/.local/state/fteproxy`. Created with mode
+0700. Files:
+
+| File | Mode | Content |
+|---|---|---|
+| `server.key` | 0600 | 64 hex characters, the X25519 private key |
+| `connection.txt` | 0600 | the connection string, one line, `<server-ip>` placeholder unless `--advertise` was given |
+
+The replay filter (2.3) is in memory only.
+
+## 2. Protocol version 1
+
+### 2.1 Keys
+
+- `S` is the server's long-term X25519 keypair. `S_pub` is the server-id.
+- `K_cover = HKDF-SHA256(ikm=S_pub, salt=b"", info=b"fteproxy/v1/cover", 32)`.
+  Both handshake records are libfte covertexts sealed under `K_cover`. Anyone
+  holding the connection string can compute it, which is the intended
+  meaning: holding the string is what authorises a connection attempt.
+- Per connection: client ephemeral `c`, server ephemeral `s`.
+  `DH_ee = X25519(c, s_pub)`, `DH_es = X25519(c, S_pub)` on the client side
+  and the corresponding private-key computations on the server. Reject an
+  all-zero shared secret.
+- `H = SHA-256(b"fteproxy/v1" || S_pub || client_hello_plaintext || s_pub)`.
+- `PRK = HKDF-Extract(salt=H, ikm=DH_ee || DH_es)`.
+- `K_auth_s, K_c2s_hdr, K_c2s_body, K_s2c_hdr, K_s2c_body =`
+  `HKDF-Expand(PRK, info=b"fteproxy/v1/keys", 160)` split into five 32-byte
+  keys.
+
+This is the Noise `NK` message pattern (`e, es` then `e, ee`) expressed with
+`cryptography`'s X25519, HKDF and HMAC. It gives server authentication and
+forward secrecy. It does not authenticate the client beyond possession of the
+connection string, the same property obfs4 has. Decision D7 covers whether a
+Noise library is used instead; the recommendation is no, because the
+maintained options are thin and the pattern is thirty lines.
+
+### 2.2 Handshake records
+
+Both handshake records are sealed exactly as any record is today
+(`record_layer._seal`: `len || seq || message || random pad`), in `format`
+mode regardless of the mode being negotiated, so the server never has to guess
+the mode to read them. `seq` is 0 for the client hello and 0 for the server
+hello; the session's data records restart the count per direction (2.4).
+
+Client hello plaintext (sealed under `K_cover` in the `<base>-request`
+format):
+
+| Field | Size | Meaning |
+|---|---|---|
+| version | 1 | `0x01` |
+| flags | 1 | bit 0: mode, 0 hybrid, 1 format; other bits must be 0 |
+| defs | 4 | definitions release as an integer, e.g. `20260110` |
+| format length | 1 | length of the next field |
+| format | n | base name, ASCII, e.g. `manual-http` |
+| c_pub | 32 | client ephemeral public key |
+| epoch | 4 | hours since the Unix epoch, big-endian |
+
+Server hello plaintext (sealed under `K_cover` in the `<base>-response`
+format):
+
+| Field | Size | Meaning |
+|---|---|---|
+| version | 1 | `0x01` |
+| flags | 1 | echo of the accepted mode bit |
+| s_pub | 32 | server ephemeral public key |
+| mac | 16 | `HMAC-SHA256(K_auth_s, H)[:16]` |
+
+The server proves possession of `S` by producing `mac`, because `PRK`
+depends on `DH_es`. The server hello is the acknowledgement the current negotiation lacks: on receiving a valid one the client knows the key, format, mode and
+version all match, before any application byte is sent.
+
+Every shipped format must hold a client hello (about 75 bytes plus libfte's
+28-byte AE frame) in one covertext. PR2 adds a definitions-load check that
+fails on any format whose capacity is below 128 bytes, and adjusts `length`
+in the definitions file for any that fail.
+
+### 2.3 Server behaviour on the first record
+
+1. Buffer until at least the largest request-format covertext could be
+   present, then try to unseal the buffered bytes under `K_cover` with each
+   request format, most-recently-matched first. This replaces the configured
+   `--upstream-format` hint with an adaptive order and keeps the existing
+   cipher cache (one static key per server, so `_make_cipher` hits).
+2. Reject if: version unknown, reserved flag bits set, `defs` is not the
+   release the server serves, format unknown, epoch outside ±1 hour, or
+   `c_pub` seen within the window (replay filter keyed on `c_pub`, pruned by
+   epoch).
+3. On rejection: never reply. Read and discard for a random 1 to 5 seconds,
+   then close. Log one line at DEBUG. This is obfs4's behaviour and is what
+   stops an active prober learning anything from a bad guess.
+4. On success: derive keys, send the server hello, switch to session ciphers.
+
+### 2.4 Session records
+
+After the handshake, each direction has its own header key and body key and
+its own `seq` starting at 0. The FTE header cipher for a session is built as
+`fte.FTE(output_format=<cached RegexFormat>, key=K_dir_hdr)`: PR2 splits the
+current `_make_cipher` cache so that `RegexFormat` (the DFA, the expensive
+part) is cached by `(pattern, length)` and the `FTE` instance is built per
+session with the session key. The body carrier `_AEADBody` is built per
+session with `K_dir_body`. Per-connection keys close the cross-stream replay
+limitation in `SECURITY.md` and give forward secrecy.
+
+Record plaintext gains a leading type byte:
+
+| Type | Name | Payload |
+|---|---|---|
+| `0x00` | DATA | application bytes |
+| `0x01` | OPEN | destination, see 3.1 |
+| `0x02` | OPEN_RESULT | status, see 3.1 |
+| `0x03` | PADDING | ignored; reserved for future shaping |
+| `0x04` | CLOSE | no payload; the sender will send no more DATA |
+
+Unknown types close the connection. In `hybrid` mode the type byte is the
+first byte of the raw body; in `format` mode it is the first byte inside the
+sealed covertext. The sealed length and `seq` fields are unchanged, so the
+record layer's chunking, buffering and bounds logic is unchanged.
+
+Headers in `hybrid` mode are sealed under the session header key, so a
+connection-string holder can no longer forge a header for someone else's
+stream, which was the remaining gap when a cover key was considered for
+headers.
+
+### 2.5 What an observer sees
+
+Unchanged from the current record layer for data records. The two handshake records are one
+request-format covertext and one response-format covertext, the same shape as today's negotiation cell and its first reply. A prober without the connection
+string gets no bytes back.
+
+## 3. Streams and destinations
+
+### 3.1 OPEN and OPEN_RESULT
+
+OPEN payload, SOCKS5 address encoding so the client can pass a SOCKS request
+through without re-encoding:
+
+| Field | Size | Meaning |
+|---|---|---|
+| atyp | 1 | `0x01` IPv4, `0x03` domain name, `0x04` IPv6 |
+| addr | 4, 1+n, or 16 | address or length-prefixed name |
+| port | 2 | big-endian |
+
+OPEN_RESULT payload: one status byte using SOCKS5 reply codes (`0x00`
+succeeded, `0x01` general failure, `0x02` not allowed by ruleset, `0x03`
+network unreachable, `0x04` host unreachable, `0x05` connection refused,
+`0x06` TTL expired). The client maps it straight onto its SOCKS5 reply.
+
+OPEN is a relay-layer message. The library API (3.4) lets a program send DATA
+without ever sending OPEN, which is what the chat and echo examples do.
+
+### 3.2 Server
+
+The accept loop hands each connection to a setup thread immediately; today
+it dials the fixed destination inside the accept loop, so a slow `connect()`
+stalls every other client. The setup thread: handshake (2.3), read OPEN with
+the negotiation timeout, check the allow rules, dial with a 10-second timeout,
+send OPEN_RESULT, then start the two relay workers as today. Any failure after
+the handshake sends OPEN_RESULT with the matching status and closes.
+
+Allow rules, `--allow RULE`, repeatable:
+
+- `any`: everything.
+- `HOST[:PORT]`, `CIDR[:PORT]`, `*.example.com[:PORT]`: as written; a rule
+  without a port allows every port. Names are matched against the requested
+  name; a request by IP is matched against IP and CIDR rules only.
+- Default (Decision D3): all destinations except the server's loopback and
+  link-local ranges. `--allow 127.0.0.1:8081` opts a local service back in.
+
+The server resolves names itself, so a `-L` forward to `127.0.0.1:22` means
+port 22 on the server host, which is exactly what the current topology does with
+`--proxy_ip 127.0.0.1`.
+
+### 3.3 Client
+
+Two listener kinds, any number of each:
+
+- `-D [BIND:]PORT`: SOCKS5, RFC 1928, CONNECT only, no authentication
+  method, IPv4, IPv6 and domain address types. UDP ASSOCIATE and BIND return
+  `0x07` command not supported.
+- `-L [BIND:]PORT:HOST:PORT`: plain listener; every accepted connection opens
+  `HOST:PORT` through the tunnel.
+
+Per accepted connection: dial the server, handshake, send OPEN, wait for
+OPEN_RESULT, then (SOCKS only) send the SOCKS reply, then relay. Local bytes
+that arrive before OPEN_RESULT are buffered, bounded by the relay's existing
+receive buffer size.
+
+Startup check (Decision D5): unless `--no-check`, the client dials the server
+once, completes the handshake, and closes. Success prints one line with the
+protocol version, format and mode; failure prints the reason and exits 1. The
+check is one short connection that looks like any other session start.
+
+### 3.4 Library API
+
+`fteproxy.wrap_socket` keeps its name and gains a role from its keyword
+arguments; `K1`, `K2` and `negotiate` are removed.
+
+```python
+# server side
+sock = fteproxy.wrap_socket(conn, server_key=private_key_bytes)
+dest = sock.wait_open()            # (host, port) or None if the peer sent DATA first
+sock.open_result(0x00)
+
+# client side
+sock = fteproxy.wrap_socket(raw, server_id=public_key_bytes_or_str,
+                            format="manual-http", mode="hybrid")
+sock.open(("example.com", 443))     # raises fteproxy.OpenRefused(status) on failure
+```
+
+`fteproxy.generate_server_key()` returns `(private_bytes, public_bytes)`;
+`fteproxy.ConnectionString.parse(str)` and `.format()` round-trip the URI.
+Handshake and key-schedule code lives in a new `fteproxy/handshake.py`;
+stream messages and allow rules in `fteproxy/stream.py`; SOCKS5 in
+`fteproxy/socks.py`; URI and state directory in `fteproxy/config.py`.
+
+## 4. Documentation and security model
+
+- `README.md`: rewrite Usage around the two commands and the connection
+  string; replace the options table; rewrite "Upgrading to 0.4.0" to cover the wire break from 0.3.x, the new
+  command line, keys, the topology change, and `-L` for the old
+  fixed-destination setup. `PYPI_README.md` mirrors the quick start.
+- `SECURITY.md`: replace "The key" with the keypair and connection-string
+  model; delete the cross-stream replay limitation and "No protocol-version
+  handshake"; add: what the connection string authorises, replay window and
+  filter, behaviour on failed handshakes, the allow-rule default, and that
+  the handshake is Noise-NK-shaped and hand-assembled from `cryptography`
+  primitives with test vectors in the repository.
+- `examples/`: the shell scripts become two-line invocations; Python examples
+  use `generate_server_key` and the new `wrap_socket`; `examples/README.md`
+  and the per-directory READMEs updated. `benchmark.py` and
+  `fteproxy/tests/test_system.py` move to the new command line.
+
+## 5. PR sequence
+
+Each PR is independently mergeable and leaves the test suite green. Sizes:
+S under 300 lines changed, M under 800, L above.
+
+### PR1 (S): parser hygiene and the bugs found on the way
+
+No user-visible flag changes.
+
+- Replace the `setConfValue` argparse action with a plain parse followed by
+  one `apply_args_to_conf` step; `type=int` on ports; delete the dead
+  `--stop`/`--mode` guards.
+- Fix: no-argument run crashes with a `TypeError` and exits 0 (default mode
+  never reaches config because argparse does not run actions for defaults).
+- Fix: invalid format name and other startup failures exit 0.
+- Validate formats and key before printing anything or writing the PID file.
+- `logging` to stderr with `-q`/`-v`; `warn`/`info`/`fatal_error` become
+  thin wrappers; exit codes 0/1/2.
+- `fteproxy formats` subcommand (argparse subparsers introduced here, with the
+  existing flat interface kept as the default command).
+- Tests: `tests/test_cli.py` for parse and apply; system test for the
+  no-argument case and exit codes.
+
+Acceptance: `python -m fteproxy` prints usage and exits 2;
+`python -m fteproxy --mode client --upstream-format nope; echo $?` prints 1;
+`pytest` green.
+
+### PR2 (L): handshake, session keys, record types
+
+Wire break from 0.3.x; the version stays 0.4.0 because 0.4.0 has not been
+cut. Library level only.
+
+- `fteproxy/handshake.py`: key generation, `K_cover`, hello encode/decode,
+  key schedule, epoch, replay filter. Test vectors generated once and checked
+  in (`tests/vectors/handshake_v1.json`).
+- `fteproxy/__init__.py`: split the cipher cache into a `RegexFormat` cache
+  and per-session `FTE` construction; per-direction `_AEADBody`; record type
+  byte in `record_layer`; `NegotiationManager` replaced by the handshake
+  driver; `wrap_socket` new signature; `generate_server_key`.
+- Definitions-load capacity check (2.2); adjust any format that cannot hold
+  a hello.
+- Server-side first-record scan with most-recently-matched ordering and the
+  reject path (2.3).
+- Tests: vectors; tamper each field of each hello; replay within and outside
+  the window; epoch skew; wrong `S_pub`; each record type; both modes;
+  `benchmark.py` before/after for the per-session cipher construction cost
+  (target: connection setup within 1 ms of 0.4, bulk throughput unchanged).
+- Review gate: a security review of `handshake.py` and the key schedule by
+  someone other than the author before merge, as was done for #229.
+
+Acceptance: `pytest fteproxy/tests/test_handshake.py test_record_layer.py
+test_socket_wrapper.py`; a client speaking master's pre-plan negotiation against the new server produces no reply and one DEBUG log line.
+
+### PR3 (L): streams, SOCKS5, allow rules, relay rewrite
+
+- `fteproxy/stream.py`: OPEN/OPEN_RESULT encode/decode, allow rules, address
+  classification (loopback, link-local).
+- `fteproxy/socks.py`: RFC 1928 CONNECT server side for the client listener.
+- `fteproxy/relay.py`: per-connection setup thread on the server; listener
+  kinds on the client; OPEN before relay; half-close via CLOSE where the
+  local socket supports `shutdown(SHUT_WR)`; workers unchanged otherwise.
+- `fteproxy/server.py` and `client.py` collapse into the new relay roles.
+- Tests: allow-rule table; SOCKS5 conformance against a local echo server
+  including each failure reply; `-L` flow; OPEN to a refused port maps to
+  `0x05`; default policy blocks `127.0.0.1` and `--allow` re-enables it.
+
+Acceptance: end-to-end SOCKS transfer and `-L` transfer in
+`test_system.py` using the library API directly (the CLI lands in PR4).
+
+### PR4 (M): the command line
+
+- `fteproxy/config.py`: connection string parse/format, state directory,
+  `server.key` and `connection.txt` handling with the modes in 1.3.
+- `fteproxy/cli.py`: `server`, `client`, `keygen`, `formats` subparsers as
+  in 1.1; `HOST:PORT` and `-L` spec parsers with IPv6 brackets; dual-stack
+  bind; startup check; old-flag error; env vars; redaction filter on the
+  logger; signal handling; removal of PID files and `--stop`.
+- `benchmark.py` and `test_system.py` on the new command line.
+- Tests: URI round-trips including IPv6 and query hints; spec parsers;
+  state-directory permissions; old flags exit 2 with the pointer; startup
+  check pass and fail; no-argument client finds `connection.txt`.
+
+Acceptance: the transcript in section 1 works verbatim on one host, with the
+`curl` line pointed at a local HTTP server and `--allow 127.0.0.1:PORT` on
+the server.
+
+### PR5 (M): docs, examples, release
+
+- Section 4 in full. `__version__` stays `"0.4.0"`; PyPI metadata; the
+  `SECURITY.md` supported-versions table already lists 0.4.x.
+- `examples/` scripts and Python files; `test_examples.py`.
+- Release notes: wire break, command-line change, topology change, key
+  model, upgrade steps.
+
+Acceptance: `pytest` green including `test_examples.py`; README quick start
+executed by hand on two hosts.
+
+## 6. Decisions needed
+
+Each has a recommendation; the PR that depends on it is noted.
+
+- **D1 (PR2)** No compatibility path for the shared-key negotiation on master or for the 0.3.x wire format.
+  Recommended: yes. A compatibility mode would keep the shared-key path and
+  its public default key alive and double the first-record scan.
+- **D2 (PR2)** Remove shared-key operation entirely (`--key`, `--key-file`,
+  `negotiate=False`). Recommended: yes. One key model is easier to explain
+  and audit; the examples that used the symmetric mode move to the keypair.
+- **D3 (PR3)** Default destination policy: block the server's loopback and
+  link-local unless allowed. Recommended: yes. The alternative (allow all,
+  as shadowsocks does) exposes every local admin service to every holder of
+  the connection string.
+- **D4 (PR3)** Client default listener: SOCKS5 on `127.0.0.1:1080`.
+  Recommended: yes; matches shadowsocks, hysteria and wstunnel defaults.
+- **D5 (PR4)** Startup check on by default, `--no-check` to skip.
+  Recommended: yes. The cost is one short connection; the benefit is that a
+  bad connection string fails in one second with a reason instead of a
+  timeout on first use.
+- **D6 (PR4)** Scheme name `fte://`, base64url server-id, state directory
+  under `$XDG_STATE_HOME`. Recommended as written.
+- **D7 (PR2)** Hand-assemble the NK handshake from `cryptography` primitives
+  with checked-in vectors and an external review, rather than add a Noise
+  dependency. Recommended: yes; the candidate libraries are unmaintained and
+  the pattern is small.

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -7,9 +7,9 @@ import os
 import sys
 import hmac
 import functools
+import logging
 import socket
 import hashlib
-import traceback
 
 import fteproxy.conf
 import fteproxy.defs
@@ -143,20 +143,43 @@ class NegotiateTimeoutException(Exception):
     pass
 
 
+logger = logging.getLogger('fteproxy')
+"""The package logger. ``fteproxy.cli`` attaches a stderr handler to it and
+sets its level from ``-q``/``-v``; embedding programs are free to attach their
+own handlers instead. Nothing here configures the root logger, so importing
+fteproxy never changes an application's logging setup.
+
+Logging goes to stderr, never stdout, so a command whose output is data (for
+example ``fteproxy formats``) stays pipeable.
+"""
+
+
 def fatal_error(msg):
-    if fteproxy.conf.getValue('runtime.loglevel') in [1,2,3]:
-        print('ERROR:', msg)
+    """Log ``msg`` at ERROR and terminate with exit status 1.
+
+    Reserved for conditions from which no connection can recover, such as a
+    format provider that breaks libfte's ranking contract. Callers that can
+    report a failure to their own caller should raise instead: this raises
+    ``SystemExit``, which only unwinds the calling thread when it is not the
+    main one.
+    """
+    logger.error(msg)
     sys.exit(1)
 
 
 def warn(msg):
-    if fteproxy.conf.getValue('runtime.loglevel') in [2,3]:
-        print('WARN:', msg)
+    """Log ``msg`` at WARNING: something is wrong but the process continues."""
+    logger.warning(msg)
 
 
 def info(msg):
-    if fteproxy.conf.getValue('runtime.loglevel') in [3]:
-        print('INFO:', msg)
+    """Log ``msg`` at INFO: normal, low-volume progress reporting."""
+    logger.info(msg)
+
+
+def debug(msg):
+    """Log ``msg`` at DEBUG: per-connection and per-record detail."""
+    logger.debug(msg)
 
 
 class NegotiateCell(object):

--- a/fteproxy/__main__.py
+++ b/fteproxy/__main__.py
@@ -5,7 +5,9 @@
 Allow running fteproxy as a module: python -m fteproxy
 """
 
+import sys
+
 from fteproxy.cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -1,148 +1,148 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""The fteproxy command line.
 
+Both ``python -m fteproxy`` and the ``fteproxy`` console script call
+:func:`main`, which returns a process exit status:
 
+===  ==========================================================
+  0  clean shutdown
+  1  runtime failure (bad format name, unusable key, bind refused)
+  2  usage error (argparse rejected the command line, or a required
+     argument is missing)
+===  ==========================================================
 
+Parsing is a plain ``argparse`` parse followed by one
+:func:`apply_args_to_conf` step. The previous ``setConfValue`` action wrote
+``fteproxy.conf`` as a side effect of parsing, which meant a value that came
+from a default never reached the configuration at all (argparse does not run
+actions for defaults). That is why a no-argument run used to die with a
+``TypeError`` deep in the relay, and why it still exited 0.
+"""
 
-import sys
+import argparse
+import glob
+import logging
 import os
 import signal
-import glob
-import argparse
+import sys
 import threading
-import traceback
 
 import fteproxy
 import fteproxy.conf
+import fteproxy.defs
 import fteproxy.server
 import fteproxy.client
 
 FTEPROXY_VERSION = fteproxy.__version__
 
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
 
-class FTEMain(threading.Thread):
-
-    def __init__(self, args):
-        threading.Thread.__init__(self)
-        self._args = args
-
-    def run(self):
-        try:
-            self._client = None
-            self._server = None
-
-            if not self._args.quiet:
-                print("""fteproxy Copyright (C) 2012-2026 Kevin P. Dyer <kpdyer@gmail.com>
-    This program comes with ABSOLUTELY NO WARRANTY.
-    This is free software, and you are welcome to redistribute it under certain conditions.
-    """)
-
-            if self._args.stop:
-                FTEMain.do_stop(self)
-
-            try:
-                pid_file = get_pid_file()
-
-                with open(pid_file, 'w') as f:
-                    f.write(str(os.getpid()))
-            except IOError:
-                fteproxy.warn('Failed to write PID file to disk: '+pid_file)
-
-            if fteproxy.conf.getValue('runtime.mode') == 'client':
-                FTEMain.do_client(self)
-            elif fteproxy.conf.getValue('runtime.mode') == 'server':
-                FTEMain.do_server(self)
-
-        except Exception as e:
-            traceback.print_exc()
-            fteproxy.fatal_error("FTEMain terminated unexpectedly: "+str(e))
-
-    def stop(self):
-        if self._client is not None:
-            self._client.stop()
-        if self._server is not None:
-            self._server.stop()
-
-    def do_stop(self):
-        pid_files_path = \
-            os.path.join(fteproxy.conf.getValue('general.pid_dir'),
-                         '.' + self._args.mode + '-*.pid')
-        pid_files = glob.glob(pid_files_path)
-        for pid_file in pid_files:
-            with open(pid_file) as f:
-                pid = int(f.read())
-                try:
-                    os.kill(pid, signal.SIGINT)
-                except OSError:
-                    fteproxy.warn('failed to remove PID file: '+pid_file)
-                os.unlink(pid_file)
-        sys.exit(0)
-
-    def init_listener(self, mode):
-        server_ip = fteproxy.conf.getValue('runtime.server.ip')
-        server_port = fteproxy.conf.getValue('runtime.server.port')
-        if mode == 'client':
-            client_ip = fteproxy.conf.getValue('runtime.client.ip')
-            client_port = fteproxy.conf.getValue('runtime.client.port')
-            return fteproxy.client.listener(client_ip, client_port,
-                                            server_ip, server_port)
-        elif mode == 'server':
-            proxy_ip = fteproxy.conf.getValue('runtime.proxy.ip')
-            proxy_port = fteproxy.conf.getValue('runtime.proxy.port')
-            return fteproxy.server.listener(server_ip, server_port,
-                                            proxy_ip, proxy_port)
-        else:
-            fteproxy.fatal_error('Unexpected mode in init_listener: ' + mode)
-
-    def init_cipher(self, stream_format):
-
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-
-        try:
-            pattern = fteproxy.defs.getRegex(stream_format)
-        except fteproxy.defs.InvalidRegexName:
-            fteproxy.fatal_error('Invalid format name ' + stream_format)
-
-        length = fteproxy.defs.getLength(stream_format)
-        # Build the cipher to validate the format is usable with this key.
-        # libfte 0.4 raises FormatCapacityError here if the format is too small
-        # to carry the cipher's frame overhead.
-        fteproxy._make_cipher(pattern, length, key)
-
-    def do_client(self):
-
-        FTEMain.init_cipher(self, self._args.downstream_format)
-        FTEMain.init_cipher(self, self._args.upstream_format)
-        warn_if_default_key()
-
-        if not self._args.quiet:
-            print('Client ready!')
-
-        self._client = FTEMain.init_listener(self, 'client')
-        self._client.daemon = True
-        self._client.start()
-        self._client.join()
-
-    def do_server(self):
-
-        languages = fteproxy.defs.load_definitions()
-        for language in languages.keys():
-            FTEMain.init_cipher(self, language)
-        warn_if_default_key()
-
-        self._server = FTEMain.init_listener(self, 'server')
-        self._server.daemon = True
-        self._server.start()
-        if not self._args.quiet:
-            print('Server ready!')
-        self._server.join()
+_LICENSE_BANNER = """fteproxy %s
+Copyright (C) 2012-2026 Kevin P. Dyer <kpdyer@gmail.com>
+This program comes with ABSOLUTELY NO WARRANTY. This is free software, and
+you are welcome to redistribute it under certain conditions.""" % FTEPROXY_VERSION
 
 
-def get_pid_file():
-    pid_file = os.path.join(fteproxy.conf.getValue('general.pid_dir'),
-                              '.' + fteproxy.conf.getValue('runtime.mode')
-                            + '-' + str(os.getpid()) + '.pid')
-    return pid_file
+class _PrintVersion(argparse.Action):
+    """``--version``: the version and the licence notice, unwrapped.
+
+    argparse's own ``version`` action runs the text through the help
+    formatter, which reflows the notice into a paragraph. The notice used to
+    be a banner printed on every run; it lives here now.
+    """
+
+    def __init__(self, option_strings, dest, **kwargs):
+        kwargs.setdefault('nargs', 0)
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(_LICENSE_BANNER)
+        parser.exit(EXIT_OK)
+
+
+class UsageError(Exception):
+    """The command line parsed, but one of its values cannot be used.
+
+    Reported like any other argparse error: the message on stderr and exit
+    status 2.
+    """
+
+
+class StartupError(Exception):
+    """A resource the run needs could not be obtained: an unknown format name,
+    a format the key cannot drive, or a port that will not bind. Exit status 1.
+    """
+
+
+# --------------------------------------------------------------------------- #
+# Logging
+# --------------------------------------------------------------------------- #
+
+def configure_logging(quiet=False, verbose=False):
+    """Point the ``fteproxy`` logger at stderr and set its level.
+
+    Default INFO, ``-q`` ERROR, ``-v`` DEBUG. stderr, not stdout, so that a
+    command whose stdout is data (``fteproxy formats``) stays pipeable.
+    """
+    if quiet:
+        level = logging.ERROR
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+
+    logger = fteproxy.logger
+    for existing in list(logger.handlers):
+        logger.removeHandler(existing)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    # Do not let fteproxy's records reach a root handler an embedding program
+    # installed; the CLI owns the process's stderr.
+    logger.propagate = False
+    return level
+
+
+# --------------------------------------------------------------------------- #
+# Keys
+# --------------------------------------------------------------------------- #
+
+def parse_hex_key(hex_key):
+    """Validate a hex-encoded key and return it as bytes.
+
+    The key must be exactly 64 hexadecimal characters (a 32-byte key).
+    Surrounding whitespace is ignored so keys read from a file may end in a
+    trailing newline. Raises :class:`UsageError` on invalid input; the message
+    never contains the key material.
+    """
+    hex_key = hex_key.strip()
+    if len(hex_key) != 64:
+        raise UsageError('invalid key length: %d hex characters, expected 64'
+                         % len(hex_key))
+    try:
+        return bytes.fromhex(hex_key)
+    except ValueError:
+        raise UsageError('invalid key format: must contain only 0-9a-fA-F')
+
+
+def read_key_file(path):
+    """Read a hex-encoded key from a file and return it as bytes.
+
+    Storing the key in a file keeps it out of shell history and process
+    listings (e.g., ``ps``), unlike passing it via ``--key``. Raises
+    :class:`UsageError` if the file cannot be read or holds an invalid key.
+    """
+    try:
+        with open(path) as key_file:
+            contents = key_file.read()
+    except OSError as e:
+        raise UsageError('failed to read key file "%s": %s' % (path, e))
+    return parse_hex_key(contents)
 
 
 def warn_if_default_key():
@@ -157,127 +157,56 @@ def warn_if_default_key():
                       '--key or --key-file with a secret shared by both endpoints')
 
 
-def parse_hex_key(hex_key):
-    """Validate a hex-encoded key and return it as bytes.
+# --------------------------------------------------------------------------- #
+# Argument parsing
+# --------------------------------------------------------------------------- #
 
-    The key must be exactly 64 hexadecimal characters (a 32-byte key).
-    Surrounding whitespace is ignored so keys read from a file may end in a
-    trailing newline. Exits the process with an error on invalid input.
+def build_parser():
+    """Build the argument parser.
+
+    One flat command (the relay, selected with ``--mode``) plus subcommands.
+    ``formats`` is the first subcommand; the 0.4 command line replaces the flat
+    interface with ``server``/``client``/``keygen`` alongside it.
     """
-    hex_key = hex_key.strip()
-    if len(hex_key) != 64:
-        fteproxy.warn('Invalid key length: ' + str(len(hex_key))
-                      + ', should be 64')
-        sys.exit(1)
-    try:
-        return bytes.fromhex(hex_key)
-    except ValueError:
-        fteproxy.warn('Invalid key format, must contain only 0-9a-fA-F')
-        sys.exit(1)
-
-
-def read_key_file(path):
-    """Read a hex-encoded key from a file and return it as bytes.
-
-    Storing the key in a file keeps it out of shell history and process
-    listings (e.g., ``ps``), unlike passing it via ``--key``. Exits the
-    process with an error if the file cannot be read or holds an invalid key.
-    """
-    try:
-        with open(path) as key_file:
-            contents = key_file.read()
-    except IOError as e:
-        fteproxy.warn('Failed to read key file "' + str(path) + '": ' + str(e))
-        sys.exit(1)
-    return parse_hex_key(contents)
-
-
-def get_args():
-
-    class setConfValue(argparse.Action):
-        def __call__(self, parser, namespace, values, options_string):
-            args_to_conf = {
-                "--quiet":              "runtime.loglevel",
-                "--mode":               "runtime.mode",
-                "--client_ip":          "runtime.client.ip",
-                "--client_port":        "runtime.client.port",
-                "--server_ip":          "runtime.server.ip",
-                "--server_port":        "runtime.server.port",
-                "--proxy_ip":           "runtime.proxy.ip",
-                "--proxy_port":         "runtime.proxy.port",
-                "--downstream-format":  "runtime.state.downstream_language",
-                "--upstream-format":    "runtime.state.upstream_language",
-                "--release":            "fteproxy.defs.release",
-                "--key":                "runtime.fteproxy.encrypter.key",
-                "--record-layer-mode":  "runtime.fteproxy.record_layer.mode",
-            }
-
-            if self.dest == "key_file":
-                setattr(namespace, self.dest, values)
-                fteproxy.conf.setValue('runtime.fteproxy.encrypter.key',
-                                       read_key_file(values))
-                return
-
-            if self.dest == "key":
-                values = parse_hex_key(values)
-
-            if self.dest == 'quiet':
-                fteproxy.conf.setValue(args_to_conf[options_string], 0)
-                setattr(namespace, self.dest, True)
-            else:
-                setattr(namespace, self.dest, values)
-                if "port" in self.dest:
-                    values = int(values)
-                fteproxy.conf.setValue(args_to_conf[options_string], values)
-
-    parser = argparse.ArgumentParser(prog='fteproxy',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--version', action='version', version=FTEPROXY_VERSION,
+    parser = argparse.ArgumentParser(
+        prog='fteproxy',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--version', action=_PrintVersion,
                         help='Output the version of fteproxy, then quit.')
-    parser.add_argument('--mode', action=setConfValue, default='client',
+    parser.add_argument('--mode', default=None,
                         metavar='(client|server)',
                         choices=['client', 'server'],
                         help='Relay mode: client or server')
     parser.add_argument('--stop', action='store_true',
                         help='Shutdown daemon process')
-    parser.add_argument('--upstream-format', action=setConfValue,
+    parser.add_argument('--upstream-format', dest='upstream_format',
                         help='Client-to-server language format',
-                        default=fteproxy.conf.getValue('runtime.state.upstream_language'
-                                                  ))
-    parser.add_argument('--downstream-format', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.state.upstream_language'))
+    parser.add_argument('--downstream-format', dest='downstream_format',
                         help='Server-to-client language format',
-                        default=fteproxy.conf.getValue('runtime.state.downstream_language'
-                                                  ))
-    parser.add_argument('--client_ip', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.state.downstream_language'))
+    parser.add_argument('--client_ip',
                         help='Client-side listening IP',
-                        default=fteproxy.conf.getValue('runtime.client.ip'
-                                                  ))
-    parser.add_argument('--client_port', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.client.ip'))
+    parser.add_argument('--client_port', type=int,
                         help='Client-side listening port',
-                        default=fteproxy.conf.getValue('runtime.client.port'
-                                                  ))
-    parser.add_argument('--server_ip', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.client.port'))
+    parser.add_argument('--server_ip',
                         help='Server-side listening IP',
-                        default=fteproxy.conf.getValue('runtime.server.ip'
-                                                  ))
-    parser.add_argument('--server_port', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.server.ip'))
+    parser.add_argument('--server_port', type=int,
                         help='Server-side listening port',
-                        default=fteproxy.conf.getValue('runtime.server.port'
-                                                  ))
-    parser.add_argument('--proxy_ip', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.server.port'))
+    parser.add_argument('--proxy_ip',
                         help='Forwarding-proxy listening IP',
-                        default=fteproxy.conf.getValue('runtime.proxy.ip'
-                                                  ))
-    parser.add_argument('--proxy_port', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.proxy.ip'))
+    parser.add_argument('--proxy_port', type=int,
                         help='Forwarding-proxy listening port',
-                        default=fteproxy.conf.getValue('runtime.proxy.port'
-                                                  ))
-    parser.add_argument('--quiet', action=setConfValue, default=False,
-                        help='Be completely silent. Print nothing.', nargs=0)
-    parser.add_argument('--release', action=setConfValue,
+                        default=fteproxy.conf.getValue('runtime.proxy.port'))
+    parser.add_argument('--release',
                         help='Definitions file to use, specified as YYYYMMDD',
                         default=fteproxy.conf.getValue('fteproxy.defs.release'))
-    parser.add_argument('--record-layer-mode', action=setConfValue,
+    parser.add_argument('--record-layer-mode', dest='record_layer_mode',
                         metavar='(format|hybrid)',
                         choices=['format', 'hybrid'],
                         help='Record framing. "hybrid" (default) formats a '
@@ -288,54 +217,334 @@ def get_args():
                              'much lower throughput. Both endpoints must match.',
                         default=fteproxy.conf.getValue(
                             'runtime.fteproxy.record_layer.mode'))
+
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument('-q', '--quiet', action='store_true',
+                           help='Log errors only.')
+    verbosity.add_argument('-v', '--verbose', action='store_true',
+                           help='Log per-connection detail.')
+
     key_group = parser.add_mutually_exclusive_group()
-    key_group.add_argument('--key', action=setConfValue,
-                        help='Shared secret, hex, exactly 64 characters; must '
-                             'match on both endpoints. The built-in default '
-                             'is public and gives no protection: always '
-                             'supply your own (see --key-file).',
-                        default=fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'
-                                                  ).hex())
-    key_group.add_argument('--key-file', action=setConfValue, dest='key_file',
-                        metavar='PATH', default=None,
-                        help='Path to a file containing the cryptographic key '
-                             '(64 hex characters). Use instead of --key to keep '
-                             'the key out of shell history and process listings.')
-    args = parser.parse_args(sys.argv[1:])
+    key_group.add_argument('--key',
+                           help='Shared secret, hex, exactly 64 characters; must '
+                                'match on both endpoints. The built-in default '
+                                'is public and gives no protection: always '
+                                'supply your own (see --key-file).',
+                           default=fteproxy.conf.getValue(
+                               'runtime.fteproxy.encrypter.key').hex())
+    key_group.add_argument('--key-file', dest='key_file',
+                           metavar='PATH', default=None,
+                           help='Path to a file containing the cryptographic key '
+                                '(64 hex characters). Use instead of --key to keep '
+                                'the key out of shell history and process listings.')
 
-    if args.stop and not args.mode:
-        parser.error('--mode keyword is required with --stop')
+    subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
+    formats_parser = subparsers.add_parser(
+        'formats',
+        help='List the formats in a definitions file, then quit.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # SUPPRESS so that "fteproxy --release X formats" keeps the value given
+    # before the subcommand; a subparser default would otherwise overwrite it.
+    formats_parser.add_argument('--release', default=argparse.SUPPRESS,
+                                help='Definitions file to list, as YYYYMMDD')
 
-    if not args.mode:  # set client mode in conf if not set
-        fteproxy.conf.setValue('runtime.mode', 'client')
-
-    return args
+    return parser
 
 
-def main():
-    global running
-    running = True
+def apply_args_to_conf(args):
+    """Copy every parsed argument into ``fteproxy.conf``, defaults included.
 
-    def signal_handler(signal, frame):
-        global running
-        running = False
-    signal.signal(signal.SIGINT, signal_handler)
+    One step, run after parsing, so the configuration a run sees is exactly
+    what the command line says, whether a value was typed or defaulted.
+    """
+    conf = fteproxy.conf
+    conf.setValue('runtime.mode', args.mode)
+    conf.setValue('runtime.client.ip', args.client_ip)
+    conf.setValue('runtime.client.port', args.client_port)
+    conf.setValue('runtime.server.ip', args.server_ip)
+    conf.setValue('runtime.server.port', args.server_port)
+    conf.setValue('runtime.proxy.ip', args.proxy_ip)
+    conf.setValue('runtime.proxy.port', args.proxy_port)
+    conf.setValue('runtime.state.upstream_language', args.upstream_format)
+    conf.setValue('runtime.state.downstream_language', args.downstream_format)
+    conf.setValue('runtime.fteproxy.record_layer.mode', args.record_layer_mode)
+
+    if conf.getValue('fteproxy.defs.release') != args.release:
+        conf.setValue('fteproxy.defs.release', args.release)
+        fteproxy.defs._definitions = None
+
+    if args.key_file is not None:
+        conf.setValue('runtime.fteproxy.encrypter.key', read_key_file(args.key_file))
+    else:
+        conf.setValue('runtime.fteproxy.encrypter.key', parse_hex_key(args.key))
+
+
+# --------------------------------------------------------------------------- #
+# Startup validation
+# --------------------------------------------------------------------------- #
+
+def check_format(format_name):
+    """Build the cipher for ``format_name`` so an unusable format fails now.
+
+    libfte raises ``FormatCapacityError`` when a format is too small to carry
+    the cipher's frame, and the definitions lookup raises for an unknown name.
+    Both used to surface only on the first connection, as a client-side
+    timeout.
+    """
+    try:
+        pattern = fteproxy.defs.getRegex(format_name)
+    except fteproxy.defs.InvalidRegexName:
+        raise StartupError('invalid format name: ' + format_name)
+    except OSError as e:
+        raise StartupError('failed to read the definitions file: ' + str(e))
+
+    length = fteproxy.defs.getLength(format_name)
+    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+    try:
+        fteproxy._make_cipher(pattern, length, key)
+    except Exception as e:
+        raise StartupError('format %s is unusable: %s' % (format_name, e))
+
+
+def check_startup(mode):
+    """Validate every format this role will use, before anything is printed,
+    bound, or written to disk."""
+    if mode == 'client':
+        check_format(fteproxy.conf.getValue('runtime.state.upstream_language'))
+        check_format(fteproxy.conf.getValue('runtime.state.downstream_language'))
+    else:
+        try:
+            definitions = fteproxy.defs.load_definitions()
+        except OSError as e:
+            raise StartupError('failed to read the definitions file: ' + str(e))
+        # The server accepts any format the client asks for, so all of them
+        # have to work here.
+        for format_name in definitions.keys():
+            check_format(format_name)
+    warn_if_default_key()
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands
+# --------------------------------------------------------------------------- #
+
+def do_formats(args):
+    """Print each base format name with its covertext length and capacity.
+
+    A base name is what the two directions share: ``manual-http`` covers
+    ``manual-http-request`` and ``manual-http-response``. The capacity is how
+    many bytes of message one covertext of that length carries, which is what
+    bounds a record.
+    """
+    try:
+        definitions = fteproxy.defs.load_definitions()
+    except OSError as e:
+        fteproxy.warn('failed to read the definitions file: ' + str(e))
+        return EXIT_FAILURE
+
+    default_base = _base_name(
+        fteproxy.conf.getValue('runtime.state.upstream_language'))
+    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+
+    bases = {}
+    for name in definitions:
+        base = _base_name(name)
+        direction = name[len(base) + 1:] if name != base else ''
+        if direction not in ('request', 'response'):
+            continue
+        bases.setdefault(base, {})[direction] = name
+
+    rows = []
+    for base in sorted(bases):
+        row = [base]
+        for direction in ('request', 'response'):
+            name = bases[base].get(direction)
+            if name is None:
+                row += ['-', '-']
+                continue
+            length = fteproxy.defs.getLength(name)
+            try:
+                capacity = fteproxy._make_cipher(
+                    fteproxy.defs.getRegex(name), length, key).max_plaintext_bytes
+            except Exception:
+                row += [str(length), 'unusable']
+                continue
+            row += [str(length), str(capacity)]
+        row.append('(default)' if base == default_base else '')
+        rows.append(row)
+
+    header = ['name', 'req len', 'req cap', 'resp len', 'resp cap', '']
+    widths = [max(len(r[i]) for r in [header] + rows) for i in range(len(header))]
+    print('definitions release %s'
+          % fteproxy.conf.getValue('fteproxy.defs.release'))
+    print('covertext length and message capacity, in bytes, per direction')
+    print()
+    for row in [header] + rows:
+        line = '  '.join(cell.ljust(widths[i]) if i == 0 else cell.rjust(widths[i])
+                         for i, cell in enumerate(row))
+        print(line.rstrip())
+    return EXIT_OK
+
+
+def _base_name(format_name):
+    """``manual-http-request`` -> ``manual-http``."""
+    for suffix in ('-request', '-response'):
+        if format_name.endswith(suffix):
+            return format_name[:-len(suffix)]
+    return format_name
+
+
+# --------------------------------------------------------------------------- #
+# PID files (removed with --stop in the 0.4 command line)
+# --------------------------------------------------------------------------- #
+
+def get_pid_file():
+    return os.path.join(
+        fteproxy.conf.getValue('general.pid_dir'),
+        '.' + str(fteproxy.conf.getValue('runtime.mode'))
+        + '-' + str(os.getpid()) + '.pid')
+
+
+def write_pid_file():
+    pid_file = get_pid_file()
+    try:
+        with open(pid_file, 'w') as f:
+            f.write(str(os.getpid()))
+    except OSError:
+        fteproxy.warn('failed to write PID file to disk: ' + pid_file)
+        return None
+    return pid_file
+
+
+def do_stop(mode):
+    """Signal every running fteproxy of ``mode`` recorded in the PID directory."""
+    pattern = os.path.join(fteproxy.conf.getValue('general.pid_dir'),
+                           '.' + mode + '-*.pid')
+    for pid_file in glob.glob(pattern):
+        try:
+            with open(pid_file) as f:
+                pid = int(f.read())
+        except (OSError, ValueError):
+            fteproxy.warn('failed to read PID file: ' + pid_file)
+            continue
+        try:
+            os.kill(pid, signal.SIGINT)
+        except OSError:
+            fteproxy.warn('failed to signal process ' + str(pid))
+        try:
+            os.unlink(pid_file)
+        except OSError:
+            fteproxy.warn('failed to remove PID file: ' + pid_file)
+    return EXIT_OK
+
+
+# --------------------------------------------------------------------------- #
+# The relay
+# --------------------------------------------------------------------------- #
+
+def init_listener(mode):
+    server_ip = fteproxy.conf.getValue('runtime.server.ip')
+    server_port = fteproxy.conf.getValue('runtime.server.port')
+    if mode == 'client':
+        return fteproxy.client.listener(
+            fteproxy.conf.getValue('runtime.client.ip'),
+            fteproxy.conf.getValue('runtime.client.port'),
+            server_ip, server_port)
+    return fteproxy.server.listener(
+        server_ip, server_port,
+        fteproxy.conf.getValue('runtime.proxy.ip'),
+        fteproxy.conf.getValue('runtime.proxy.port'))
+
+
+def run_relay(mode):
+    """Bind, then relay until SIGINT or SIGTERM. Returns the exit status.
+
+    The bind happens on this thread so a refused port is a startup failure with
+    a non-zero status, not a listener thread that dies while the process goes
+    on to exit 0.
+    """
+    listener = init_listener(mode)
+    try:
+        listener.bind()
+    except OSError as e:
+        raise StartupError('failed to bind %s: %s'
+                           % (_bind_address(mode), e))
+
+    pid_file = write_pid_file()
+
+    stopping = threading.Event()
+
+    def _stop(signum, frame):
+        stopping.set()
+
+    previous = {}
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        try:
+            previous[signum] = signal.signal(signum, _stop)
+        except ValueError:
+            # Not the main thread (an embedding program calling main()).
+            pass
+
+    listener.daemon = True
+    listener.start()
+    fteproxy.info('%s listening on %s' % (mode, _bind_address(mode)))
+    try:
+        while listener.is_alive() and not stopping.is_set():
+            stopping.wait(0.5)
+    finally:
+        listener.stop()
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+        if pid_file and os.path.exists(pid_file):
+            try:
+                os.unlink(pid_file)
+            except OSError:
+                pass
+    return EXIT_OK
+
+
+def _bind_address(mode):
+    if mode == 'client':
+        return '%s:%d' % (fteproxy.conf.getValue('runtime.client.ip'),
+                          fteproxy.conf.getValue('runtime.client.port'))
+    return '%s:%d' % (fteproxy.conf.getValue('runtime.server.ip'),
+                      fteproxy.conf.getValue('runtime.server.port'))
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+def main(argv=None):
+    """Parse ``argv``, run the requested command, and return an exit status."""
+    argv = sys.argv[1:] if argv is None else list(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    configure_logging(quiet=args.quiet, verbose=args.verbose)
 
     try:
-        args = get_args()
-        main_thread = FTEMain(args)
-        main_thread.daemon = True
-        main_thread.start()
-        while running and main_thread.is_alive():
-            main_thread.join(timeout=0.5)
-        main_thread.stop()
-    except KeyboardInterrupt:
-        pass
-    except Exception as e:
-        fteproxy.fatal_error("Main thread terminated unexpectedly: "+str(e))
-    finally:
-        if fteproxy.conf.getValue('runtime.mode'):
-            pid_file = get_pid_file()
+        apply_args_to_conf(args)
+    except UsageError as e:
+        parser.error(str(e))  # exits 2
 
-            if pid_file and os.path.exists(pid_file):
-                os.unlink(pid_file)
+    if args.command == 'formats':
+        return do_formats(args)
+
+    if args.mode is None:
+        parser.print_usage(sys.stderr)
+        print('fteproxy: --mode (client|server) is required, '
+              'or name a subcommand (formats).', file=sys.stderr)
+        return EXIT_USAGE
+
+    if args.stop:
+        return do_stop(args.mode)
+
+    try:
+        check_startup(args.mode)
+        return run_relay(args.mode)
+    except StartupError as e:
+        fteproxy.logger.error(str(e))
+        return EXIT_FAILURE
+    except KeyboardInterrupt:
+        return EXIT_OK

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -60,10 +60,6 @@ conf['general.pid_dir'] = tempfile.gettempdir()
 conf['runtime.mode'] = None
 
 
-"""Our loglevel = 0|1|2|3"""
-conf['runtime.loglevel'] = 3
-
-
 """The maximum number of queued connections for sockets"""
 conf['runtime.fteproxy.relay.backlog'] = 100
 

--- a/fteproxy/relay.py
+++ b/fteproxy/relay.py
@@ -73,28 +73,44 @@ class listener(threading.Thread):
         threading.Thread.__init__(self)
 
         self._running = False
+        self._sock = None
         self._local_ip = local_ip
         self._local_port = local_port
         self._remote_ip = remote_ip
         self._remote_port = remote_port
 
-    def _instantiateSocket(self):
+    def bind(self):
+        """Bind and listen on ``local_ip:local_port``, raising ``OSError`` on
+        failure.
+
+        Separate from :meth:`run` so a caller can claim the port on the main
+        thread and report a bind failure with a non-zero exit status. Binding
+        inside the thread instead only killed the thread, and the process went
+        on to exit 0.
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self._sock.bind((self._local_ip, self._local_port))
-            self._sock.listen(fteproxy.conf.getValue('runtime.fteproxy.relay.backlog'))
-            self._sock.settimeout(
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((self._local_ip, self._local_port))
+            sock.listen(fteproxy.conf.getValue('runtime.fteproxy.relay.backlog'))
+            sock.settimeout(
                 fteproxy.conf.getValue('runtime.fteproxy.relay.accept_timeout'))
-        except Exception as e:
-            fteproxy.fatal_error('Failed to bind to ' +
-                            str((self._local_ip, self._local_port)) + ': ' + str(e))
+        except OSError:
+            sock.close()
+            raise
+        self._sock = sock
 
     def run(self):
         """Bind to ``local_ip:local_port`` and forward all connections to
         ``remote_ip:remote_port``.
         """
-        self._instantiateSocket()
+        if self._sock is None:
+            try:
+                self.bind()
+            except OSError as e:
+                fteproxy.fatal_error(
+                    'Failed to bind to '
+                    + str((self._local_ip, self._local_port)) + ': ' + str(e))
 
         self._running = True
         while self._running:
@@ -136,7 +152,8 @@ class listener(threading.Thread):
         """Terminate the thread and stop listening on ``local_ip:local_port``.
         """
         self._running = False
-        fteproxy.network_io.close_socket(self._sock)
+        if self._sock is not None:
+            fteproxy.network_io.close_socket(self._sock)
 
     def onNewIncomingConnection(self, socket):
         """``onNewIncomingConnection`` returns the socket unmodified, by default we do not need to

--- a/fteproxy/tests/conftest.py
+++ b/fteproxy/tests/conftest.py
@@ -5,6 +5,8 @@ Pytest configuration and fixtures for fteproxy tests.
 """
 
 import pytest
+
+import fteproxy
 import fteproxy.conf
 
 
@@ -15,6 +17,26 @@ def setup_test_mode():
     yield
     # Reset after test if needed
     fteproxy.conf.setValue('runtime.mode', None)
+
+
+@pytest.fixture(autouse=True)
+def restore_fteproxy_logger():
+    """Undo any logging setup a test performed.
+
+    ``fteproxy.cli.configure_logging`` attaches a handler and stops the
+    package logger propagating to the root, which is right for a CLI process
+    and wrong for the rest of the session: ``caplog`` reads records off the
+    root logger, so a leaked configuration would silently blind every later
+    test that asserts on a log message.
+    """
+    logger = fteproxy.logger
+    handlers = list(logger.handlers)
+    level = logger.level
+    propagate = logger.propagate
+    yield
+    logger.handlers[:] = handlers
+    logger.setLevel(level)
+    logger.propagate = propagate
 
 
 @pytest.fixture

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the command line: parsing, applying to conf, and exit statuses.
+
+These call :func:`fteproxy.cli.main` in process, so they assert on the status
+the process would exit with rather than on a subprocess return code.
+``test_system.py`` covers the subprocess path.
+"""
+
+import logging
+
+import pytest
+
+import fteproxy
+import fteproxy.cli
+import fteproxy.conf
+import fteproxy.defs
+
+
+@pytest.fixture(autouse=True)
+def restore_conf():
+    """Snapshot and restore the global configuration around each test.
+
+    ``apply_args_to_conf`` writes process-global state; without this a test
+    that sets a non-default release or key would leak into the next one.
+    """
+    saved = dict(fteproxy.conf.conf)
+    saved_defs = fteproxy.defs._definitions
+    yield
+    fteproxy.conf.conf.clear()
+    fteproxy.conf.conf.update(saved)
+    fteproxy.defs._definitions = saved_defs
+
+
+def parse(argv):
+    return fteproxy.cli.build_parser().parse_args(argv)
+
+
+class TestParser:
+    """The parse step alone: no configuration is written."""
+
+    def test_ports_are_integers(self):
+        args = parse(['--mode', 'client', '--client_port', '1234',
+                      '--server_port', '5678', '--proxy_port', '9012'])
+        assert args.client_port == 1234
+        assert args.server_port == 5678
+        assert args.proxy_port == 9012
+
+    def test_non_integer_port_is_a_usage_error(self):
+        with pytest.raises(SystemExit) as excinfo:
+            parse(['--mode', 'client', '--client_port', 'http'])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_mode_has_no_default(self):
+        """A bare run must be a usage error, not a client that was never
+        configured. The old default hid the no-argument crash."""
+        assert parse([]).mode is None
+
+    def test_invalid_mode_is_a_usage_error(self):
+        with pytest.raises(SystemExit) as excinfo:
+            parse(['--mode', 'invalid'])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_parsing_does_not_write_conf(self):
+        before = fteproxy.conf.getValue('runtime.client.port')
+        parse(['--mode', 'client', '--client_port', str(before + 1)])
+        assert fteproxy.conf.getValue('runtime.client.port') == before
+
+    def test_quiet_and_verbose_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit) as excinfo:
+            parse(['--mode', 'client', '-q', '-v'])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_key_and_key_file_are_mutually_exclusive(self, tmp_path):
+        key_file = tmp_path / 'k'
+        key_file.write_text('a' * 64)
+        with pytest.raises(SystemExit) as excinfo:
+            parse(['--mode', 'server', '--key', 'a' * 64,
+                   '--key-file', str(key_file)])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_formats_subcommand_is_recognised(self):
+        assert parse(['formats']).command == 'formats'
+        assert parse(['--mode', 'client']).command is None
+
+    def test_release_before_the_subcommand_is_kept(self):
+        """The subcommand's own --release defaults to SUPPRESS so it does not
+        clobber a value given ahead of it."""
+        assert parse(['--release', '20131224', 'formats']).release == '20131224'
+        assert parse(['formats', '--release', '20131224']).release == '20131224'
+
+
+class TestApplyArgsToConf:
+    """Every value reaches conf, whether typed or defaulted."""
+
+    def test_defaults_reach_conf(self):
+        args = parse(['--mode', 'client'])
+        # Poison conf after parsing: applying must put the default back. The
+        # old setConfValue action ran only for values the user typed, so a
+        # default never reached conf at all.
+        fteproxy.conf.setValue('runtime.client.port', 1)
+        fteproxy.conf.setValue('runtime.mode', None)
+        fteproxy.cli.apply_args_to_conf(args)
+        assert fteproxy.conf.getValue('runtime.mode') == 'client'
+        assert fteproxy.conf.getValue('runtime.client.port') == args.client_port
+
+    def test_typed_values_reach_conf(self):
+        fteproxy.cli.apply_args_to_conf(parse([
+            '--mode', 'server',
+            '--client_ip', '10.0.0.1', '--client_port', '1111',
+            '--server_ip', '10.0.0.2', '--server_port', '2222',
+            '--proxy_ip', '10.0.0.3', '--proxy_port', '3333',
+            '--upstream-format', 'ssh-request',
+            '--downstream-format', 'ssh-response',
+            '--record-layer-mode', 'format',
+        ]))
+        get = fteproxy.conf.getValue
+        assert get('runtime.mode') == 'server'
+        assert get('runtime.client.ip') == '10.0.0.1'
+        assert get('runtime.client.port') == 1111
+        assert get('runtime.server.ip') == '10.0.0.2'
+        assert get('runtime.server.port') == 2222
+        assert get('runtime.proxy.ip') == '10.0.0.3'
+        assert get('runtime.proxy.port') == 3333
+        assert get('runtime.state.upstream_language') == 'ssh-request'
+        assert get('runtime.state.downstream_language') == 'ssh-response'
+        assert get('runtime.fteproxy.record_layer.mode') == 'format'
+
+    def test_key_reaches_conf_as_bytes(self):
+        fteproxy.cli.apply_args_to_conf(
+            parse(['--mode', 'client', '--key', '0123456789abcdef' * 4]))
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        assert key == bytes.fromhex('0123456789abcdef' * 4)
+
+    def test_key_file_reaches_conf(self, tmp_path):
+        key_file = tmp_path / 'fteproxy.key'
+        key_file.write_text('0123456789abcdef' * 4 + '\n')
+        fteproxy.cli.apply_args_to_conf(
+            parse(['--mode', 'client', '--key-file', str(key_file)]))
+        assert fteproxy.conf.getValue('runtime.fteproxy.encrypter.key') == \
+            bytes.fromhex('0123456789abcdef' * 4)
+
+    def test_changing_the_release_drops_the_definitions_cache(self):
+        fteproxy.defs.load_definitions()
+        assert fteproxy.defs._definitions is not None
+        fteproxy.cli.apply_args_to_conf(
+            parse(['--mode', 'client', '--release', '20131224']))
+        assert fteproxy.defs._definitions is None
+        assert fteproxy.conf.getValue('fteproxy.defs.release') == '20131224'
+
+
+class TestKeyValidation:
+    """Key errors are usage errors and never quote the key material."""
+
+    def test_short_key_rejected(self):
+        with pytest.raises(fteproxy.cli.UsageError) as excinfo:
+            fteproxy.cli.parse_hex_key('abcdef')
+        assert 'abcdef' not in str(excinfo.value)
+
+    def test_non_hex_key_rejected(self):
+        with pytest.raises(fteproxy.cli.UsageError):
+            fteproxy.cli.parse_hex_key('z' * 64)
+
+    def test_trailing_newline_accepted(self):
+        assert fteproxy.cli.parse_hex_key('ab' * 32 + '\n') == b'\xab' * 32
+
+    def test_missing_key_file_rejected(self, tmp_path):
+        with pytest.raises(fteproxy.cli.UsageError):
+            fteproxy.cli.read_key_file(str(tmp_path / 'nope.key'))
+
+    def test_bad_key_file_is_exit_2(self, tmp_path):
+        key_file = tmp_path / 'short.key'
+        key_file.write_text('abcdef')
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['--mode', 'server', '--key-file', str(key_file)])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+
+class TestStartupChecks:
+    """Formats are validated before anything is printed or bound."""
+
+    def test_unknown_format_raises(self):
+        with pytest.raises(fteproxy.cli.StartupError) as excinfo:
+            fteproxy.cli.check_format('no-such-format')
+        assert 'no-such-format' in str(excinfo.value)
+
+    def test_known_format_passes(self):
+        fteproxy.cli.check_format('manual-http-request')
+
+
+class TestMainExitStatus:
+    """The statuses the plan fixes: 0 clean, 1 runtime failure, 2 usage."""
+
+    def test_no_arguments_is_usage(self, capsys):
+        assert fteproxy.cli.main([]) == fteproxy.cli.EXIT_USAGE
+        err = capsys.readouterr().err
+        assert 'usage:' in err
+        assert '--mode' in err
+
+    def test_unknown_upstream_format_is_failure(self, capsys):
+        status = fteproxy.cli.main(
+            ['--mode', 'client', '--upstream-format', 'nope'])
+        assert status == fteproxy.cli.EXIT_FAILURE
+        assert 'nope' in capsys.readouterr().err
+
+    def test_unknown_downstream_format_is_failure(self):
+        assert fteproxy.cli.main(
+            ['--mode', 'client', '--downstream-format', 'nope']) == \
+            fteproxy.cli.EXIT_FAILURE
+
+    def test_bind_failure_is_failure(self):
+        """A port already taken exits 1 rather than leaving a dead thread and
+        exiting 0."""
+        import socket
+
+        taken = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        taken.bind(('127.0.0.1', 0))
+        taken.listen(1)
+        port = taken.getsockname()[1]
+        try:
+            status = fteproxy.cli.main([
+                '--mode', 'client',
+                '--client_ip', '127.0.0.1', '--client_port', str(port),
+            ])
+        finally:
+            taken.close()
+        assert status == fteproxy.cli.EXIT_FAILURE
+
+    def test_version_exits_zero(self, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['--version'])
+        assert excinfo.value.code == fteproxy.cli.EXIT_OK
+        out = capsys.readouterr().out
+        assert fteproxy.__version__ in out
+        assert 'NO WARRANTY' in out
+
+
+class TestFormatsSubcommand:
+
+    def test_lists_base_names_with_capacity(self, capsys):
+        assert fteproxy.cli.main(['formats']) == fteproxy.cli.EXIT_OK
+        out = capsys.readouterr().out
+        assert 'manual-http' in out
+        # Base names only: the direction suffixes are columns, not rows.
+        assert 'manual-http-request' not in out
+        assert '(default)' in out
+        # manual-http-response carries 192 bytes per covertext at length 256.
+        assert '192' in out
+
+    def test_marks_the_configured_default(self, capsys):
+        fteproxy.cli.main(['--upstream-format', 'ssh-request', 'formats'])
+        for line in capsys.readouterr().out.splitlines():
+            if '(default)' in line:
+                assert line.split()[0] == 'ssh'
+                break
+        else:
+            pytest.fail('no format marked as the default')
+
+    def test_honours_the_release(self, capsys):
+        assert fteproxy.cli.main(['--release', '20131224', 'formats']) == \
+            fteproxy.cli.EXIT_OK
+        out = capsys.readouterr().out
+        assert '20131224' in out
+
+
+class TestLogging:
+    """Verbosity flags set the package logger's level; output is on stderr.
+
+    ``conftest.restore_fteproxy_logger`` puts the logger back afterwards.
+    """
+
+    def test_default_is_info(self):
+        assert fteproxy.cli.configure_logging() == logging.INFO
+
+    def test_quiet_is_error(self):
+        assert fteproxy.cli.configure_logging(quiet=True) == logging.ERROR
+
+    def test_verbose_is_debug(self):
+        assert fteproxy.cli.configure_logging(verbose=True) == logging.DEBUG
+
+    def test_messages_go_to_stderr(self, capsys):
+        fteproxy.cli.configure_logging()
+        # The handler is bound to whatever sys.stderr is when it is built, so
+        # build it under capsys's replacement.
+        fteproxy.warn('a warning')
+        captured = capsys.readouterr()
+        assert 'a warning' in captured.err
+        assert captured.out == ''

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -212,18 +212,22 @@ class TestWrapSocket:
         assert fteproxy._make_cipher('^[a-z]+$', 96, key) is not a
         assert fteproxy._make_cipher('^[a-z]+$', 64, bytes(range(32))) is not a
 
-    def test_default_key_warns(self, capsys):
-        """Starting with the public built-in key prints a warning; a real key does not."""
+    def test_default_key_warns(self, caplog):
+        """Starting with the public built-in key logs a warning; a real key does not."""
+        import logging
+
         import fteproxy.cli
         key = 'runtime.fteproxy.encrypter.key'
         prev = fteproxy.conf.getValue(key)
         try:
-            fteproxy.conf.setValue(key, fteproxy.conf.DEFAULT_KEY)
-            fteproxy.cli.warn_if_default_key()
-            assert 'default key' in capsys.readouterr().out
-            fteproxy.conf.setValue(key, bytes(range(32)))
-            fteproxy.cli.warn_if_default_key()
-            assert capsys.readouterr().out == ''
+            with caplog.at_level(logging.WARNING, logger='fteproxy'):
+                fteproxy.conf.setValue(key, fteproxy.conf.DEFAULT_KEY)
+                fteproxy.cli.warn_if_default_key()
+                assert 'default key' in caplog.text
+                caplog.clear()
+                fteproxy.conf.setValue(key, bytes(range(32)))
+                fteproxy.cli.warn_if_default_key()
+                assert caplog.text == ''
         finally:
             fteproxy.conf.setValue(key, prev)
 

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -4,6 +4,7 @@
 Tests for the FTE record layer encoding/decoding.
 """
 
+import logging
 import struct
 
 import pytest
@@ -244,15 +245,16 @@ class TestHybridRecordLayer:
         assert decoder.pop() == b'R' * 10
         assert len(calls) == 2
 
-    def test_oversized_body_length_is_rejected(self, capsys):
+    def test_oversized_body_length_is_rejected(self, caplog):
         """A header announcing a body larger than any record can carry is
         refused instead of buffering up to 4 GiB waiting for it."""
         encoder, decoder = self._pair()
         header = fteproxy.record_layer._seal(
             encoder._cipher, fteproxy.record_layer._OVERFLOW_LEN.pack(2 ** 32 - 1), 0)
         decoder.push(header + b'x' * 64)
-        assert decoder.pop() == b''
-        assert 'exceeds the record limit' in capsys.readouterr().out
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            assert decoder.pop() == b''
+        assert 'exceeds the record limit' in caplog.text
         assert len(decoder._buffer) == len(header) + 64
 
     def test_reordered_record_is_rejected(self):

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -246,7 +246,32 @@ class TestCLI:
         """Test that invalid mode is rejected."""
         cmd = get_fteproxy_cmd() + ['--mode', 'invalid']
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode != 0
+        assert result.returncode == 2
+
+    def test_no_arguments_prints_usage_and_exits_2(self):
+        """A bare run used to crash with a TypeError deep in the relay and
+        still exit 0, because argparse never applied the defaults to conf."""
+        result = subprocess.run(get_fteproxy_cmd(), capture_output=True,
+                                text=True, timeout=10)
+        assert result.returncode == 2
+        assert 'usage:' in result.stderr
+        assert 'Traceback' not in result.stderr
+
+    def test_invalid_format_exits_1(self):
+        """A startup failure is a runtime failure, not a silent success."""
+        cmd = get_fteproxy_cmd() + [
+            '--mode', 'client', '--upstream-format', 'no-such-format']
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        assert result.returncode == 1
+        assert 'no-such-format' in result.stderr
+
+    def test_formats_subcommand(self):
+        """``fteproxy formats`` lists the base names on stdout and exits 0."""
+        cmd = get_fteproxy_cmd() + ['formats']
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        assert result.returncode == 0
+        assert 'manual-http' in result.stdout
+        assert '(default)' in result.stdout
 
     def test_key_file_in_help(self):
         """Test that --key-file appears in the help output."""
@@ -260,7 +285,7 @@ class TestCLI:
         missing = tmp_path / 'does-not-exist.key'
         cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(missing)]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode != 0
+        assert result.returncode == 2
 
     def test_key_file_invalid_length(self, tmp_path):
         """Test that a key file with the wrong length is rejected."""
@@ -268,7 +293,7 @@ class TestCLI:
         key_file.write_text('abcdef')
         cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode != 0
+        assert result.returncode == 2
 
     def test_key_file_invalid_characters(self, tmp_path):
         """Test that a key file with non-hex characters is rejected."""
@@ -276,7 +301,7 @@ class TestCLI:
         key_file.write_text('z' * 64)
         cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode != 0
+        assert result.returncode == 2
 
     def test_key_and_key_file_mutually_exclusive(self, tmp_path):
         """Test that --key and --key-file cannot be used together."""
@@ -288,7 +313,7 @@ class TestCLI:
             '--key-file', str(key_file),
         ]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode != 0
+        assert result.returncode == 2
         assert '--key-file' in result.stderr and '--key' in result.stderr
 
 


### PR DESCRIPTION
### docs: add the 0.4 CLI and protocol redesign plan

Adds docs/plan-0.4.md, the design and PR sequence for the 0.4.0 release:
a one-argument client and no-argument server, an X25519/HKDF Noise-NK-shaped
handshake with per-connection keys, in-band destinations with SOCKS5 and -L
forwards, and the state directory and connection string that make the short
command line possible.

The following commits implement it PR by PR.

### PR1: parser hygiene, exit statuses, logging, and a formats subcommand

Implements section 5 / PR1 of docs/plan-0.4.md. No flag is renamed or
removed; what changes is that the command line now means what it says.

Parsing
- The setConfValue argparse action is gone. Parsing produces a namespace and
  nothing else; apply_args_to_conf() copies every value into fteproxy.conf in
  one place, defaults included. argparse never runs actions for defaults, so
  under the old scheme a defaulted value never reached conf at all.
- Ports are type=int at parse time instead of str-in-conf.
- --mode no longer defaults to 'client', which is what made the dead
  --stop/--mode guards dead; both guards are replaced by one required-argument
  check.

Bugs fixed
- A no-argument run crashed with a TypeError deep in the relay and exited 0.
  It now prints usage on stderr and exits 2.
- An unknown format name, an unusable format, an unreadable key file and a
  refused bind all exited 0. Formats and the key are validated on the main
  thread before anything is printed, bound, or written to disk; the listener's
  bind moved out of the listener thread (relay.listener.bind()) so a taken
  port is a startup failure rather than a thread that dies while the process
  exits 0.
- Exit statuses are now 0 clean shutdown, 1 runtime failure, 2 usage.

Logging
- fatal_error/warn/info become thin wrappers over a 'fteproxy' logger, plus a
  new debug(). fteproxy.cli attaches a stderr handler and sets the level from
  -q (ERROR), the default (INFO) or -v (DEBUG). Nothing writes to stdout any
  more except command output, so `fteproxy formats` is pipeable. The dead
  runtime.loglevel config key is removed.
- The licence banner is no longer printed on every run; --version prints it.

New
- `fteproxy formats [--release YYYYMMDD]` lists each base format name with its
  covertext length and message capacity per direction, marking the default.
  argparse subparsers are introduced here, with the flat interface kept as the
  default command until PR4 replaces it.

Deviations from the plan: none of substance. The plan does not say when the
licence banner goes away; it is dropped here rather than in PR4 because PR1
already moves every other message off stdout. SIGTERM joins SIGINT as a clean
shutdown signal now rather than in PR4, since the shutdown path was being
rewritten anyway.

Tests: new fteproxy/tests/test_cli.py (33 cases) for the parser, the apply
step, key validation, exit statuses and the formats subcommand; test_system.py
gains the no-argument, invalid-format and formats-subcommand cases and pins
the exact status codes; conftest.py restores the package logger after each
test; the two tests that asserted on stdout from the old print-based logging
now use caplog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
