### PR TITLE
PR2: keypair handshake, session keys, record types

### DIFF
--- a/examples/chat/client.py
+++ b/examples/chat/client.py
@@ -3,16 +3,23 @@
 FTE Chat Client
 
 A simple chat client that has a 10-round conversation with the server.
-All traffic is FTE-encoded to look like binary (0s and 1s) or letters (As and Bs).
+All traffic is FTE-encoded to look like binary (0s and 1s).
+
+The client picks the format and the record-layer mode; the server follows.
+All it needs of the server is the server-id below.
 """
 
 import sys
 import socket
 import fteproxy
 
-# Format definitions - must match server
-CLIENT_TO_SERVER = '^(0|1)+$'   # Client sends as binary
-SERVER_TO_CLIENT = '^(A|B)+$'   # Server sends as A/B letters
+# The server-id: the public half of the demo server's keypair, which is all a
+# client ever needs. A real client reads this out of a connection string.
+DEMO_SERVER_ID = "g7RzVlLwycSzfHmHwo2LOdkvZ2rG_-J4lmsosmKPzQY"
+
+# A base name from the definitions file: the server derives the request and
+# response formats from it. `fteproxy formats` lists them all.
+FORMAT = "binary"
 
 HOST = '127.0.0.1'
 PORT = 50007
@@ -36,19 +43,14 @@ def main():
     print("FTE Chat Client")
     print("=" * 50)
     print(f"Connecting to {HOST}:{PORT}")
-    print(f"Client->Server format: binary (0s and 1s)")
-    print(f"Server->Client format: letters (As and Bs)")
+    print(f"Format: {FORMAT} (0s and 1s in both directions)")
     print("=" * 50)
     print()
 
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock = fteproxy.wrap_socket(sock,
-                                    outgoing_regex=CLIENT_TO_SERVER,
-                                    outgoing_length=520,
-                                    incoming_regex=SERVER_TO_CLIENT,
-                                    incoming_length=520,
-                                    negotiate=False)
+        sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID,
+                                    format=FORMAT)
         sock.connect((HOST, PORT))
         print("Connected!")
         print()

--- a/examples/chat/server.py
+++ b/examples/chat/server.py
@@ -3,16 +3,23 @@
 FTE Chat Server
 
 A simple chat server that has a 10-round conversation with the client.
-All traffic is FTE-encoded to look like binary (0s and 1s) or letters (As and Bs).
+All traffic is FTE-encoded to look like binary (0s and 1s).
+
+The server is told nothing about the format: it learns it, and the
+record-layer mode, from the client's first record, and proves its identity
+with the private key below.
 """
 
 import sys
 import socket
 import fteproxy
 
-# Format definitions - must match client
-CLIENT_TO_SERVER = '^(0|1)+$'   # Client sends as binary
-SERVER_TO_CLIENT = '^(A|B)+$'   # Server sends as A/B letters
+# A fixed demo identity so the two scripts agree without exchanging anything.
+# The private key is published here on purpose: it is a demo. A real server
+# generates its own with `fteproxy keygen`, keeps server.key at mode 0600, and
+# hands out only the public half.
+DEMO_SERVER_KEY = bytes.fromhex(
+    "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
 
 HOST = ''       # All interfaces
 PORT = 50007
@@ -36,20 +43,14 @@ def main():
     print("FTE Chat Server")
     print("=" * 50)
     print(f"Listening on port {PORT}")
-    print(f"Client->Server format: binary (0s and 1s)")
-    print(f"Server->Client format: letters (As and Bs)")
+    print("Format and mode: whatever the client asks for")
     print("=" * 50)
     print()
 
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock = fteproxy.wrap_socket(sock,
-                                    outgoing_regex=SERVER_TO_CLIENT,
-                                    outgoing_length=520,
-                                    incoming_regex=CLIENT_TO_SERVER,
-                                    incoming_length=520,
-                                    negotiate=False)
+        sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
         sock.bind((HOST, PORT))
         sock.listen(1)
 

--- a/examples/integration/secure_chat.py
+++ b/examples/integration/secure_chat.py
@@ -11,9 +11,16 @@ import sys
 import threading
 import fteproxy
 
-# Chat traffic will look like space-separated words
-SEND_FORMAT = "^([a-z]+ )+[a-z]+$"
-RECV_FORMAT = "^([A-Z]+ )+[A-Z]+$"
+# A fixed demo identity so the two scripts agree without exchanging anything.
+# The private key is published here on purpose: it is a demo. A real server
+# generates its own with `fteproxy keygen`, keeps server.key at mode 0600, and
+# hands out only the public half.
+DEMO_SERVER_KEY = bytes.fromhex(
+    "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
+DEMO_SERVER_ID = fteproxy.server_id(DEMO_SERVER_KEY)
+
+# Chat traffic will look like space-separated words.
+FORMAT = "words"
 
 PORT = 50009
 
@@ -39,15 +46,8 @@ def chat_server():
     print(f"Waiting for connection on port {PORT}...")
     
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock = fteproxy.wrap_socket(
-        sock,
-        outgoing_regex=RECV_FORMAT,  # Server sends in UPPERCASE format
-        outgoing_length=256,
-        incoming_regex=SEND_FORMAT,   # Client sends in lowercase format
-        incoming_length=256,
-        negotiate=False
-    )
-    
+    sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
+
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", PORT))
     sock.listen(1)
@@ -78,15 +78,8 @@ def chat_client(host: str):
     print(f"Connecting to {host}:{PORT}...")
     
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock = fteproxy.wrap_socket(
-        sock,
-        outgoing_regex=SEND_FORMAT,   # Client sends in lowercase format
-        outgoing_length=256,
-        incoming_regex=RECV_FORMAT,   # Server sends in UPPERCASE format
-        incoming_length=256,
-        negotiate=False
-    )
-    
+    sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID, format=FORMAT)
+
     sock.connect((host, PORT))
     print("Connected!")
     print("Type messages and press Enter. Ctrl+C to quit.\n")

--- a/examples/programmatic/echo_client.py
+++ b/examples/programmatic/echo_client.py
@@ -4,15 +4,21 @@ FTE-Powered Echo Client
 
 Connects to the FTE echo server and sends a message.
 The transmitted data looks like space-separated words to any observer.
+
+The client picks the format; the server follows. All it needs of the server
+is the server-id below.
 """
 
 import sys
 import socket
 import fteproxy
 
-# Must match the server's formats (but reversed for directions)
-CLIENT_TO_SERVER = "^([a-z]+ )+[a-z]+$"
-SERVER_TO_CLIENT = "^([A-Z]+ )+[A-Z]+$"
+# The server-id: the public half of the demo server's keypair, which is all a
+# client ever needs. A real client reads this out of a connection string.
+DEMO_SERVER_ID = "g7RzVlLwycSzfHmHwo2LOdkvZ2rG_-J4lmsosmKPzQY"
+
+# A base name from the definitions file. `fteproxy formats` lists them all.
+FORMAT = "words"
 
 HOST = "127.0.0.1"
 PORT = 50007
@@ -28,15 +34,9 @@ def main():
         # Create a regular TCP socket
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         
-        # Wrap it with FTE encoding
-        sock = fteproxy.wrap_socket(
-            sock,
-            outgoing_regex=CLIENT_TO_SERVER,
-            outgoing_length=256,
-            incoming_regex=SERVER_TO_CLIENT,
-            incoming_length=256,
-            negotiate=False
-        )
+        # Wrap it with FTE encoding, in the client role
+        sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID,
+                                    format=FORMAT)
         
         sock.connect((HOST, PORT))
         

--- a/examples/programmatic/echo_server.py
+++ b/examples/programmatic/echo_server.py
@@ -4,17 +4,21 @@ FTE-Powered Echo Server
 
 Listens for FTE-encoded connections and echoes back any received data.
 The transmitted data looks like space-separated words to any observer.
+
+The server is told no format at all: it learns the format and the
+record-layer mode from the client's first record.
 """
 
 import sys
 import socket
 import fteproxy
 
-# Define the regex formats for each direction
-# Client->Server: looks like lowercase words
-CLIENT_TO_SERVER = "^([a-z]+ )+[a-z]+$"
-# Server->Client: looks like UPPERCASE words  
-SERVER_TO_CLIENT = "^([A-Z]+ )+[A-Z]+$"
+# A fixed demo identity so the two scripts agree without exchanging anything.
+# The private key is published here on purpose: it is a demo. A real server
+# generates its own with `fteproxy keygen`, keeps server.key at mode 0600, and
+# hands out only the public half.
+DEMO_SERVER_KEY = bytes.fromhex(
+    "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
 
 HOST = ""          # All interfaces
 PORT = 50007       # Arbitrary port
@@ -24,8 +28,7 @@ def main():
     print("FTE Echo Server")
     print("===============")
     print(f"Listening on port {PORT}")
-    print(f"Client->Server format: words (lowercase)")
-    print(f"Server->Client format: WORDS (UPPERCASE)")
+    print("Format and mode: whatever the client asks for")
     print()
     
     try:
@@ -33,15 +36,8 @@ def main():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         
-        # Wrap it with FTE encoding
-        sock = fteproxy.wrap_socket(
-            sock,
-            outgoing_regex=SERVER_TO_CLIENT,
-            outgoing_length=256,
-            incoming_regex=CLIENT_TO_SERVER,
-            incoming_length=256,
-            negotiate=False  # Both sides know the formats
-        )
+        # Wrap it with FTE encoding, in the server role
+        sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
         
         sock.bind((HOST, PORT))
         sock.listen(1)

--- a/examples/programmatic/file_transfer.py
+++ b/examples/programmatic/file_transfer.py
@@ -16,9 +16,17 @@ import threading
 import tempfile
 import fteproxy
 
-# Formats for file transfer
-SENDER_FORMAT = "^([a-z]+ )+[a-z]+$"
-RECEIVER_FORMAT = "^([A-Z]+ )+[A-Z]+$"
+# A fixed demo identity so the two scripts agree without exchanging anything.
+# The private key is published here on purpose: it is a demo. A real server
+# generates its own with `fteproxy keygen`, keeps server.key at mode 0600, and
+# hands out only the public half.
+DEMO_SERVER_KEY = bytes.fromhex(
+    "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
+DEMO_SERVER_ID = fteproxy.server_id(DEMO_SERVER_KEY)
+
+# A base name from the definitions file: the traffic looks like lowercase
+# words in both directions. `fteproxy formats` lists them all.
+FORMAT = "words"
 
 PORT = 50008
 CHUNK_SIZE = 4096
@@ -42,15 +50,8 @@ def send_file(filename: str, host: str = "127.0.0.1"):
     
     # Create FTE socket
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock = fteproxy.wrap_socket(
-        sock,
-        outgoing_regex=SENDER_FORMAT,
-        outgoing_length=256,
-        incoming_regex=RECEIVER_FORMAT,
-        incoming_length=256,
-        negotiate=False
-    )
-    
+    sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID, format=FORMAT)
+
     sock.connect((host, PORT))
     
     # Send file info first (filename and size)
@@ -72,15 +73,8 @@ def receive_file(save_dir: str = "."):
     
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock = fteproxy.wrap_socket(
-        sock,
-        outgoing_regex=RECEIVER_FORMAT,
-        outgoing_length=256,
-        incoming_regex=SENDER_FORMAT,
-        incoming_length=256,
-        negotiate=False
-    )
-    
+    sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
+
     sock.bind(("", PORT))
     sock.listen(1)
     

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -6,13 +6,18 @@ __version__ = "0.4.0"
 import os
 import sys
 import hmac
+import collections
 import functools
 import logging
+import re
 import socket
 import hashlib
+import threading
+import time
 
 import fteproxy.conf
 import fteproxy.defs
+import fteproxy.handshake
 import fteproxy.record_layer
 
 import fte
@@ -20,38 +25,65 @@ import fte
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from fteproxy.handshake import generate_server_key, server_id
+
 
 @functools.lru_cache(maxsize=256)
+def _regex_format(pattern, length):
+    """The cached half of a libfte cipher: the compiled DFA.
+
+    ``fte.RegexFormat`` compiles the pattern's DFA and builds its ranking
+    tables, which is the expensive part of standing a cipher up and depends
+    only on ``(pattern, length)``. libfte 0.3 cached this globally; 0.4 does
+    not, and fteproxy builds a cipher per connection, so caching it here is
+    what keeps connection setup at a few milliseconds.
+
+    The tables are read-only, so one instance serves every connection and
+    thread.
+    """
+    return fte.RegexFormat(pattern, length=length)
+
+
 def _make_cipher(pattern, length, key):
-    """Build a libfte 0.4 cipher that hides bytes as one fixed-length covertext.
+    """A libfte 0.4 cipher that hides bytes as one fixed-length covertext.
 
     ``pattern`` is the regex whose language the covertext is drawn from;
-    ``length`` picks the fixed covertext length. This replaces libfte 0.3's
-    ``fte.Encoder(regex, fixed_slice, key)``. The
+    ``length`` picks the fixed covertext length; ``key`` is 32 bytes. The
     cipher ``encrypt``/``decrypt`` one whole covertext per call; the record
     layer handles stream chunking and framing on top of it.
 
-    Cached. libfte 0.4 compiles the DFA afresh for every ``RegexFormat``
-    (0.5 to 1.5 ms per format, and libfte 0.3 cached it globally), while
-    fteproxy builds a cipher per socket and per negotiation attempt: that
-    turned connection setup from about 3 ms into about 9 ms. An ``fte.FTE``
-    holds only read-only tables and draws a fresh nonce on every call, so one
-    instance serves every connection and thread.
+    Deliberately not cached: since 0.4 every connection derives its own header
+    keys, so a cache keyed on the key would grow by one entry per connection
+    and never hit. ``fte.FTE`` holds only a reference to the (cached) format
+    and the key schedule, and costs a couple of microseconds to build.
     """
-    return fte.FTE(
-        output_format=fte.RegexFormat(pattern, length=length),
-        key=key,
-    )
+    return fte.FTE(output_format=_regex_format(pattern, length), key=key)
+
+
+@functools.lru_cache(maxsize=256)
+def _cover_cipher(pattern, length, key):
+    """The cipher for handshake records, cached.
+
+    ``K_cover`` is derived from the server's long-term public key, so it is
+    the same for every connection: unlike the session ciphers this one is
+    worth caching, and the server's first-record scan tries several of them
+    per connection.
+    """
+    return _make_cipher(pattern, length, key)
 
 
 def _hybrid_mode():
-    """Whether the record layer runs in 'hybrid' (fast bulk) mode.
+    """Whether this end's *default* record-layer mode is 'hybrid'.
 
     'hybrid' (the default) formats only a fixed-length header per record and
     carries the body as raw authenticated bytes: much faster for bulk transfer,
     but everything past the header looks like random data. 'format' (opt-in)
     transforms every covertext byte into the target format for full-stream
     realism. See ``runtime.fteproxy.record_layer.mode`` in ``fteproxy.conf``.
+
+    Since 0.4 the mode is not a setting both endpoints must match by hand: the
+    client puts its choice in the handshake and the server follows. This is
+    where the client's choice comes from when the caller does not pass one.
     """
     return fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode') == 'hybrid'
 
@@ -59,27 +91,32 @@ def _hybrid_mode():
 class _AEADBody:
     """AES-128-CTR + HMAC-SHA256 (Encrypt-then-MAC) carrier for hybrid-mode bodies.
 
-    Matches libfte's AE construction (the FTE paper's CTR+HMAC). Under
-    fteproxy's static shared key, Encrypt-then-MAC means a nonce collision costs
-    only the confidentiality of the colliding pair, never authenticity. Each
-    record binds its sequence number into the MAC, so a record reordered,
-    dropped, or replayed within its stream fails authentication. The key is
-    shared by every connection and both directions, so a record replayed at the
-    same position of another stream is not detected (see SECURITY.md). The
-    encryption and MAC subkeys are derived from a distinct namespace,
-    domain-separated from the header cipher's key. libfte does the
-    same construction for the formatted header; this is the raw-body counterpart
-    the FTE paper appended as unformatted ciphertext.
+    Matches libfte's AE construction (the FTE paper's CTR+HMAC). Encrypt-then-MAC
+    means a nonce collision costs only the confidentiality of the colliding
+    pair, never authenticity. Each record binds its sequence number into the
+    MAC, so a record reordered, dropped, or replayed within its stream fails
+    authentication. Since 0.4 the key is per connection *and* per direction
+    (``K_c2s_body`` / ``K_s2c_body`` from :mod:`fteproxy.handshake`), so a
+    record replayed into another connection or the other direction fails too --
+    the cross-stream replay gap SECURITY.md used to document. The encryption
+    and MAC subkeys are derived from a distinct namespace, domain-separated
+    from the header cipher's key. libfte does the same construction for the
+    formatted header; this is the raw-body counterpart the FTE paper appended
+    as unformatted ciphertext.
     """
     _NONCE = 12
     _TAG = 16
     _COUNTER = 16  # AES block: 12-byte nonce || 4-byte block counter
-    # Largest body a single record carries. Bounds memory and amortizes the one
-    # formatted header per record over a large payload.
+    # The record layer prepends a one-byte record type before sealing.
+    _TYPE = 1
+    # Largest payload a single record carries. Bounds memory and amortizes the
+    # one formatted header per record over a large payload. The type byte is
+    # not taken out of it: unlike a covertext, the body has no fixed width, so
+    # a 1 MiB write still travels as exactly one record.
     max_plaintext_bytes = 2 ** 20
     # Largest framed body (nonce || ciphertext || tag) a header may announce;
     # the decoder refuses to buffer more than this for one record.
-    max_framed_bytes = max_plaintext_bytes + _NONCE + _TAG
+    max_framed_bytes = max_plaintext_bytes + _TYPE + _NONCE + _TAG
 
     def __init__(self, key):
         self._enc_key = hashlib.sha256(key + b'fteproxy/record-layer/body/enc/v3').digest()[:16]
@@ -114,33 +151,45 @@ def _make_body_cipher(key):
     return _AEADBody(key)
 
 
-def _record_encoder(header_cipher, key):
-    body = _make_body_cipher(key) if _hybrid_mode() else None
-    return fteproxy.record_layer.Encoder(cipher=header_cipher, body_cipher=body)
+# --------------------------------------------------------------------------- #
+# Logging
+# --------------------------------------------------------------------------- #
 
+class RedactingFilter(logging.Filter):
+    """Strips secrets out of every record logged through ``fteproxy``.
 
-def _record_decoder(header_cipher, key):
-    body = _make_body_cipher(key) if _hybrid_mode() else None
-    return fteproxy.record_layer.Decoder(cipher=header_cipher, body_cipher=body)
+    A backstop, not a licence: no call site should format a key, a server-id
+    or handshake material into a message in the first place. What this catches
+    is the case nobody thought of -- an exception's ``str()``, a connection
+    string echoed in an error, a hex key pasted into a debug line -- because a
+    log file is the easiest place for a server-id to escape to.
 
-
-class InvalidRoleException(Exception):
-    pass
-
-
-class NegotiationFailedException(Exception):
-    pass
-
-
-class ChannelNotReadyException(Exception):
-    pass
-
-
-class NegotiateTimeoutException(Exception):
-
-    """Raised when negotiation fails to complete after """ + str(fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')) + """ seconds.
+    Installed on the package logger at import, so it applies to every handler,
+    including one an embedding program attaches.
     """
-    pass
+
+    _PATTERNS = (
+        # A connection string: keep the shape, drop the server-id.
+        (re.compile(r'fte://[A-Za-z0-9_\-]+@'), 'fte://…@'),
+        # 16 bytes or more of hex: a key, a MAC, or a transcript hash.
+        (re.compile(r'(?<![0-9A-Fa-f])[0-9A-Fa-f]{32,}(?![0-9A-Fa-f])'),
+         '<redacted>'),
+        # A bare 43-character base64url token is a 32-byte public key.
+        (re.compile(r'(?<![A-Za-z0-9_\-])[A-Za-z0-9_\-]{43}(?![A-Za-z0-9_\-])'),
+         '<redacted>'),
+    )
+
+    def filter(self, record):
+        message = record.getMessage()
+        redacted = message
+        for pattern, replacement in self._PATTERNS:
+            redacted = pattern.sub(replacement, redacted)
+        if redacted != message:
+            # Collapse to a plain string: the arguments are what carried the
+            # secret, so they must not survive for a handler to re-expand.
+            record.msg = redacted
+            record.args = ()
+        return True
 
 
 logger = logging.getLogger('fteproxy')
@@ -152,6 +201,7 @@ fteproxy never changes an application's logging setup.
 Logging goes to stderr, never stdout, so a command whose output is data (for
 example ``fteproxy formats``) stays pipeable.
 """
+logger.addFilter(RedactingFilter())
 
 
 def fatal_error(msg):
@@ -182,245 +232,473 @@ def debug(msg):
     logger.debug(msg)
 
 
-class NegotiateCell(object):
-    _CELL_SIZE = 64
-    _PADDING_LEN = 32
-    _PADDING_CHAR = b'\x00'
-    _DATE_FORMAT = b'YYYYMMDD'
+# --------------------------------------------------------------------------- #
+# Exceptions
+# --------------------------------------------------------------------------- #
 
-    def __init__(self):
-        self._def_file = b""
-        self._language = b""
-
-    def setDefFile(self, def_file):
-        if isinstance(def_file, str):
-            def_file = def_file.encode('utf-8')
-        self._def_file = def_file
-
-    def getDefFile(self):
-        if isinstance(self._def_file, bytes):
-            return self._def_file.decode('utf-8')
-        return self._def_file
-
-    def setLanguage(self, language):
-        if isinstance(language, str):
-            language = language.encode('utf-8')
-        self._language = language
-
-    def getLanguage(self):
-        if isinstance(self._language, bytes):
-            return self._language.decode('utf-8')
-        return self._language
-
-    def toBytes(self):
-        retval = b''
-        retval += self._def_file
-        retval += self._language
-        retval = retval.rjust(NegotiateCell._CELL_SIZE, NegotiateCell._PADDING_CHAR)
-        assert retval[:NegotiateCell._PADDING_LEN] == NegotiateCell._PADDING_CHAR * \
-            NegotiateCell._PADDING_LEN
-        return retval
-
-    def fromBytes(self, negotiate_cell_bytes):
-        assert len(negotiate_cell_bytes) == NegotiateCell._CELL_SIZE
-        assert negotiate_cell_bytes[
-            :NegotiateCell._PADDING_LEN] == NegotiateCell._PADDING_CHAR * NegotiateCell._PADDING_LEN
-        negotiate_cell_bytes = negotiate_cell_bytes.strip(
-            NegotiateCell._PADDING_CHAR)
-        # 8==len(YYYYMMDD)
-        def_file = negotiate_cell_bytes[:len(NegotiateCell._DATE_FORMAT)]
-        language = negotiate_cell_bytes[len(NegotiateCell._DATE_FORMAT):]
-        negotiate_cell = NegotiateCell()
-        negotiate_cell.setDefFile(def_file)
-        negotiate_cell.setLanguage(language)
-        return negotiate_cell
+class InvalidRoleException(Exception):
+    """``wrap_socket`` was given neither, or both, of a server key and a
+    server-id."""
 
 
-class NegotiationManager(object):
+class HandshakeFailedException(Exception):
+    """This connection will never carry a session.
 
-    def __init__(self, K1, K2):
-        self._negotiationComplete = False
-        self._K1 = K1
-        self._K2 = K2
-
-    def _key(self):
-        # libfte 0.4 requires an explicit 32-byte key; the old "key=None means
-        # generate a random key" path is gone (and never interoperated across a
-        # client/server pair anyway). Fall back to the configured shared key.
-        if self._K1 and self._K2:
-            return self._K1 + self._K2
-        return fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-
-    def getNegotiationComplete(self):
-        return self._negotiationComplete
-
-    def _acceptNegotiation(self, data):
-
-        languages = fteproxy.defs.load_definitions()
-
-        # Try the configured upstream language first. The server otherwise scans
-        # request-languages in definition order and attempts a decode against
-        # each until one succeeds; the default is near the end of that list, so
-        # every connection pays ~20 failed decodes before matching. A client and
-        # server sharing config (the common case) now match on the first try,
-        # while non-default clients still fall through to the full scan.
-        preferred = fteproxy.conf.getValue('runtime.state.upstream_language')
-        scan_order = ([preferred] if preferred in languages else []) + \
-            [lang for lang in languages.keys() if lang != preferred]
-
-        for incoming_language in scan_order:
-            try:
-                if incoming_language.endswith('response'):
-                    continue
-
-                incoming_regex = fteproxy.defs.getRegex(incoming_language)
-                incoming_length = fteproxy.defs.getLength(
-                    incoming_language)
-
-                key = self._key()
-                incoming_cipher = _make_cipher(incoming_regex, incoming_length, key)
-                decoder = _record_decoder(incoming_cipher, key)
-
-                decoder.push(data)
-                negotiate_cell = decoder.pop(oneCell=True)
-                NegotiateCell().fromBytes(negotiate_cell)
-
-                return [negotiate_cell, decoder._buffer]
-            except Exception as e:
-                fteproxy.info('Failed to decode first message as '+incoming_language+': '+str(e))
-
-        raise NegotiationFailedException()
-
-    def _init_encoders(self,
-                       outgoing_regex, outgoing_length,
-                       incoming_regex, incoming_length):
-
-        encoder = None
-        decoder = None
-
-        key = self._key()
-
-        if outgoing_regex != None and outgoing_length != -1:
-            outgoing_cipher = _make_cipher(outgoing_regex, outgoing_length, key)
-            encoder = _record_encoder(outgoing_cipher, key)
-
-        if incoming_regex != None and incoming_length != -1:
-            incoming_cipher = _make_cipher(incoming_regex, incoming_length, key)
-            decoder = _record_decoder(incoming_cipher, key)
-
-        return [encoder, decoder]
-
-    def _makeNegotiationCell(self, encoder):
-        negotiate_cell = NegotiateCell()
-        def_file = fteproxy.conf.getValue('fteproxy.defs.release')
-        negotiate_cell.setDefFile(def_file)
-        language = fteproxy.conf.getValue('runtime.state.upstream_language')
-        language = language[:-len('-request')]
-        negotiate_cell.setLanguage(language)
-        encoder.push(negotiate_cell.toBytes())
-        data = encoder.pop()
-        return data
-
-    def makeClientNegotiationCell(self,
-                                  outgoing_regex, outgoing_length,
-                                  incoming_regex, incoming_length):
-        [encoder, decoder] = self._init_encoders(
-            outgoing_regex, outgoing_length, incoming_regex, incoming_length)
-        return self._makeNegotiationCell(encoder)
-
-    def doServerSideNegotiation(self, data):
-        [negotiate_cell, remaining_buffer] = self._acceptNegotiation(data)
-
-        negotiate = NegotiateCell().fromBytes(negotiate_cell)
-
-        outgoing_language = negotiate.getLanguage() + '-response'
-        incoming_language = negotiate.getLanguage() + '-request'
-
-        outgoing_regex = fteproxy.defs.getRegex(outgoing_language)
-        outgoing_length = fteproxy.defs.getLength(outgoing_language)
-        incoming_regex = fteproxy.defs.getRegex(incoming_language)
-        incoming_length = fteproxy.defs.getLength(incoming_language)
-
-        [encoder, decoder] = self._init_encoders(
-            outgoing_regex, outgoing_length, incoming_regex, incoming_length)
-
-        decoder.push(remaining_buffer)
-
-        return [encoder, decoder]
+    On the server this is answered by silence: read and discard for a random
+    interval, then close, so a prober cannot tell which check failed, or that
+    anything was there to fail.
+    """
 
 
-class FTEHelper(object):
-
-    def _processRecv(self, data):
-        retval = data
-        if self._isServer and not self._negotiationComplete:
-            try:
-                self._preNegotiationBuffer_incoming += data
-                [encoder, decoder] = self._negotiation_manager.doServerSideNegotiation(
-                    self._preNegotiationBuffer_incoming)
-                self._encoder = encoder
-                self._decoder = decoder
-                self._preNegotiationBuffer_incoming = b''
-                self._negotiationComplete = True
-                retval = b''
-            except Exception as e:
-                raise ChannelNotReadyException()
-
-        return retval
-
-    def _processSend(self):
-        retval = b''
-        if self._isClient and not self._negotiationComplete:
-            [encoder, decoder] = self._negotiation_manager._init_encoders(
-                self._outgoing_regex,
-                self._outgoing_length,
-                self._incoming_regex,
-                self._incoming_length)
-            self._encoder = encoder
-            self._decoder = decoder
-            negotiation_cell = self._negotiation_manager.makeClientNegotiationCell(
-                self._outgoing_regex, self._outgoing_length,
-                self._incoming_regex, self._incoming_length)
-            retval = negotiation_cell
-            self._negotiationComplete = True
-        return retval
+class HandshakeTimeoutException(HandshakeFailedException):
+    """No valid handshake reply arrived within the negotiate timeout."""
 
 
-class _FTESocketWrapper(FTEHelper, object):
+class ChannelNotReadyException(Exception):
+    """The handshake has not completed, so this call cannot be served yet."""
 
-    def __init__(self, _socket,
-                 outgoing_regex=None, outgoing_length=-1,
-                 incoming_regex=None, incoming_length=-1,
-                 K1=None, K2=None,
-                 negotiate=True):
 
+class _NeedMoreData(Exception):
+    """Internal: the server has not yet buffered a whole client hello."""
+
+
+class _PeerClosed(Exception):
+    """Internal: the peer closed before the handshake could complete."""
+
+
+# --------------------------------------------------------------------------- #
+# Session set-up
+# --------------------------------------------------------------------------- #
+
+#: The base name of the request format that most recently matched a client
+#: hello. The server's first-record scan tries it first, so a server whose
+#: clients share a format pays one decrypt attempt per connection instead of
+#: one per candidate format. Process-wide and advisory: a wrong guess only
+#: costs the rest of the scan.
+_last_matched_format = None
+
+#: Client ephemeral keys seen inside the epoch window, shared by every
+#: connection this process accepts.
+_replay_filter = fteproxy.handshake.ReplayFilter()
+
+
+def _format_pair(base):
+    """``('base-request', 'base-response')``, validated against the
+    definitions."""
+    request, response = base + '-request', base + '-response'
+    fteproxy.defs.getRegex(request)
+    fteproxy.defs.getRegex(response)
+    return request, response
+
+
+def _cipher_for(format_name, key, cover=False):
+    build = _cover_cipher if cover else _make_cipher
+    return build(fteproxy.defs.getRegex(format_name),
+                 fteproxy.defs.getLength(format_name), key)
+
+
+def _session_channel(base, mode, keys, is_client):
+    """Build the ``(Encoder, Decoder)`` pair for one end of a session.
+
+    Each direction gets its own header key and body key, so the two directions
+    are cryptographically independent streams that happen to share a socket.
+    """
+    request, response = _format_pair(base)
+    outgoing, incoming = ((request, response) if is_client
+                          else (response, request))
+    out_header, out_body = keys.outgoing(is_client)
+    in_header, in_body = keys.incoming(is_client)
+    hybrid = (mode == fteproxy.handshake.MODE_HYBRID)
+    encoder = fteproxy.record_layer.Encoder(
+        cipher=_cipher_for(outgoing, out_header),
+        body_cipher=_make_body_cipher(out_body) if hybrid else None)
+    decoder = fteproxy.record_layer.Decoder(
+        cipher=_cipher_for(incoming, in_header),
+        body_cipher=_make_body_cipher(in_body) if hybrid else None)
+    return encoder, decoder
+
+
+def _request_scan_order():
+    """Candidate request formats, most-recently-matched first."""
+    definitions = fteproxy.defs.load_definitions()
+    names = [name for name in definitions if name.endswith('-request')]
+    preferred = _last_matched_format
+    if preferred in names:
+        return [preferred] + [name for name in names if name != preferred]
+    return names
+
+
+# --------------------------------------------------------------------------- #
+# The socket wrapper
+# --------------------------------------------------------------------------- #
+
+class _FTESocketWrapper(object):
+    """A socket whose bytes travel as a sequence of format-transformed records.
+
+    One of two roles, decided by which key ``wrap_socket`` was given:
+
+    client
+        holds the server-id, opens with a client hello, and will not send an
+        application byte until a server hello has proved the peer holds the
+        matching private key.
+
+    server
+        holds the private key, learns the format and the mode from the first
+        record, and answers a hello it cannot validate with silence rather
+        than an error.
+
+    Threading: one reader and one writer, as the relay uses it. The handshake
+    lock serialises the two while it runs, since neither direction has keys
+    until it finishes, and is released before any long read so a slow peer in
+    one direction never blocks the other.
+    """
+
+    #: Never buffer more than this waiting for a client hello, or waiting for
+    #: the handshake before the server can send. A hello is one covertext;
+    #: anything beyond the largest format plus a margin is a peer that is not
+    #: speaking this protocol.
+    _MAX_PRE_HANDSHAKE_BYTES = 1 << 16
+
+    def __init__(self, _socket, role, server_key=None, server_public=None,
+                 format=None, mode=None, defs=None):
         self._socket = _socket
-        self._outgoing_regex = outgoing_regex
-        self._outgoing_length = outgoing_length
-        self._incoming_regex = incoming_regex
-        self._incoming_length = incoming_length
-        self._K1 = K1
-        self._K2 = K2
-        self._negotiate = negotiate
+        self._role = role
+        self._server_key = server_key
+        self._server_public = server_public
+        self._format = format
+        self._mode = mode
+        self._defs = defs
+        self._cover_key = fteproxy.handshake.cover_key(server_public)
 
-        self._negotiation_manager = NegotiationManager(K1, K2)
+        self._handshake_lock = threading.RLock()
+        self._send_lock = threading.RLock()
+        self._handshake_done = False
+        self._encoder = None
+        self._decoder = None
         self._incoming_buffer = b''
-        self._preNegotiationBuffer_outgoing = b''
-        self._preNegotiationBuffer_incoming = b''
+        self._pre_handshake_incoming = b''
+        self._pre_handshake_outgoing = b''
+        self._control = collections.deque()
+        self._peer_closed = False
+        self._reject_deadline = None
+        self._negotiated_format = None
+        self._negotiated_mode = None
 
-        if negotiate:
-            # Standard relay mode: client sends negotiation cell, server waits for it
-            self._negotiationComplete = False
-            self._isServer = (outgoing_regex is None and incoming_regex is None)
-            self._isClient = (outgoing_regex is not None and incoming_regex is not None)
-        else:
-            # No negotiation: both sides know the formats, set up encoders immediately
-            self._negotiationComplete = True
-            self._isServer = False
-            self._isClient = False
-            [self._encoder, self._decoder] = self._negotiation_manager._init_encoders(
-                outgoing_regex, outgoing_length,
-                incoming_regex, incoming_length)
+    # -- properties -------------------------------------------------------- #
+
+    @property
+    def negotiated_format(self):
+        """The base format name in use, once the handshake has completed."""
+        return self._negotiated_format
+
+    @property
+    def negotiated_mode(self):
+        """``'hybrid'`` or ``'format'``, once the handshake has completed."""
+        return self._negotiated_mode
+
+    @property
+    def handshake_complete(self):
+        return self._handshake_done
+
+    # -- handshake --------------------------------------------------------- #
+
+    def handshake(self):
+        """Complete the handshake now, blocking until it succeeds or fails.
+
+        Idempotent. A client calls this straight after ``connect`` so that a
+        bad connection string fails immediately rather than at the first byte.
+        A server may call it too, once it has a connection to read from.
+        """
+        leftover = self._ensure_handshake()
+        if leftover:
+            self._decode(leftover)
+
+    def _ensure_handshake(self):
+        """Run the handshake if it has not run. Returns any bytes that arrived
+        behind the client hello, which belong to the session stream."""
+        with self._handshake_lock:
+            if self._handshake_done:
+                return b''
+            if self._role == 'client':
+                self._client_handshake()
+                return b''
+            try:
+                return self._await_client_hello()
+            except HandshakeFailedException as e:
+                self._begin_reject(e)
+                raise
+
+    def _client_handshake(self):
+        request, response = _format_pair(self._format)
+        driver = fteproxy.handshake.ClientHandshake(
+            server_public=self._server_public, format=self._format,
+            mode=self._mode, defs=self._defs)
+        request_cipher = _cipher_for(request, self._cover_key, cover=True)
+        response_cipher = _cipher_for(response, self._cover_key, cover=True)
+
+        sealed = fteproxy.record_layer._seal(request_cipher,
+                                             driver.hello_bytes, 0)
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        try:
+            self._socket.sendall(sealed)
+            frame = self._read_exactly(
+                response_cipher.output_format.max_length, timeout)
+        except OSError as e:
+            raise HandshakeFailedException('handshake I/O failed: %s' % e)
+        if frame is None:
+            raise HandshakeTimeoutException(
+                'no valid handshake reply within %ss (wrong connection '
+                'string, or the peer is not running fteproxy 0.4)' % timeout)
+
+        try:
+            plaintext = response_cipher.decrypt(frame)
+        except fte.FTEError:
+            raise HandshakeFailedException(
+                'the reply did not unseal as a %s covertext (wrong connection '
+                'string, format, or definitions release)' % response)
+        reply = fteproxy.record_layer._unseal(plaintext, 0)
+        if reply is None:
+            raise HandshakeFailedException('malformed server hello frame')
+        try:
+            keys = driver.finish(reply)
+        except fteproxy.handshake.HandshakeError as e:
+            raise HandshakeFailedException(str(e))
+
+        self._negotiated_format = self._format
+        self._negotiated_mode = self._mode
+        self._encoder, self._decoder = _session_channel(
+            self._format, self._mode, keys, is_client=True)
+        self._handshake_done = True
+        fteproxy.debug('handshake complete: protocol 1, %s, %s'
+                       % (self._format, self._mode))
+        self._flush_pre_handshake_outgoing()
+
+    def _await_client_hello(self):
+        """Block until a client hello decodes, or the handshake deadline passes.
+
+        The server handshake is synchronous for the same reason the client's
+        is: until it completes there is no format, no mode and no keys, so
+        there is nothing useful to do with the socket. Bounding it also stops a
+        peer that opens a connection, sends a few bytes and falls silent from
+        holding a relay worker open indefinitely.
+        """
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        deadline = time.monotonic() + timeout
+        previous = self._socket.gettimeout()
+        try:
+            while True:
+                try:
+                    return self._server_handshake()
+                except _NeedMoreData:
+                    pass
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise HandshakeFailedException(
+                        'no client hello within %ss' % timeout)
+                self._socket.settimeout(remaining)
+                try:
+                    chunk = self._socket.recv(65536)
+                except socket.timeout:
+                    raise HandshakeFailedException(
+                        'no client hello within %ss' % timeout)
+                if not chunk:
+                    raise _PeerClosed()
+                self._pre_handshake_incoming += chunk
+        finally:
+            try:
+                self._socket.settimeout(previous)
+            except OSError:
+                pass
+
+    def _server_handshake(self):
+        """Try to complete the handshake from ``_pre_handshake_incoming``.
+
+        Tries each request format whose covertext could fit in what has
+        arrived, most-recently-matched first, and asks libfte to unseal the
+        leading covertext under ``K_cover``. A wrong guess is an
+        ``InvalidCovertextError`` from the AE tag, so the scan simply falls
+        through to the next candidate.
+
+        Returns the bytes left over after the hello. Raises
+        :class:`_NeedMoreData` while the hello could still be incomplete and
+        :class:`HandshakeFailedException` once it cannot be one.
+        """
+        buffered = self._pre_handshake_incoming
+        for name in _request_scan_order():
+            length = fteproxy.defs.getLength(name)
+            if len(buffered) < length:
+                continue
+            cipher = _cipher_for(name, self._cover_key, cover=True)
+            try:
+                plaintext = cipher.decrypt(buffered[:length])
+            except fte.FTEError:
+                continue
+            hello_bytes = fteproxy.record_layer._unseal(plaintext, 0)
+            if hello_bytes is None:
+                continue
+            base = name[:-len('-request')]
+            return self._accept_hello(base, hello_bytes, buffered[length:])
+
+        if len(buffered) > self._MAX_PRE_HANDSHAKE_BYTES:
+            raise HandshakeFailedException(
+                'no client hello in the first %d bytes' % len(buffered))
+        raise _NeedMoreData()
+
+    def _accept_hello(self, base, hello_bytes, remainder):
+        global _last_matched_format
+
+        try:
+            hello, reply_bytes, keys = fteproxy.handshake.accept_client_hello(
+                hello_bytes, self._server_key, self._server_public,
+                defs=self._defs, formats={base}, replay=_replay_filter)
+        except fteproxy.handshake.HandshakeError as e:
+            raise HandshakeFailedException(str(e))
+        if hello.format != base:
+            # The covertext format and the name inside it are the same fact
+            # stated twice; a disagreement is not a client.
+            raise HandshakeFailedException('hello format does not match its '
+                                           'covertext format')
+
+        _, response = _format_pair(base)
+        response_cipher = _cipher_for(response, self._cover_key, cover=True)
+        try:
+            self._socket.sendall(
+                fteproxy.record_layer._seal(response_cipher, reply_bytes, 0))
+        except OSError as e:
+            raise HandshakeFailedException('failed to send server hello: %s' % e)
+
+        self._negotiated_format = base
+        self._negotiated_mode = hello.mode
+        self._encoder, self._decoder = _session_channel(
+            base, hello.mode, keys, is_client=False)
+        self._handshake_done = True
+        _last_matched_format = base + '-request'
+        self._pre_handshake_incoming = b''
+        fteproxy.debug('handshake complete: protocol 1, %s, %s'
+                       % (base, hello.mode))
+        self._flush_pre_handshake_outgoing()
+        return remainder
+
+    def _flush_pre_handshake_outgoing(self):
+        pending, self._pre_handshake_outgoing = self._pre_handshake_outgoing, b''
+        if pending:
+            with self._send_lock:
+                self._encoder.push(pending)
+                out = self._encoder.pop()
+                if out:
+                    self._socket.sendall(out)
+
+    def _read_exactly(self, count, timeout):
+        """Read exactly ``count`` bytes within ``timeout`` seconds, or None.
+
+        Used only for the client's single handshake reply, whose length is
+        fixed by the response format.
+        """
+        deadline = time.monotonic() + timeout
+        previous = self._socket.gettimeout()
+        buffer = b''
+        try:
+            while len(buffer) < count:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._socket.settimeout(remaining)
+                try:
+                    chunk = self._socket.recv(count - len(buffer))
+                except socket.timeout:
+                    return None
+                if not chunk:
+                    return None
+                buffer += chunk
+            return buffer
+        finally:
+            try:
+                self._socket.settimeout(previous)
+            except OSError:
+                pass
+
+    # -- rejection --------------------------------------------------------- #
+
+    def _begin_reject(self, reason):
+        """Answer a failed handshake the way obfs4 does: with nothing.
+
+        No error, no close, no timing signal. The connection stays open,
+        reading and discarding, for a random interval, so an active prober
+        that guessed the connection string wrong learns only that something
+        accepted a TCP connection.
+        """
+        self._reject_deadline = time.monotonic() + fteproxy.handshake.reject_delay()
+        fteproxy.debug('rejecting handshake without reply: %s' % (reason,))
+
+    def _discard_until_deadline(self):
+        previous = self._socket.gettimeout()
+        try:
+            while True:
+                remaining = self._reject_deadline - time.monotonic()
+                if remaining <= 0:
+                    return b''
+                self._socket.settimeout(min(remaining, 0.5))
+                try:
+                    if self._socket.recv(65536) == b'':
+                        return b''
+                except socket.timeout:
+                    continue
+                except OSError:
+                    return b''
+        finally:
+            try:
+                self._socket.settimeout(previous)
+            except OSError:
+                pass
+
+    # -- records ----------------------------------------------------------- #
+
+    def _decode(self, data):
+        """Decode ``data`` into the incoming buffer and the control queue.
+
+        Returns False when the peer sent a record type this version does not
+        define, which the caller answers by closing: continuing would mean
+        guessing at the meaning of the bytes that follow.
+        """
+        self._decoder.push(data)
+        try:
+            records = self._decoder.pop_records()
+        except fteproxy.record_layer.UnknownRecordType as e:
+            fteproxy.warn('closing connection: %s' % e)
+            return False
+        for record_type, payload in records:
+            if record_type == fteproxy.record_layer.DATA:
+                self._incoming_buffer += payload
+            elif record_type == fteproxy.record_layer.CLOSE:
+                self._peer_closed = True
+            elif record_type == fteproxy.record_layer.PADDING:
+                continue
+            else:
+                self._control.append((record_type, payload))
+        return True
+
+    def send_record(self, record_type, payload=b''):
+        """Send one control record. Requires a completed handshake."""
+        self._ensure_handshake()
+        if not self._handshake_done:
+            raise ChannelNotReadyException(
+                'cannot send a control record before the handshake')
+        with self._send_lock:
+            self._socket.sendall(self._encoder.encode(record_type, payload))
+
+    def next_control_record(self):
+        """Pop the next received control record, or None."""
+        try:
+            return self._control.popleft()
+        except IndexError:
+            return None
+
+    @property
+    def peer_closed(self):
+        """Whether the peer has sent CLOSE: no more DATA will arrive."""
+        return self._peer_closed
+
+    # -- socket interface -------------------------------------------------- #
 
     def fileno(self):
         return self._socket.fileno()
@@ -434,76 +712,57 @@ class _FTESocketWrapper(FTEHelper, object):
         return self._socket.getsockopt(level, optname, buflen)
 
     def recv(self, bufsize):
-        # <HACK>
-        # Required to deal with case when client attempts to recv
-        # before sending. This checks to ensure that a negotiate
-        # cell is sent no matter what the client does first.
-        to_send = self._processSend()
-        if to_send:
-            numbytes = self._socket.send(to_send)
-            assert numbytes == len(to_send)
-        # </HACK>
-
+        if self._reject_deadline is not None:
+            return self._discard_until_deadline()
         try:
-            while True:
-                data = self._socket.recv(bufsize)
-                noData = (data == b'')
-                if noData and self._isServer and not self._negotiationComplete:
-                    # The peer closed before a negotiation cell decoded. Nothing
-                    # more will arrive, so report EOF. Treating this as "not
-                    # ready yet" (a socket.timeout) made the relay worker poll
-                    # the closed socket forever, since recv keeps returning b''.
-                    if self._preNegotiationBuffer_incoming:
-                        fteproxy.warn(
-                            'peer closed before negotiation completed: check '
-                            'that both endpoints share the key, '
-                            '--record-layer-mode, and the same fteproxy/libfte '
-                            'line (0.4 is not wire-compatible with 0.3)')
-                    else:
-                        fteproxy.info('peer closed without sending anything')
-                    return b''
-                data = self._processRecv(data)
+            leftover = self._ensure_handshake()
+        except _PeerClosed:
+            fteproxy.debug('peer closed before a client hello decoded'
+                           if self._pre_handshake_incoming
+                           else 'peer closed without sending anything')
+            return b''
+        except HandshakeFailedException:
+            return self._discard_until_deadline()
 
-                if noData and not self._incoming_buffer and not self._decoder._buffer:
-                    return b''
+        if leftover and not self._decode(leftover):
+            return b''
 
-                self._decoder.push(data)
-
-                while True:
-                    frag = self._decoder.pop()
-                    if not frag:
-                        break
-                    self._incoming_buffer += frag
-
-                if self._incoming_buffer:
-                    break
-
-                if noData:
-                    # The peer has closed the connection (recv returned b'').
-                    # No further bytes will ever arrive, so any undecodable data
-                    # still sitting in the decoder buffer (e.g. a covertext cell
-                    # the peer was cut off part-way through) can never complete.
-                    # Report EOF instead of busy-looping on the closed socket.
-                    return b''
-
-            retval = self._incoming_buffer
-            self._incoming_buffer = b''
-        except ChannelNotReadyException:
-            raise socket.timeout
-
-        return retval
-    
-    def send(self, data):
-        to_send = self._processSend()
-        if to_send:
-            self._socket.sendall(to_send)
-
-        self._encoder.push(data)
         while True:
-            to_send = self._encoder.pop()
-            if not to_send:
-                break
-            self._socket.sendall(to_send)
+            if self._incoming_buffer:
+                out, self._incoming_buffer = self._incoming_buffer, b''
+                return out
+            if self._peer_closed:
+                return b''
+
+            data = self._socket.recv(bufsize)
+            if not self._decode(data):
+                return b''
+            if data == b'' and not self._incoming_buffer:
+                # No further bytes will ever arrive, so anything still in the
+                # decoder's buffer can never complete. Report EOF instead of
+                # busy-looping on a closed socket.
+                return b''
+
+    def send(self, data):
+        with self._handshake_lock:
+            if not self._handshake_done:
+                if self._role == 'client':
+                    self._client_handshake()
+                else:
+                    # The server has not seen a hello yet, so it knows neither
+                    # the format nor the keys. Hold the bytes; a destination
+                    # that speaks first (an SSH or SMTP banner) is this case.
+                    if (len(self._pre_handshake_outgoing) + len(data)
+                            > self._MAX_PRE_HANDSHAKE_BYTES):
+                        raise ChannelNotReadyException(
+                            'too much data buffered before the handshake')
+                    self._pre_handshake_outgoing += data
+                    return len(data)
+        with self._send_lock:
+            self._encoder.push(data)
+            out = self._encoder.pop()
+            if out:
+                self._socket.sendall(out)
         return len(data)
 
     def sendall(self, data):
@@ -522,17 +781,17 @@ class _FTESocketWrapper(FTEHelper, object):
         return self._socket.close()
 
     def connect(self, addr):
-        return self._socket.connect(addr)
+        self._socket.connect(addr)
+        if self._role == 'client':
+            self.handshake()
 
     def accept(self):
         conn, addr = self._socket.accept()
-        conn = _FTESocketWrapper(conn,
-                                 self._outgoing_regex, self._outgoing_length,
-                                 self._incoming_regex, self._incoming_length,
-                                 self._K1, self._K2,
-                                 self._negotiate)
-
-        return conn, addr
+        return _FTESocketWrapper(conn, self._role,
+                                 server_key=self._server_key,
+                                 server_public=self._server_public,
+                                 format=self._format, mode=self._mode,
+                                 defs=self._defs), addr
 
     def bind(self, addr):
         return self._socket.bind(addr)
@@ -541,46 +800,76 @@ class _FTESocketWrapper(FTEHelper, object):
         return self._socket.listen(N)
 
 
-def wrap_socket(sock,
-                outgoing_regex=None, outgoing_length=-1,
-                incoming_regex=None, incoming_length=-1,
-                K1=None, K2=None,
-                negotiate=True):
-    """``fteproxy.wrap_socket`` turns an existing socket into an fteproxy socket.
+def wrap_socket(sock, server_key=None, server_id=None,
+                format=None, mode=None, defs=None):
+    """Turn an existing socket into an fteproxy socket.
 
-    The input parameter ``sock`` is the socket to wrap.
-    The parameter ``outgoing_regex`` specifies the format of the messages
-    to send via the socket. The ``outgoing_length`` parameter is the exact
-    length, in bytes, of every formatted covertext sent (libfte 0.4 emits
-    fixed-length covertexts; the capacity of one covertext follows from the
-    pattern and the length, and building the cipher raises
-    ``fte.FormatCapacityError`` if the format cannot hold even an empty
-    message at that length).
-    The parameters ``incoming_regex`` and ``incoming_length`` are defined
-    similarly.
-    The optional parameters ``K1`` and ``K2`` specify 128-bit keys to be used
-    in FTE's underlying AE scheme. If specified, these values must be 16-byte
-    strings. If omitted, the key from ``fteproxy.conf`` is used, which is the
-    public built-in default unless the application has set
-    ``runtime.fteproxy.encrypter.key``; always share a secret key.
+    Exactly one of ``server_key`` and ``server_id`` decides the role:
 
-    The record-layer mode (``hybrid`` or ``format``) comes from
-    ``runtime.fteproxy.record_layer.mode`` in ``fteproxy.conf`` and must be the
-    same on both endpoints.
+    ``server_key``
+        the server's 32-byte X25519 private key, from
+        :func:`fteproxy.generate_server_key`. The socket takes the server
+        role: it learns the format, the mode and the definitions release from
+        the client's first record, and answers anything it cannot validate
+        with silence.
 
-    The ``negotiate`` parameter controls whether the client sends a negotiation
-    cell to establish the format. Set to ``False`` when both sides already know
-    the formats (e.g., in symmetric client/server examples). Default is ``True``
-    for backwards compatibility with the relay use case.
+    ``server_id``
+        the matching public key, as 32 bytes or 43 base64url characters. The
+        socket takes the client role and opens with a hello. ``format`` (a
+        base name such as ``manual-http``, default from ``fteproxy.conf``),
+        ``mode`` (``hybrid`` or ``format``) and ``defs`` are the client's
+        choices; the server follows them.
+
+    Both ends derive their own header and body keys for each direction from
+    the handshake, so nothing has to be configured to match and no two
+    connections share a record key.
     """
+    if (server_key is None) == (server_id is None):
+        raise InvalidRoleException(
+            'wrap_socket needs exactly one of server_key (server role) and '
+            'server_id (client role)')
 
-    assert K1 == None or len(K1) == 16
-    assert K2 == None or len(K2) == 16
+    if server_key is not None:
+        role = 'server'
+        server_key = _as_key_bytes(server_key, 'server_key')
+        server_public = fteproxy.handshake.server_id(server_key)
+    else:
+        role = 'client'
+        server_public = _as_key_bytes(server_id, 'server_id')
 
-    socket_wrapped = _FTESocketWrapper(
-        sock,
-        outgoing_regex, outgoing_length,
-        incoming_regex, incoming_length,
-        K1, K2,
-        negotiate)
-    return socket_wrapped
+    if format is None:
+        format = fteproxy.conf.getValue('runtime.state.upstream_language')
+        if format.endswith('-request'):
+            format = format[:-len('-request')]
+    if mode is None:
+        mode = (fteproxy.handshake.MODE_HYBRID if _hybrid_mode()
+                else fteproxy.handshake.MODE_FORMAT)
+    if mode not in fteproxy.handshake.MODES:
+        raise ValueError('mode must be one of %r' % (fteproxy.handshake.MODES,))
+    if defs is None:
+        defs = fteproxy.conf.getValue('fteproxy.defs.release')
+
+    return _FTESocketWrapper(sock, role, server_key=server_key,
+                             server_public=server_public, format=format,
+                             mode=mode, defs=int(defs))
+
+
+def _as_key_bytes(value, what):
+    """Accept a key as raw bytes or as base64url without padding."""
+    if isinstance(value, (bytes, bytearray)):
+        if len(value) != fteproxy.handshake.KEY_BYTES:
+            raise ValueError('%s must be %d bytes'
+                             % (what, fteproxy.handshake.KEY_BYTES))
+        return bytes(value)
+    if isinstance(value, str):
+        import base64
+        padded = value + '=' * (-len(value) % 4)
+        try:
+            raw = base64.urlsafe_b64decode(padded)
+        except (ValueError, TypeError):
+            raise ValueError('%s is not valid base64url' % what)
+        if len(raw) != fteproxy.handshake.KEY_BYTES:
+            raise ValueError('%s must decode to %d bytes'
+                             % (what, fteproxy.handshake.KEY_BYTES))
+        return raw
+    raise TypeError('%s must be bytes or a base64url string' % what)

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -295,8 +295,8 @@ def check_format(format_name):
         pattern = fteproxy.defs.getRegex(format_name)
     except fteproxy.defs.InvalidRegexName:
         raise StartupError('invalid format name: ' + format_name)
-    except OSError as e:
-        raise StartupError('failed to read the definitions file: ' + str(e))
+    except (OSError, fteproxy.defs.DefinitionsError) as e:
+        raise StartupError('failed to load the definitions file: ' + str(e))
 
     length = fteproxy.defs.getLength(format_name)
     key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
@@ -310,13 +310,23 @@ def check_startup(mode):
     """Validate every format this role will use, before anything is printed,
     bound, or written to disk."""
     if mode == 'client':
-        check_format(fteproxy.conf.getValue('runtime.state.upstream_language'))
-        check_format(fteproxy.conf.getValue('runtime.state.downstream_language'))
+        upstream = fteproxy.conf.getValue('runtime.state.upstream_language')
+        downstream = fteproxy.conf.getValue('runtime.state.downstream_language')
+        check_format(upstream)
+        check_format(downstream)
+        # TODO(PR4): the 0.4 handshake carries one base name and the server
+        # derives both directions from it, so the two flags can no longer
+        # express a mixed pair. The new command line has a single --format.
+        if fteproxy.defs.base_name(upstream) != fteproxy.defs.base_name(downstream):
+            fteproxy.warn(
+                'the format pair is chosen by base name now: using %s for '
+                'both directions and ignoring --downstream-format %s'
+                % (fteproxy.defs.base_name(upstream), downstream))
     else:
         try:
             definitions = fteproxy.defs.load_definitions()
-        except OSError as e:
-            raise StartupError('failed to read the definitions file: ' + str(e))
+        except (OSError, fteproxy.defs.DefinitionsError) as e:
+            raise StartupError('failed to load the definitions file: ' + str(e))
         # The server accepts any format the client asks for, so all of them
         # have to work here.
         for format_name in definitions.keys():

--- a/fteproxy/client.py
+++ b/fteproxy/client.py
@@ -1,35 +1,47 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
-
+import fteproxy
+import fteproxy.conf
+import fteproxy.defs
 import fteproxy.relay
 
 
 class listener(fteproxy.relay.listener):
 
     def onNewOutgoingConnection(self, socket):
-        """On an outgoing data stream we wrap it with ``fteproxy.wrap_socket``, with
-        the languages specified in the ``runtime.state.upstream_language`` and
-        ``runtime.state.downstream_language`` configuration parameters.
+        """Wrap the connection to the fteproxy server in the client role.
+
+        The base format and the record-layer mode are the client's choices and
+        travel in the handshake; the server follows them.
         """
+        base = fteproxy.defs.base_name(
+            fteproxy.conf.getValue('runtime.state.upstream_language'))
+        mode = fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode')
+        # TODO(PR4): the flat command line still carries a shared secret rather
+        # than a connection string, so the client derives the server's identity
+        # from it. PR4 replaces this with the server-id parsed from the URI.
+        _, server_public = shim_keypair_from_shared_key(
+            fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'))
+        return fteproxy.wrap_socket(socket, server_id=server_public,
+                                    format=base, mode=mode)
 
-        outgoing_language = fteproxy.conf.getValue(
-            'runtime.state.upstream_language')
-        incoming_language = fteproxy.conf.getValue(
-            'runtime.state.downstream_language')
 
-        outgoing_regex = fteproxy.defs.getRegex(outgoing_language)
-        outgoing_length = fteproxy.defs.getLength(outgoing_language)
+# TODO(PR4): delete with the flat command line.
+def shim_keypair_from_shared_key(key):
+    """Derive a fixed server keypair from the pre-0.4 shared secret.
 
-        incoming_regex = fteproxy.defs.getRegex(incoming_language)
-        incoming_length = fteproxy.defs.getLength(incoming_language)
+    The 0.4 protocol authenticates the server with a keypair, and the 0.4
+    command line hands the client that keypair's public half in a connection
+    string. Until PR4 lands the new command line, ``--key``/``--key-file``
+    still name a secret both endpoints hold, so both derive the same keypair
+    from it and the real handshake runs unchanged. Nothing about the protocol
+    is weakened by this; what it lacks is the operational property that the
+    client only ever needs a public key.
+    """
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
-        K1 = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')[:16]
-        K2 = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')[16:]
-        socket = fteproxy.wrap_socket(socket,
-                                 outgoing_regex, outgoing_length,
-                                 incoming_regex, incoming_length,
-                                 K1, K2)
-
-        return socket
+    private = HKDF(algorithm=hashes.SHA256(), length=32, salt=b'',
+                   info=b'fteproxy/shim/shared-key-server-identity').derive(key)
+    return private, fteproxy.server_id(private)

--- a/fteproxy/defs/20260110.json
+++ b/fteproxy/defs/20260110.json
@@ -9,59 +9,59 @@
     },
     "ssh-request": {
         "regex": "^SSH-2\\.0-[a-zA-Z0-9_]+$",
-        "length": 184,
+        "length": 232,
         "description": "SSH protocol version banner (e.g., SSH-2.0-OpenSSH_8.4)"
     },
     "ssh-response": {
         "regex": "^SSH-2\\.0-[a-zA-Z0-9_]+$",
-        "length": 184,
+        "length": 232,
         "description": "SSH protocol version banner"
     },
     "tls-sni-request": {
         "regex": "^[a-z0-9]+\\.[a-z0-9]+\\.[a-z]+$",
-        "length": 200,
+        "length": 256,
         "description": "TLS Server Name Indication style (subdomain.domain.tld)"
     },
     "tls-sni-response": {
         "regex": "^[a-z0-9]+\\.[a-z0-9]+\\.[a-z]+$",
-        "length": 200,
+        "length": 256,
         "description": "TLS Server Name Indication style"
     },
     "smtp-request": {
         "regex": "^EHLO [a-z0-9]+\\.[a-z]+$",
-        "length": 208,
+        "length": 264,
         "description": "SMTP EHLO command (e.g., EHLO mail.example.com)"
     },
     "smtp-response": {
         "regex": "^250-[a-z0-9]+\\.[a-z]+ [A-Z]+$",
-        "length": 208,
+        "length": 264,
         "description": "SMTP 250 response"
     },
     "ftp-request": {
         "regex": "^USER [a-z0-9]+$",
-        "length": 208,
+        "length": 264,
         "description": "FTP USER command"
     },
     "ftp-response": {
         "regex": "^220 [a-z]+\\.[a-z]+ ready$",
-        "length": 232,
+        "length": 296,
         "description": "FTP welcome banner (e.g., 220 ftp.example.com ready)"
     },
     "lowercase-request": {
         "regex": "^[a-z]+$",
-        "length": 256
+        "length": 280
     },
     "lowercase-response": {
         "regex": "^[a-z]+$",
-        "length": 256
+        "length": 280
     },
     "uppercase-request": {
         "regex": "^[A-Z]+$",
-        "length": 256
+        "length": 280
     },
     "uppercase-response": {
         "regex": "^[A-Z]+$",
-        "length": 256
+        "length": 280
     },
     "alphanumeric-request": {
         "regex": "^[a-zA-Z0-9]+$",
@@ -73,27 +73,27 @@
     },
     "hex-request": {
         "regex": "^[0-9a-f]+$",
-        "length": 256
+        "length": 336
     },
     "hex-response": {
         "regex": "^[0-9a-f]+$",
-        "length": 256
+        "length": 336
     },
     "digits-request": {
         "regex": "^[0-9]+$",
-        "length": 256
+        "length": 400
     },
     "digits-response": {
         "regex": "^[0-9]+$",
-        "length": 256
+        "length": 400
     },
     "binary-request": {
         "regex": "^[01]+$",
-        "length": 1032
+        "length": 1320
     },
     "binary-response": {
         "regex": "^[01]+$",
-        "length": 1032
+        "length": 1320
     },
     "base64-request": {
         "regex": "^[a-zA-Z0-9+/]+$",
@@ -105,35 +105,35 @@
     },
     "words-request": {
         "regex": "^([a-z]+ )+[a-z]+$",
-        "length": 256
+        "length": 280
     },
     "words-response": {
         "regex": "^([a-z]+ )+[a-z]+$",
-        "length": 256
+        "length": 280
     },
     "sentences-request": {
         "regex": "^([A-Z][a-z]+ )+[a-z]+\\.$",
-        "length": 256
+        "length": 280
     },
     "sentences-response": {
         "regex": "^([A-Z][a-z]+ )+[a-z]+\\.$",
-        "length": 256
+        "length": 280
     },
     "ip-address-request": {
         "regex": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
-        "length": 312
+        "length": 392
     },
     "ip-address-response": {
         "regex": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
-        "length": 312
+        "length": 392
     },
     "domain-request": {
         "regex": "^[a-z0-9]+\\.[a-z]+$",
-        "length": 200
+        "length": 256
     },
     "domain-response": {
         "regex": "^[a-z0-9]+\\.[a-z]+$",
-        "length": 200
+        "length": 256
     },
     "url-path-request": {
         "regex": "^\\/[a-z0-9]+(\\/[a-z0-9]+)*$",
@@ -145,11 +145,11 @@
     },
     "key-value-request": {
         "regex": "^[a-z]+=[a-zA-Z0-9]+$",
-        "length": 176
+        "length": 224
     },
     "key-value-response": {
         "regex": "^[a-z]+=[a-zA-Z0-9]+$",
-        "length": 176
+        "length": 224
     },
     "csv-request": {
         "regex": "^[a-zA-Z0-9]+(,[a-zA-Z0-9]+)+$",
@@ -161,19 +161,19 @@
     },
     "email-simple-request": {
         "regex": "^[a-z]+@[a-z]+\\.[a-z]+$",
-        "length": 224
+        "length": 280
     },
     "email-simple-response": {
         "regex": "^[a-z]+@[a-z]+\\.[a-z]+$",
-        "length": 224
+        "length": 280
     },
     "timestamp-request": {
         "regex": "^[0-9]+:[0-9]+:[0-9]+$",
-        "length": 312
+        "length": 400
     },
     "timestamp-response": {
         "regex": "^[0-9]+:[0-9]+:[0-9]+$",
-        "length": 312
+        "length": 400
     },
     "manual-http-request": {
         "regex": "^GET\\ \\/([a-zA-Z0-9./]*) HTTP/1\\.1\\r\\n\\r\\n$"

--- a/fteproxy/defs/__init__.py
+++ b/fteproxy/defs/__init__.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""Loading and validating the format definitions.
 
+A definitions file maps a format name to the regex its covertexts are drawn
+from and the fixed byte length of one covertext. Names come in pairs: a
+``-request`` for client-to-server and a ``-response`` for server-to-client,
+sharing a base name such as ``manual-http``. The base name is what a
+connection string and a client hello carry; the two directions are derived
+from it.
+"""
 
 
 import os
@@ -12,21 +20,89 @@ import fteproxy.conf
 class InvalidRegexName(Exception):
     pass
 
+
+class DefinitionsError(Exception):
+    """A definitions file that cannot be served as written."""
+
+
+#: Every format must hold a client hello, which is about 55 bytes of fields
+#: plus the record layer's 12-byte seal. 128 leaves room for a longer format
+#: name and for a field a later protocol version adds, and is checked at load
+#: so a format that cannot carry a handshake is caught here rather than as a
+#: client that hangs.
+MIN_CAPACITY = 128
+
 _definitions = None
+_checked_releases = set()
+
+REQUEST_SUFFIX = '-request'
+RESPONSE_SUFFIX = '-response'
 
 
 def load_definitions():
     global _definitions
 
     if _definitions == None:
+        release = fteproxy.conf.getValue('fteproxy.defs.release')
         def_dir = os.path.join(fteproxy.conf.getValue('general.defs_dir'))
-        def_file = fteproxy.conf.getValue('fteproxy.defs.release') + '.json'
-        def_abspath = os.path.join(def_dir, def_file)
+        def_abspath = os.path.join(def_dir, release + '.json')
 
         with open(def_abspath) as fh:
             _definitions = json.load(fh)
 
+        if release not in _checked_releases:
+            check_capacities(_definitions)
+            _checked_releases.add(release)
+
     return _definitions
+
+
+def check_capacities(definitions, minimum=MIN_CAPACITY):
+    """Raise :class:`DefinitionsError` for any format too small for a hello.
+
+    Building the cipher also proves the regex compiles and that libfte can
+    drive it at the configured length, so this doubles as a load-time syntax
+    check. It costs one DFA compile per format, which the cache in
+    :func:`fteproxy._regex_format` then hands back to every connection.
+    """
+    import fteproxy  # deferred: fteproxy imports this module at import time
+
+    too_small = []
+    for name, spec in definitions.items():
+        length = spec.get('length', fteproxy.conf.getValue(
+            'fteproxy.default_length'))
+        try:
+            capacity = fteproxy._make_cipher(
+                spec['regex'], length, b'\x00' * 32).max_plaintext_bytes
+        except Exception as e:
+            raise DefinitionsError('format %s is unusable at length %d: %s'
+                                   % (name, length, e))
+        if capacity < minimum:
+            too_small.append((name, length, capacity))
+
+    if too_small:
+        raise DefinitionsError(
+            'these formats cannot carry a handshake (need %d bytes of '
+            'capacity): %s' % (minimum, ', '.join(
+                '%s at length %d holds %d' % row for row in too_small)))
+
+
+def base_names(definitions=None):
+    """The set of base names that have both a request and a response format."""
+    definitions = load_definitions() if definitions is None else definitions
+    requests = {name[:-len(REQUEST_SUFFIX)] for name in definitions
+                if name.endswith(REQUEST_SUFFIX)}
+    responses = {name[:-len(RESPONSE_SUFFIX)] for name in definitions
+                 if name.endswith(RESPONSE_SUFFIX)}
+    return requests & responses
+
+
+def base_name(format_name):
+    """``manual-http-request`` -> ``manual-http``."""
+    for suffix in (REQUEST_SUFFIX, RESPONSE_SUFFIX):
+        if format_name.endswith(suffix):
+            return format_name[:-len(suffix)]
+    return format_name
 
 
 def getRegex(format_name):

--- a/fteproxy/handshake.py
+++ b/fteproxy/handshake.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Protocol version 1: the fteproxy handshake and its key schedule.
+
+Two records, one in each direction, both libfte covertexts sealed under a key
+that anyone holding the connection string can compute:
+
+===============  =========================================================
+client -> server  version, flags, definitions release, format base name,
+                  client ephemeral public key, epoch
+server -> client  version, flags, server ephemeral public key, MAC
+===============  =========================================================
+
+This is the Noise ``NK`` message pattern (``e, es`` then ``e, ee``) written
+out with ``cryptography``'s X25519, HKDF and HMAC. It authenticates the
+server, gives forward secrecy, and derives a distinct header key and body key
+for each direction, so no two connections and no two directions ever share a
+record key. It does not authenticate the client beyond possession of the
+connection string, which is the property obfs4 has.
+
+What the connection string authorises
+-------------------------------------
+``K_cover`` is derived from the server's *public* key, so every holder of the
+connection string can seal and unseal handshake records. That is deliberate:
+holding the string is what authorises a connection attempt, and a prober that
+does not hold it gets no reply at all. It does not let the holder impersonate
+the server (the server hello's MAC requires the server's private key) nor read
+another client's session (the session keys come from two ephemeral keys).
+
+Nothing in this module does I/O or logging: it encodes, decodes, and derives.
+:mod:`fteproxy` drives it over a socket, and the reject path -- read and
+discard, never reply -- lives there.
+"""
+
+import functools
+import hashlib
+import hmac
+import os
+import struct
+import threading
+import time
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.hmac import HMAC
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF, HKDFExpand
+
+
+PROTOCOL_VERSION = 1
+
+MODE_HYBRID = 'hybrid'
+MODE_FORMAT = 'format'
+MODES = (MODE_HYBRID, MODE_FORMAT)
+
+#: ``flags`` bit 0: 0 selects hybrid framing, 1 selects format framing.
+FLAG_FORMAT_MODE = 0x01
+#: Every other ``flags`` bit is reserved and must be zero. A future version
+#: that assigns one negotiates its use through ``version``, so a v1 peer is
+#: right to refuse a hello that sets one.
+FLAG_RESERVED_MASK = 0xFE
+
+KEY_BYTES = 32
+MAC_BYTES = 16
+
+#: The epoch counts hours, so a client and server whose clocks differ by less
+#: than an hour usually agree, and ``EPOCH_WINDOW`` covers the rest.
+EPOCH_SECONDS = 3600
+EPOCH_WINDOW = 1
+
+#: A ``c_pub`` is remembered for the whole accepted window. Past this many
+#: entries the oldest hour is forgotten; see :class:`ReplayFilter`.
+REPLAY_MAX_ENTRIES = 1 << 17
+
+_HASH_PREFIX = b'fteproxy/v1'
+_COVER_INFO = b'fteproxy/v1/cover'
+_KEYS_INFO = b'fteproxy/v1/keys'
+#: K_auth_s, K_c2s_hdr, K_c2s_body, K_s2c_hdr, K_s2c_body.
+_KEY_SCHEDULE_BYTES = 5 * KEY_BYTES
+
+_ZERO_SHARED_SECRET = b'\x00' * KEY_BYTES
+
+_CLIENT_HELLO_HEAD = struct.Struct('>BBIB')   # version, flags, defs, name len
+_EPOCH = struct.Struct('>I')
+_SERVER_HELLO_HEAD = struct.Struct('>BB')     # version, flags
+
+
+class HandshakeError(Exception):
+    """A handshake that cannot continue.
+
+    The server answers every one of these the same way -- read and discard for
+    a random interval, then close, without replying -- so that a prober learns
+    nothing from which check failed. Instances carry a reason for the DEBUG
+    log, never any key material.
+    """
+
+
+class InvalidHello(HandshakeError):
+    """A hello that is malformed, of an unknown version, or out of policy."""
+
+
+class ReplayedHello(InvalidHello):
+    """A client ephemeral public key already seen inside the epoch window."""
+
+
+# --------------------------------------------------------------------------- #
+# Primitives
+# --------------------------------------------------------------------------- #
+
+def _hmac_sha256(key, data):
+    mac = HMAC(key, hashes.SHA256())
+    mac.update(data)
+    return mac.finalize()
+
+
+def _hkdf_extract(salt, ikm):
+    """HKDF-Extract, which is exactly HMAC-SHA256 with the salt as the key."""
+    return _hmac_sha256(salt, ikm)
+
+
+def _hkdf_expand(prk, info, length):
+    return HKDFExpand(algorithm=hashes.SHA256(), length=length,
+                      info=info).derive(prk)
+
+
+@functools.lru_cache(maxsize=8)
+def _static_private_key(private_bytes):
+    """The key object for a long-term private key, built once.
+
+    Turning 32 bytes into an OpenSSL key object costs about as much as the
+    scalar multiplication it is then used for, and a server drives every
+    connection from the same static key. The bytes are already resident -- the
+    process loaded them at startup and keeps them for its lifetime -- so the
+    cache holds nothing that was not already in memory, and it is small
+    because a process has one identity, not thousands. Ephemeral keys are
+    never cached: they are used once, by the object that generated them.
+    """
+    return X25519PrivateKey.from_private_bytes(private_bytes)
+
+
+def _x25519(private, peer_public_bytes):
+    """One X25519 exchange, refusing a degenerate result.
+
+    ``private`` is either an ``X25519PrivateKey`` (an ephemeral, held by the
+    handshake that generated it) or its raw bytes.
+
+    A peer public key of small order drives the shared secret to all zeroes,
+    which would let anyone who can rewrite the hellos fix both sides' key
+    schedule. ``cryptography`` already rejects most such points; the explicit
+    check makes the guarantee ours and independent of the backend.
+    """
+    try:
+        if not isinstance(private, X25519PrivateKey):
+            private = _static_private_key(bytes(private))
+        public = X25519PublicKey.from_public_bytes(peer_public_bytes)
+        shared = private.exchange(public)
+    except ValueError as e:
+        raise InvalidHello('X25519 exchange failed: %s' % e)
+    if hmac.compare_digest(shared, _ZERO_SHARED_SECRET):
+        raise InvalidHello('degenerate X25519 shared secret')
+    return shared
+
+
+def generate_server_key():
+    """Return ``(private_bytes, public_bytes)`` for a new server identity.
+
+    The public half is the server-id that goes in the connection string; the
+    private half belongs in ``server.key`` with mode 0600 and nowhere else.
+    """
+    private = X25519PrivateKey.generate()
+    return (private.private_bytes_raw(),
+            private.public_key().public_bytes_raw())
+
+
+def server_id(private_bytes):
+    """The public server-id matching a 32-byte private key."""
+    _check_key_length(private_bytes, 'server private key')
+    return _static_private_key(
+        bytes(private_bytes)).public_key().public_bytes_raw()
+
+
+def cover_key(server_public):
+    """``K_cover``: the key both handshake records are sealed under.
+
+    Derived from the server's public key alone, so it is exactly as secret as
+    the connection string.
+    """
+    _check_key_length(server_public, 'server public key')
+    return HKDF(algorithm=hashes.SHA256(), length=KEY_BYTES, salt=b'',
+                info=_COVER_INFO).derive(server_public)
+
+
+def _check_key_length(value, what):
+    if not isinstance(value, (bytes, bytearray)) or len(value) != KEY_BYTES:
+        raise ValueError('%s must be %d bytes' % (what, KEY_BYTES))
+
+
+def current_epoch(now=None):
+    """Hours since the Unix epoch, the units of the hello's ``epoch`` field."""
+    return int((time.time() if now is None else now) // EPOCH_SECONDS)
+
+
+# --------------------------------------------------------------------------- #
+# Records
+# --------------------------------------------------------------------------- #
+
+class ClientHello:
+    """The client's half of the handshake, before sealing.
+
+    ``version | flags | defs | format length | format | c_pub | epoch``
+    """
+
+    __slots__ = ('version', 'mode', 'defs', 'format', 'client_public', 'epoch')
+
+    def __init__(self, mode, defs, format, client_public, epoch,
+                 version=PROTOCOL_VERSION):
+        self.version = version
+        self.mode = mode
+        self.defs = defs
+        self.format = format
+        self.client_public = client_public
+        self.epoch = epoch
+
+    def encode(self):
+        if self.mode not in MODES:
+            raise ValueError('unknown record-layer mode: %r' % (self.mode,))
+        name = self.format.encode('ascii')
+        if not 0 < len(name) <= 0xFF:
+            raise ValueError('format name must be 1 to 255 ASCII characters')
+        _check_key_length(self.client_public, 'client ephemeral public key')
+        flags = FLAG_FORMAT_MODE if self.mode == MODE_FORMAT else 0
+        return (_CLIENT_HELLO_HEAD.pack(self.version, flags, self.defs,
+                                        len(name))
+                + name + bytes(self.client_public) + _EPOCH.pack(self.epoch))
+
+    @classmethod
+    def decode(cls, data):
+        """Parse a client hello, raising :class:`InvalidHello` on anything
+        that is not exactly one well-formed v1 hello."""
+        head = _CLIENT_HELLO_HEAD.size
+        if len(data) < head:
+            raise InvalidHello('client hello is %d bytes, too short'
+                               % len(data))
+        version, flags, defs, name_len = _CLIENT_HELLO_HEAD.unpack_from(data)
+        if version != PROTOCOL_VERSION:
+            raise InvalidHello('unsupported protocol version %d' % version)
+        if flags & FLAG_RESERVED_MASK:
+            raise InvalidHello('reserved flag bits set')
+        expected = head + name_len + KEY_BYTES + _EPOCH.size
+        if len(data) != expected:
+            raise InvalidHello('client hello is %d bytes, expected %d'
+                               % (len(data), expected))
+        if name_len == 0:
+            raise InvalidHello('empty format name')
+        name = data[head:head + name_len]
+        try:
+            format_name = name.decode('ascii')
+        except UnicodeDecodeError:
+            raise InvalidHello('format name is not ASCII')
+        offset = head + name_len
+        client_public = data[offset:offset + KEY_BYTES]
+        epoch = _EPOCH.unpack_from(data, offset + KEY_BYTES)[0]
+        mode = MODE_FORMAT if flags & FLAG_FORMAT_MODE else MODE_HYBRID
+        return cls(mode=mode, defs=defs, format=format_name,
+                   client_public=client_public, epoch=epoch, version=version)
+
+
+class ServerHello:
+    """The server's reply, before sealing: ``version | flags | s_pub | mac``.
+
+    ``mac`` is ``HMAC-SHA256(K_auth_s, H)[:16]``, and ``K_auth_s`` depends on
+    ``DH_es``, so producing it proves possession of the server's private key.
+    """
+
+    __slots__ = ('version', 'mode', 'server_public', 'mac')
+
+    SIZE = _SERVER_HELLO_HEAD.size + KEY_BYTES + MAC_BYTES
+
+    def __init__(self, mode, server_public, mac, version=PROTOCOL_VERSION):
+        self.version = version
+        self.mode = mode
+        self.server_public = server_public
+        self.mac = mac
+
+    def encode(self):
+        if self.mode not in MODES:
+            raise ValueError('unknown record-layer mode: %r' % (self.mode,))
+        _check_key_length(self.server_public, 'server ephemeral public key')
+        if len(self.mac) != MAC_BYTES:
+            raise ValueError('mac must be %d bytes' % MAC_BYTES)
+        flags = FLAG_FORMAT_MODE if self.mode == MODE_FORMAT else 0
+        return (_SERVER_HELLO_HEAD.pack(self.version, flags)
+                + bytes(self.server_public) + bytes(self.mac))
+
+    @classmethod
+    def decode(cls, data):
+        if len(data) != cls.SIZE:
+            raise InvalidHello('server hello is %d bytes, expected %d'
+                               % (len(data), cls.SIZE))
+        version, flags = _SERVER_HELLO_HEAD.unpack_from(data)
+        if version != PROTOCOL_VERSION:
+            raise InvalidHello('unsupported protocol version %d' % version)
+        if flags & FLAG_RESERVED_MASK:
+            raise InvalidHello('reserved flag bits set')
+        offset = _SERVER_HELLO_HEAD.size
+        return cls(mode=MODE_FORMAT if flags & FLAG_FORMAT_MODE else MODE_HYBRID,
+                   server_public=data[offset:offset + KEY_BYTES],
+                   mac=data[offset + KEY_BYTES:], version=version)
+
+
+class SessionKeys:
+    """The five keys the schedule produces, one namespace each.
+
+    Each direction gets its own header key and body key, so a record sealed
+    for one direction cannot be replayed into the other, and a
+    connection-string holder cannot forge a header for someone else's stream.
+    """
+
+    __slots__ = ('auth', 'c2s_header', 'c2s_body', 's2c_header', 's2c_body')
+
+    def __init__(self, auth, c2s_header, c2s_body, s2c_header, s2c_body):
+        self.auth = auth
+        self.c2s_header = c2s_header
+        self.c2s_body = c2s_body
+        self.s2c_header = s2c_header
+        self.s2c_body = s2c_body
+
+    def outgoing(self, is_client):
+        """``(header key, body key)`` for what this end sends."""
+        return ((self.c2s_header, self.c2s_body) if is_client
+                else (self.s2c_header, self.s2c_body))
+
+    def incoming(self, is_client):
+        """``(header key, body key)`` for what this end receives."""
+        return ((self.s2c_header, self.s2c_body) if is_client
+                else (self.c2s_header, self.c2s_body))
+
+    def __eq__(self, other):
+        if not isinstance(other, SessionKeys):
+            return NotImplemented
+        return all(getattr(self, name) == getattr(other, name)
+                   for name in self.__slots__)
+
+    def __repr__(self):
+        # Never render the keys: a SessionKeys can reach a log or a traceback.
+        return '<SessionKeys (redacted)>'
+
+
+def transcript_hash(server_public, client_hello_bytes, server_ephemeral_public):
+    """``H = SHA-256("fteproxy/v1" || S_pub || client hello || s_pub)``.
+
+    Binding every handshake byte into ``H``, and ``H`` into both the key
+    schedule's salt and the server's MAC, is what makes a tampered hello
+    produce different keys on the two ends instead of a session.
+    """
+    digest = hashlib.sha256()
+    digest.update(_HASH_PREFIX)
+    digest.update(bytes(server_public))
+    digest.update(bytes(client_hello_bytes))
+    digest.update(bytes(server_ephemeral_public))
+    return digest.digest()
+
+
+def derive_session_keys(transcript, dh_ee, dh_es):
+    """Split ``HKDF-Expand(HKDF-Extract(H, DH_ee || DH_es))`` into five keys."""
+    prk = _hkdf_extract(salt=transcript, ikm=dh_ee + dh_es)
+    okm = _hkdf_expand(prk, _KEYS_INFO, _KEY_SCHEDULE_BYTES)
+    parts = [okm[i:i + KEY_BYTES]
+             for i in range(0, _KEY_SCHEDULE_BYTES, KEY_BYTES)]
+    return SessionKeys(*parts)
+
+
+def server_mac(keys, transcript):
+    """The server hello's proof of possession, truncated to 16 bytes."""
+    return _hmac_sha256(keys.auth, transcript)[:MAC_BYTES]
+
+
+# --------------------------------------------------------------------------- #
+# Replay filter
+# --------------------------------------------------------------------------- #
+
+class ReplayFilter:
+    """Remembers the ``c_pub`` of every accepted hello inside the epoch window.
+
+    A hello is only valid for its epoch plus or minus ``EPOCH_WINDOW`` hours,
+    so a recorded hello can only be replayed inside that window, and refusing a
+    repeated ``c_pub`` closes it. Entries are bucketed by epoch, so expiry is a
+    dict delete rather than a scan of every key ever seen.
+
+    Shared by every connection on a server, hence the lock.
+    """
+
+    def __init__(self, window=EPOCH_WINDOW, max_entries=REPLAY_MAX_ENTRIES):
+        self._window = window
+        self._max_entries = max_entries
+        self._buckets = {}
+        self._lock = threading.Lock()
+
+    def observe(self, client_public, epoch, now_epoch=None):
+        """Record ``client_public``; return False if it was already seen.
+
+        Callers reject on False. Only call this once a hello has passed every
+        other check, so that a malformed hello cannot fill the filter.
+        """
+        if now_epoch is None:
+            now_epoch = current_epoch()
+        key = bytes(client_public)
+        with self._lock:
+            self._expire(now_epoch)
+            for seen in self._buckets.values():
+                if key in seen:
+                    return False
+            self._buckets.setdefault(epoch, set()).add(key)
+            self._enforce_cap()
+            return True
+
+    def _expire(self, now_epoch):
+        for epoch in [e for e in self._buckets
+                      if abs(e - now_epoch) > self._window]:
+            del self._buckets[epoch]
+
+    def _enforce_cap(self):
+        """Bound memory under a flood of distinct ``c_pub`` values.
+
+        Dropping the oldest bucket re-opens replay only for hellos that are
+        already at the far edge of the window and about to expire anyway; the
+        alternative, refusing new clients, would hand an attacker a way to
+        deny service to everyone else.
+        """
+        while sum(len(b) for b in self._buckets.values()) > self._max_entries \
+                and len(self._buckets) > 1:
+            del self._buckets[min(self._buckets)]
+
+    def __len__(self):
+        with self._lock:
+            return sum(len(b) for b in self._buckets.values())
+
+
+# --------------------------------------------------------------------------- #
+# The two halves
+# --------------------------------------------------------------------------- #
+
+class ClientHandshake:
+    """The client half: build a hello, then verify the reply.
+
+    ``ephemeral_private`` is only ever passed by the test vectors; a real
+    connection draws a fresh key here and uses it once.
+    """
+
+    def __init__(self, server_public, format, mode, defs,
+                 epoch=None, ephemeral_private=None):
+        _check_key_length(server_public, 'server public key')
+        if mode not in MODES:
+            raise ValueError('unknown record-layer mode: %r' % (mode,))
+        self.server_public = bytes(server_public)
+        self._private = (X25519PrivateKey.from_private_bytes(ephemeral_private)
+                         if ephemeral_private is not None
+                         else X25519PrivateKey.generate())
+        public = self._private.public_key().public_bytes_raw()
+        self.hello = ClientHello(
+            mode=mode, defs=int(defs), format=format, client_public=public,
+            epoch=current_epoch() if epoch is None else epoch)
+        self.hello_bytes = self.hello.encode()
+
+    def finish(self, server_hello_bytes):
+        """Verify the server's reply and return the :class:`SessionKeys`.
+
+        Raises :class:`InvalidHello` if the reply is malformed, echoes a
+        different mode, or carries a MAC the server could not have produced --
+        which is the only evidence the client has that it is talking to the
+        holder of the private key behind the connection string.
+        """
+        reply = ServerHello.decode(server_hello_bytes)
+        if reply.mode != self.hello.mode:
+            raise InvalidHello('server echoed mode %r, asked for %r'
+                               % (reply.mode, self.hello.mode))
+        transcript = transcript_hash(self.server_public, self.hello_bytes,
+                                     reply.server_public)
+        dh_ee = _x25519(self._private, reply.server_public)
+        dh_es = _x25519(self._private, self.server_public)
+        keys = derive_session_keys(transcript, dh_ee, dh_es)
+        if not hmac.compare_digest(server_mac(keys, transcript), reply.mac):
+            raise InvalidHello('server hello MAC did not verify')
+        return keys
+
+
+def accept_client_hello(hello_bytes, server_private, server_public,
+                        defs, formats, replay=None, now_epoch=None,
+                        ephemeral_private=None):
+    """The server half: validate a hello and build the reply.
+
+    Returns ``(hello, server_hello_bytes, keys)``. Every failure raises
+    :class:`InvalidHello`; the caller must answer all of them identically, by
+    reading and discarding rather than replying, so that a prober cannot tell
+    a wrong key from a wrong format from a stale clock.
+
+    ``formats`` is the set of base names this server serves, and ``defs`` the
+    definitions release it serves them from: a client that disagrees about
+    either would derive a different covertext length or regex, so the mismatch
+    is refused here rather than surfacing as a stuck stream.
+    """
+    _check_key_length(server_private, 'server private key')
+    _check_key_length(server_public, 'server public key')
+    hello = ClientHello.decode(hello_bytes)
+    if hello.defs != int(defs):
+        raise InvalidHello('definitions release %d, this server serves %s'
+                           % (hello.defs, defs))
+    if hello.format not in formats:
+        raise InvalidHello('unknown format base name')
+    if now_epoch is None:
+        now_epoch = current_epoch()
+    if abs(hello.epoch - now_epoch) > EPOCH_WINDOW:
+        raise InvalidHello('epoch %d is outside the window around %d'
+                           % (hello.epoch, now_epoch))
+    if replay is not None and not replay.observe(hello.client_public,
+                                                 hello.epoch, now_epoch):
+        raise ReplayedHello('client ephemeral key already seen in this window')
+
+    private = (X25519PrivateKey.from_private_bytes(ephemeral_private)
+               if ephemeral_private is not None
+               else X25519PrivateKey.generate())
+    public = private.public_key().public_bytes_raw()
+    transcript = transcript_hash(server_public, hello_bytes, public)
+    dh_ee = _x25519(private, hello.client_public)
+    dh_es = _x25519(server_private, hello.client_public)
+    keys = derive_session_keys(transcript, dh_ee, dh_es)
+    reply = ServerHello(mode=hello.mode, server_public=public,
+                        mac=server_mac(keys, transcript))
+    return hello, reply.encode(), keys
+
+
+def reject_delay(rng=None):
+    """Seconds to keep reading and discarding before closing on a rejection.
+
+    obfs4's behaviour: a prober that guesses wrong sees a connection that
+    behaves like a service with nothing to say, and cannot time the difference
+    between a wrong key and a wrong format.
+    """
+    raw = int.from_bytes(os.urandom(4), 'big') if rng is None else rng()
+    return 1.0 + (raw % 4001) / 1000.0

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -20,9 +20,20 @@ so it reads as random format text and only unseals at stream position
     :class:`fteproxy._AEADBody`, with ``seq`` bound into the tag. Only the
     header blends in with the format; the body is high-entropy ciphertext.
 
+The message itself begins with a one-byte record type (:data:`DATA` and the
+other constants below), so one connection carries application bytes, stream
+control and future padding without a second framing layer. In ``format`` mode
+that byte is the first byte inside the sealed covertext; in ``hybrid`` mode it
+is the first byte of the raw body. Either way the sealed ``len`` and ``seq``
+fields are unchanged, so chunking, buffering and the body-length bound are the
+same as they were before types existed.
+
 ``seq`` is the record's position in its stream, counted from 0 by each
 ``Encoder``/``Decoder`` pair, so a record moved, replayed, or dropped within
-a stream is rejected. See SECURITY.md for what is not covered.
+a stream is rejected. Since 0.4 each direction of a connection has its own
+header and body keys, derived per connection by :mod:`fteproxy.handshake`, so
+a record cannot be replayed into another stream or the other direction either.
+See SECURITY.md for what is not covered.
 """
 
 import os
@@ -34,6 +45,19 @@ from cryptography.exceptions import InvalidTag
 import fteproxy.conf
 
 
+#: Application bytes.
+DATA = 0x00
+#: Open a stream to the destination in the payload (see ``fteproxy.stream``).
+OPEN = 0x01
+#: The status of an :data:`OPEN`.
+OPEN_RESULT = 0x02
+#: Ignored on receipt; reserved for traffic shaping.
+PADDING = 0x03
+#: The sender will send no more :data:`DATA` on this connection.
+CLOSE = 0x04
+
+RECORD_TYPES = frozenset((DATA, OPEN, OPEN_RESULT, PADDING, CLOSE))
+
 # Length prefix inside a sealed (random-padded) covertext plaintext.
 _LEN = struct.Struct('>I')
 # Sequence number inside a sealed covertext plaintext: the record's position in
@@ -42,8 +66,19 @@ _LEN = struct.Struct('>I')
 # mode the body MAC binds the same number).
 _SEQ = struct.Struct('>Q')
 _SEAL_OVERHEAD = _LEN.size + _SEQ.size
+# The record type byte that leads every message.
+_TYPE_LEN = 1
 # Hybrid-mode header payload: the length of the raw body that follows it.
 _OVERFLOW_LEN = struct.Struct('>I')
+
+
+class UnknownRecordType(Exception):
+    """An authenticated record whose type this version does not define.
+
+    Only a peer holding the session keys can produce one, so this is a version
+    mismatch rather than an attack, and the connection is closed: continuing
+    would mean guessing at the meaning of the bytes that follow.
+    """
 
 
 def _seal(cipher, message, seq):
@@ -89,17 +124,51 @@ class Encoder:
         self._body_cipher = body_cipher
         if body_cipher is None:
             # 'format' mode: one sealed covertext per chunk. Reserve the length
-            # prefix and sequence number; the rest of the covertext capacity is
-            # real payload, random-padded when the payload does not fill it.
-            self._capacity = cipher.max_plaintext_bytes - _SEAL_OVERHEAD
+            # prefix, sequence number and record type; the rest of the covertext
+            # capacity is real payload, random-padded when the payload does not
+            # fill it.
+            self._capacity = (cipher.max_plaintext_bytes
+                              - _SEAL_OVERHEAD - _TYPE_LEN)
         else:
             # 'hybrid' mode: a sealed FTE header (carrying the body length)
             # followed by the raw authenticated body. Chunk by the body's capacity, far
             # larger than a covertext's, so bulk data pays the DFA cost once per
-            # record instead of once per ~150 bytes.
+            # record instead of once per ~150 bytes. The type byte rides on top
+            # of the body rather than coming out of the payload, so the chunk
+            # boundaries are exactly where they were before types existed.
             self._capacity = body_cipher.max_plaintext_bytes
+        if self._capacity < 1:
+            raise ValueError('format is too small to carry a record')
         self._buffer = b''
         self._seq = 0
+
+    @property
+    def capacity(self):
+        """The largest payload one record of this stream can carry."""
+        return self._capacity
+
+    def _emit(self, record_type, payload):
+        """One complete record on the wire, advancing the stream position."""
+        message = bytes((record_type,)) + payload
+        if self._body_cipher is None:
+            record = _seal(self._cipher, message, self._seq)
+        else:
+            body = self._body_cipher.encrypt(message, self._seq)
+            record = (_seal(self._cipher, _OVERFLOW_LEN.pack(len(body)),
+                            self._seq)
+                      + body)
+        self._seq += 1
+        return record
+
+    def encode(self, record_type, payload=b''):
+        """Encode one record of any type. Control messages go out this way;
+        :meth:`pop` is the bulk path for :data:`DATA`."""
+        if record_type not in RECORD_TYPES:
+            raise ValueError('unknown record type: %r' % (record_type,))
+        if len(payload) > self._capacity:
+            raise ValueError('payload of %d bytes exceeds the %d-byte record '
+                             'capacity' % (len(payload), self._capacity))
+        return self._emit(record_type, payload)
 
     def push(self, data):
         """Push data onto the FIFO buffer."""
@@ -109,8 +178,8 @@ class Encoder:
 
     def pop(self):
         """Pop the whole buffer, sliced into capacity-sized chunks and encrypted
-        into one record each with the ``cipher`` (and, in hybrid mode, the
-        ``body_cipher``) from ``__init__``.
+        into one :data:`DATA` record each with the ``cipher`` (and, in hybrid
+        mode, the ``body_cipher``) from ``__init__``.
         """
         buffer = self._buffer
         if not buffer:
@@ -122,14 +191,8 @@ class Encoder:
         # iteration, making a single large ``push`` quadratic.
         records = []
         for offset in range(0, len(buffer), self._capacity):
-            chunk = buffer[offset:offset + self._capacity]
-            if self._body_cipher is None:
-                records.append(_seal(self._cipher, chunk, self._seq))
-            else:
-                body = self._body_cipher.encrypt(chunk, self._seq)
-                header = _seal(self._cipher, _OVERFLOW_LEN.pack(len(body)), self._seq)
-                records.append(header + body)
-            self._seq += 1
+            records.append(
+                self._emit(DATA, buffer[offset:offset + self._capacity]))
 
         self._buffer = b''
         return b''.join(records)
@@ -182,26 +245,44 @@ class Decoder:
             fteproxy.fatal_error("fteproxy.record_layer.FormatContractError: "+str(e))
             # exit
         except fte.InvalidCovertextError as e:
-            # A corrupt, wrong-format, or failed-MAC frame. The negotiation scan
-            # relies on this to fall through to the next candidate format.
-            fteproxy.info("fteproxy.record_layer.InvalidCovertextError: "+str(e))
+            # A corrupt, wrong-format, or failed-MAC frame. The server's
+            # first-record scan relies on this to fall through to the next
+            # candidate format.
+            fteproxy.debug("fteproxy.record_layer.InvalidCovertextError: "+str(e))
             return None
         except fte.FTEError as e:
             fteproxy.warn("fteproxy.record_layer exception: "+str(e))
             return None
 
-    def pop(self, oneCell=False):
-        """Pop decrypted messages off the FIFO buffer, one record at a time."""
+    @staticmethod
+    def _split_type(message):
+        """``type || payload`` -> ``(type, payload)``, checking the type."""
+        if not message:
+            raise UnknownRecordType('empty record')
+        record_type = message[0]
+        if record_type not in RECORD_TYPES:
+            raise UnknownRecordType('record type 0x%02x' % record_type)
+        return record_type, message[1:]
 
-        # Consume whole records from a local buffer and join the messages once at
-        # the end; ``+= msg`` per record would be quadratic. ``self._buffer`` is
-        # written back once, and the offset never advances past a record that
-        # cannot (yet) be decoded, so the undecodable remainder is preserved.
+    def pop_records(self, limit=None):
+        """Pop decoded records off the FIFO buffer as ``(type, payload)``.
+
+        Stops at ``limit`` records, or when the next record is incomplete or
+        undecodable. Raises :class:`UnknownRecordType` for an authenticated
+        record this version does not define; the caller closes the connection.
+        """
+
+        # Consume whole records from a local buffer and collect the messages,
+        # writing ``self._buffer`` back once. The offset never advances past a
+        # record that cannot (yet) be decoded, so the undecodable remainder is
+        # preserved.
         buffer = self._buffer
-        messages = []
+        records = []
         offset = 0
 
         while len(buffer) - offset >= self._frame_size:
+            if limit is not None and len(records) >= limit:
+                break
             if self._body_cipher is not None and self._pending_body_len is not None:
                 # The header at the front of the buffer was decrypted and
                 # verified on an earlier pop whose body had not fully arrived.
@@ -219,25 +300,23 @@ class Decoder:
                     # position: a peer on a different mode, corruption, or a
                     # record replayed, reordered, or dropped. Treat it as
                     # undecodable.
-                    fteproxy.info(
+                    fteproxy.debug(
                         "fteproxy.record_layer: malformed or out-of-order sealed "
                         "record at seq " + str(self._seq))
                     break
 
                 if self._body_cipher is None:
                     # 'format' mode: the sealed covertext carried the message.
-                    messages.append(head)
-                    offset += self._frame_size
                     self._seq += 1
-                    if oneCell:
-                        break
+                    offset += self._frame_size
+                    records.append(self._split_type(head))
                     continue
 
                 # 'hybrid' mode: the header carries the raw body's length. The
                 # header is authenticated, so a successful decrypt means we
                 # wrote it and the length is trustworthy.
                 if len(head) != _OVERFLOW_LEN.size:
-                    fteproxy.info(
+                    fteproxy.debug(
                         "fteproxy.record_layer: unexpected header width "
                         + str(len(head)))
                     break
@@ -259,24 +338,32 @@ class Decoder:
             self._pending_body_len = None
             body = buffer[body_start:body_start + body_len]
             try:
-                msg = self._body_cipher.decrypt(body, self._seq)
+                message = self._body_cipher.decrypt(body, self._seq)
             except InvalidTag:
                 # Wrong key, corruption, or a record out of its stream
                 # position (reorder/drop/replay). Stop draining.
-                fteproxy.info(
+                fteproxy.debug(
                     "fteproxy.record_layer: body auth failed at seq "
                     + str(self._seq))
                 break
             self._seq += 1
-            messages.append(msg)
             offset = body_start + body_len
-
-            # Stop after a single record only once one decoded successfully. This
-            # must live here, not in a ``finally``: a ``break`` in ``finally``
-            # swallows any in-flight exception (including the SystemExit raised by
-            # ``fatal_error``), silently turning a fatal condition into a return.
-            if oneCell:
-                break
+            records.append(self._split_type(message))
 
         self._buffer = buffer[offset:]
-        return b''.join(messages)
+        return records
+
+    def pop(self, limit=None):
+        """The :data:`DATA` payloads from :meth:`pop_records`, concatenated.
+
+        For callers that carry nothing but application bytes. A control record
+        raises, because silently dropping one would lose a stream's OPEN or its
+        half-close.
+        """
+        records = self.pop_records(limit=limit)
+        for record_type, _payload in records:
+            if record_type != DATA:
+                raise UnknownRecordType(
+                    'unexpected control record 0x%02x on a data-only stream'
+                    % record_type)
+        return b''.join(payload for _type, payload in records)

--- a/fteproxy/server.py
+++ b/fteproxy/server.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
-
-
+import fteproxy
+import fteproxy.client
+import fteproxy.conf
 import fteproxy.relay
 
 
 class listener(fteproxy.relay.listener):
 
     def onNewIncomingConnection(self, socket):
-        """On an incoming data stream we wrap it with ``fteproxy.wrap_socket``, with no parameters.
-        By default we want the regular expressions to be negotiated in-band, specified by the client.
-        """
-        K1 = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')[:16]
-        K2 = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')[16:]
-        socket = fteproxy.wrap_socket(socket, K1=K1, K2=K2)
+        """Wrap an incoming connection in the server role.
 
-        return socket
+        The server passes no format and no mode: it learns both from the
+        client's first record, and answers a record it cannot validate with
+        silence.
+        """
+        # TODO(PR4): the flat command line has no state directory to keep a
+        # server key in, so the keypair is derived from the shared secret.
+        server_key, _ = fteproxy.client.shim_keypair_from_shared_key(
+            fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'))
+        return fteproxy.wrap_socket(socket, server_key=server_key)

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -286,3 +286,48 @@ class TestLogging:
         captured = capsys.readouterr()
         assert 'a warning' in captured.err
         assert captured.out == ''
+
+
+class TestLogRedaction:
+    """Secrets must not reach a log file, whatever a call site passes.
+
+    The filter lives on the package logger, so it applies to every handler an
+    embedding program attaches as well as to the CLI's own.
+    """
+
+    def test_a_connection_string_keeps_only_its_shape(self, caplog):
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            fteproxy.info('checking fte://g7RzVlLwycSzfHmHwo2LOdkvZ2rG_-J4lmso'
+                          'smKPzQY@203.0.113.5:8080')
+        assert 'g7RzVlLwycSz' not in caplog.text
+        assert 'fte://…@203.0.113.5:8080' in caplog.text
+
+    def test_a_hex_key_is_removed(self, caplog):
+        key = '0123456789abcdef' * 4
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            fteproxy.info('loaded key %s' % key)
+        assert key not in caplog.text
+        assert '<redacted>' in caplog.text
+
+    def test_a_bare_server_id_is_removed(self, caplog):
+        import base64
+
+        _private, public = fteproxy.generate_server_key()
+        text = base64.urlsafe_b64encode(public).rstrip(b'=').decode('ascii')
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            fteproxy.info('server-id ' + text)
+        assert text not in caplog.text
+
+    def test_a_secret_passed_as_an_argument_is_removed(self, caplog):
+        """%-args are expanded before the filter runs, and the arguments are
+        cleared afterwards so a handler cannot re-expand them."""
+        key = 'ab' * 32
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            fteproxy.logger.info('key is %s', key)
+        assert key not in caplog.text
+        assert caplog.records[0].args in ((), None)
+
+    def test_ordinary_messages_are_untouched(self, caplog):
+        with caplog.at_level(logging.INFO, logger='fteproxy'):
+            fteproxy.info('listening on 127.0.0.1:1080, format manual-http')
+        assert 'listening on 127.0.0.1:1080, format manual-http' in caplog.text

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -525,3 +525,60 @@ class TestAllDefinedFormats:
         
         if failed:
             pytest.fail(f"Failed formats: {failed}")
+
+
+class TestDefinitionsCapacity:
+    """Every shipped format must be able to carry a handshake."""
+
+    @pytest.mark.parametrize('release', ['20260110', '20131224'])
+    def test_shipped_releases_pass_the_load_check(self, release):
+        previous = fteproxy.conf.getValue('fteproxy.defs.release')
+        try:
+            fteproxy.conf.setValue('fteproxy.defs.release', release)
+            fteproxy.defs._definitions = None
+            fteproxy.defs._checked_releases.discard(release)
+            definitions = fteproxy.defs.load_definitions()
+            fteproxy.defs.check_capacities(definitions)
+        finally:
+            fteproxy.conf.setValue('fteproxy.defs.release', previous)
+            fteproxy.defs._definitions = None
+
+    def test_a_too_small_format_is_refused(self):
+        """A format that cannot hold a client hello would fail as a client
+        that hangs, so it fails at load instead."""
+        with pytest.raises(fteproxy.defs.DefinitionsError) as excinfo:
+            fteproxy.defs.check_capacities(
+                {'tiny-request': {'regex': '^[01]+$', 'length': 300}})
+        assert 'tiny-request' in str(excinfo.value)
+
+    def test_an_uncompilable_format_is_refused(self):
+        with pytest.raises(fteproxy.defs.DefinitionsError):
+            fteproxy.defs.check_capacities(
+                {'broken-request': {'regex': '^[a-z', 'length': 256}})
+
+    def test_every_base_name_has_both_directions(self):
+        definitions = fteproxy.defs.load_definitions()
+        bases = fteproxy.defs.base_names(definitions)
+        for base in bases:
+            assert base + '-request' in definitions
+            assert base + '-response' in definitions
+        # Nothing in the file is left out of a pair.
+        assert len(bases) * 2 == len(definitions)
+
+    def test_a_client_hello_fits_every_format(self):
+        """The check is a proxy for this: the largest hello a shipped base
+        name can produce, plus the record layer's seal, must fit."""
+        import fteproxy.handshake as hs
+        import fteproxy.record_layer as rl
+
+        definitions = fteproxy.defs.load_definitions()
+        longest = max(fteproxy.defs.base_names(definitions), key=len)
+        hello = hs.ClientHello(mode='hybrid', defs=20260110, format=longest,
+                               client_public=b'\x00' * 32,
+                               epoch=hs.current_epoch()).encode()
+        needed = len(hello) + rl._SEAL_OVERHEAD
+        assert needed <= fteproxy.defs.MIN_CAPACITY
+        for name in definitions:
+            capacity = _cipher(fteproxy.defs.getRegex(name),
+                               fteproxy.defs.getLength(name)).max_plaintext_bytes
+            assert capacity >= needed, name

--- a/fteproxy/tests/test_handshake.py
+++ b/fteproxy/tests/test_handshake.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the protocol v1 handshake: vectors, tampering, replay, epoch.
+
+The vectors in ``vectors/handshake_v1.json`` pin the wire format and the key
+schedule. They were generated once from fixed seeds; if a change to
+:mod:`fteproxy.handshake` breaks them, that change breaks interoperation with
+every deployed 0.4 peer, and the version must move rather than the vectors.
+"""
+
+import json
+import os
+
+import pytest
+
+import fteproxy
+import fteproxy.handshake as hs
+
+
+VECTORS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'vectors', 'handshake_v1.json')
+
+
+def load_vectors():
+    with open(VECTORS_PATH) as fh:
+        return json.load(fh)
+
+
+VECTORS = load_vectors()
+CASES = VECTORS['cases']
+CASE_IDS = [case['name'] for case in CASES]
+
+
+def unhex(value):
+    return bytes.fromhex(value)
+
+
+def client_for(case):
+    return hs.ClientHandshake(
+        server_public=unhex(case['server_public']), format=case['format'],
+        mode=case['mode'], defs=case['defs'], epoch=case['epoch'],
+        ephemeral_private=unhex(case['client_ephemeral_private']))
+
+
+def accept(case, hello_bytes, **overrides):
+    kwargs = dict(
+        server_private=unhex(case['server_private']),
+        server_public=unhex(case['server_public']),
+        defs=case['defs'], formats={case['format']}, replay=None,
+        now_epoch=case['epoch'],
+        ephemeral_private=unhex(case['server_ephemeral_private']))
+    kwargs.update(overrides)
+    return hs.accept_client_hello(hello_bytes, **kwargs)
+
+
+class TestVectors:
+    """Every derived value matches the checked-in vector, byte for byte."""
+
+    def test_version(self):
+        assert VECTORS['protocol_version'] == hs.PROTOCOL_VERSION
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_server_id_matches(self, case):
+        assert hs.server_id(unhex(case['server_private'])) == \
+            unhex(case['server_public'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_cover_key_matches(self, case):
+        assert hs.cover_key(unhex(case['server_public'])) == \
+            unhex(case['cover_key'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_client_hello_bytes_match(self, case):
+        assert client_for(case).hello_bytes == unhex(case['client_hello'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_client_hello_decodes_to_its_fields(self, case):
+        hello = hs.ClientHello.decode(unhex(case['client_hello']))
+        assert hello.version == hs.PROTOCOL_VERSION
+        assert hello.mode == case['mode']
+        assert hello.defs == case['defs']
+        assert hello.format == case['format']
+        assert hello.epoch == case['epoch']
+        assert hello.client_public == unhex(case['client_ephemeral_public'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_transcript_and_dh_match(self, case):
+        assert hs.transcript_hash(
+            unhex(case['server_public']), unhex(case['client_hello']),
+            unhex(case['server_ephemeral_public'])) == \
+            unhex(case['transcript_hash'])
+        assert hs._x25519(unhex(case['client_ephemeral_private']),
+                          unhex(case['server_ephemeral_public'])) == \
+            unhex(case['dh_ee'])
+        assert hs._x25519(unhex(case['client_ephemeral_private']),
+                          unhex(case['server_public'])) == unhex(case['dh_es'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_key_schedule_matches(self, case):
+        keys = hs.derive_session_keys(unhex(case['transcript_hash']),
+                                      unhex(case['dh_ee']),
+                                      unhex(case['dh_es']))
+        for name, expected in case['keys'].items():
+            assert getattr(keys, name) == unhex(expected), name
+        assert hs.server_mac(keys, unhex(case['transcript_hash'])) == \
+            unhex(case['server_mac'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_server_hello_bytes_match(self, case):
+        _hello, reply, _keys = accept(case, unhex(case['client_hello']))
+        assert reply == unhex(case['server_hello'])
+
+    @pytest.mark.parametrize('case', CASES, ids=CASE_IDS)
+    def test_both_ends_agree(self, case):
+        client = client_for(case)
+        _hello, reply, server_keys = accept(case, client.hello_bytes)
+        client_keys = client.finish(reply)
+        assert client_keys == server_keys
+        for name, expected in case['keys'].items():
+            assert getattr(client_keys, name) == unhex(expected), name
+
+    def test_the_five_keys_are_distinct(self):
+        case = CASES[0]
+        keys = hs.derive_session_keys(unhex(case['transcript_hash']),
+                                      unhex(case['dh_ee']),
+                                      unhex(case['dh_es']))
+        values = [getattr(keys, name) for name in keys.__slots__]
+        assert len(set(values)) == len(values)
+
+    def test_directions_do_not_share_keys(self):
+        case = CASES[0]
+        keys = hs.derive_session_keys(unhex(case['transcript_hash']),
+                                      unhex(case['dh_ee']),
+                                      unhex(case['dh_es']))
+        assert keys.outgoing(is_client=True) == keys.incoming(is_client=False)
+        assert keys.outgoing(is_client=False) == keys.incoming(is_client=True)
+        assert keys.outgoing(is_client=True) != keys.outgoing(is_client=False)
+
+    def test_session_keys_never_render_their_material(self):
+        """A SessionKeys can reach a traceback or a log line."""
+        case = CASES[0]
+        keys = hs.derive_session_keys(unhex(case['transcript_hash']),
+                                      unhex(case['dh_ee']),
+                                      unhex(case['dh_es']))
+        rendered = repr(keys)
+        assert 'redacted' in rendered
+        for value in case['keys'].values():
+            assert value not in rendered
+
+
+class TestClientHelloTampering:
+    """Every field of the client hello, altered one at a time."""
+
+    CASE = CASES[0]
+
+    def hello(self):
+        return bytearray(unhex(self.CASE['client_hello']))
+
+    def test_untampered_is_accepted(self):
+        accept(self.CASE, bytes(self.hello()))
+
+    def test_version_byte(self):
+        raw = self.hello()
+        raw[0] = 0x02
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    @pytest.mark.parametrize('bit', [0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80])
+    def test_reserved_flag_bits(self, bit):
+        raw = self.hello()
+        raw[1] |= bit
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_mode_bit_flips_the_negotiated_mode(self):
+        """Bit 0 is not tampering: it is how the client picks the mode, and it
+        is bound into H, so a flip in flight breaks the MAC instead."""
+        raw = self.hello()
+        raw[1] ^= hs.FLAG_FORMAT_MODE
+        hello, reply, _keys = accept(self.CASE, bytes(raw))
+        assert hello.mode == 'format'
+        # The honest client's key schedule is over its own hello, so the
+        # flipped one produces a MAC it will not accept.
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(reply)
+
+    def test_definitions_release(self):
+        raw = self.hello()
+        raw[2:6] = (self.CASE['defs'] + 1).to_bytes(4, 'big')
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_format_name_length(self):
+        raw = self.hello()
+        raw[6] = raw[6] + 1
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_zero_length_format_name(self):
+        raw = self.hello()
+        del raw[7:7 + raw[6]]
+        raw[6] = 0
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_unknown_format_name(self):
+        raw = bytearray(hs.ClientHello(
+            mode=self.CASE['mode'], defs=self.CASE['defs'],
+            format='no-such-format',
+            client_public=unhex(self.CASE['client_ephemeral_public']),
+            epoch=self.CASE['epoch']).encode())
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_non_ascii_format_name(self):
+        raw = self.hello()
+        raw[7] = 0xFF
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_client_public_key(self):
+        """A substituted c_pub changes H, so the client cannot verify the
+        reply: the connection fails rather than becoming a relay for a peer in
+        the middle."""
+        raw = self.hello()
+        offset = 7 + raw[6]
+        raw[offset] ^= 0x01
+        _hello, reply, _keys = accept(self.CASE, bytes(raw))
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(reply)
+
+    def test_epoch(self):
+        raw = self.hello()
+        raw[-4:] = (self.CASE['epoch'] + 5).to_bytes(4, 'big')
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw))
+
+    def test_truncated(self):
+        raw = self.hello()
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw[:-1]))
+
+    def test_trailing_bytes(self):
+        raw = self.hello()
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, bytes(raw) + b'\x00')
+
+    def test_empty(self):
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, b'')
+
+
+class TestServerHelloTampering:
+    """Every field of the server hello, altered one at a time."""
+
+    CASE = CASES[0]
+
+    def reply(self):
+        return bytearray(unhex(self.CASE['server_hello']))
+
+    def test_untampered_is_accepted(self):
+        client_for(self.CASE).finish(bytes(self.reply()))
+
+    def test_version_byte(self):
+        raw = self.reply()
+        raw[0] = 0x02
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw))
+
+    @pytest.mark.parametrize('bit', [0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80])
+    def test_reserved_flag_bits(self, bit):
+        raw = self.reply()
+        raw[1] |= bit
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw))
+
+    def test_mode_echo_must_match(self):
+        raw = self.reply()
+        raw[1] ^= hs.FLAG_FORMAT_MODE
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw))
+
+    def test_server_ephemeral_key(self):
+        raw = self.reply()
+        raw[2] ^= 0x01
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw))
+
+    @pytest.mark.parametrize('index', range(hs.MAC_BYTES))
+    def test_every_mac_byte(self, index):
+        raw = self.reply()
+        raw[2 + hs.KEY_BYTES + index] ^= 0x01
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw))
+
+    def test_truncated(self):
+        raw = self.reply()
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw[:-1]))
+
+    def test_trailing_bytes(self):
+        raw = self.reply()
+        with pytest.raises(hs.InvalidHello):
+            client_for(self.CASE).finish(bytes(raw) + b'\x00')
+
+
+class TestWrongServerKey:
+    """Only the holder of the private key behind the server-id can reply."""
+
+    CASE = CASES[0]
+
+    def test_a_different_server_cannot_produce_the_mac(self):
+        """An impostor holding the connection string can seal a reply -- the
+        cover key is public to string holders -- but not one whose MAC
+        verifies, because K_auth_s comes from DH_es."""
+        impostor_private, _ = fteproxy.generate_server_key()
+        client = client_for(self.CASE)
+        _hello, reply, _keys = accept(
+            self.CASE, client.hello_bytes, server_private=impostor_private)
+        with pytest.raises(hs.InvalidHello):
+            client.finish(reply)
+
+    def test_a_client_with_the_wrong_server_id_derives_different_keys(self):
+        _other_private, other_public = fteproxy.generate_server_key()
+        client = hs.ClientHandshake(
+            server_public=other_public, format=self.CASE['format'],
+            mode=self.CASE['mode'], defs=self.CASE['defs'],
+            epoch=self.CASE['epoch'],
+            ephemeral_private=unhex(self.CASE['client_ephemeral_private']))
+        _hello, reply, _keys = accept(self.CASE, client.hello_bytes)
+        with pytest.raises(hs.InvalidHello):
+            client.finish(reply)
+
+    def test_all_zero_shared_secret_is_refused(self):
+        """A small-order peer point would drive the shared secret to zero and
+        let anyone who can rewrite the hellos fix both key schedules."""
+        with pytest.raises(hs.InvalidHello):
+            hs._x25519(unhex(self.CASE['client_ephemeral_private']),
+                       b'\x00' * 32)
+
+
+class TestEpoch:
+
+    CASE = CASES[0]
+
+    def hello_at(self, epoch):
+        return hs.ClientHello(
+            mode=self.CASE['mode'], defs=self.CASE['defs'],
+            format=self.CASE['format'],
+            client_public=unhex(self.CASE['client_ephemeral_public']),
+            epoch=epoch).encode()
+
+    @pytest.mark.parametrize('skew', [-1, 0, 1])
+    def test_inside_the_window_is_accepted(self, skew):
+        now = self.CASE['epoch']
+        accept(self.CASE, self.hello_at(now + skew), now_epoch=now)
+
+    @pytest.mark.parametrize('skew', [-2, 2, 24, -24])
+    def test_outside_the_window_is_refused(self, skew):
+        now = self.CASE['epoch']
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, self.hello_at(now + skew), now_epoch=now)
+
+    def test_current_epoch_is_hours(self):
+        assert hs.current_epoch(now=0) == 0
+        assert hs.current_epoch(now=3599) == 0
+        assert hs.current_epoch(now=3600) == 1
+        assert hs.current_epoch(now=7200) == 2
+
+
+class TestReplayFilter:
+
+    CASE = CASES[0]
+
+    def test_a_repeated_hello_is_refused(self):
+        replay = hs.ReplayFilter()
+        hello_bytes = unhex(self.CASE['client_hello'])
+        accept(self.CASE, hello_bytes, replay=replay)
+        with pytest.raises(hs.ReplayedHello):
+            accept(self.CASE, hello_bytes, replay=replay)
+
+    def test_a_fresh_ephemeral_key_is_accepted(self):
+        replay = hs.ReplayFilter()
+        accept(self.CASE, unhex(self.CASE['client_hello']), replay=replay)
+        fresh = client_for(dict(self.CASE,
+                                client_ephemeral_private=os.urandom(32).hex()))
+        accept(self.CASE, fresh.hello_bytes, replay=replay)
+
+    def test_a_key_outside_the_window_is_forgotten(self):
+        """The window is what bounds the filter: past it a hello is refused on
+        its epoch, so remembering the key buys nothing."""
+        replay = hs.ReplayFilter()
+        now = self.CASE['epoch']
+        assert replay.observe(b'\x01' * 32, now, now)
+        assert not replay.observe(b'\x01' * 32, now, now)
+        assert replay.observe(b'\x01' * 32, now + 10, now + 10)
+
+    def test_neighbouring_epochs_are_remembered(self):
+        replay = hs.ReplayFilter()
+        now = self.CASE['epoch']
+        assert replay.observe(b'\x02' * 32, now - 1, now)
+        assert not replay.observe(b'\x02' * 32, now, now)
+        assert not replay.observe(b'\x02' * 32, now + 1, now)
+
+    def test_the_filter_is_bounded(self):
+        replay = hs.ReplayFilter(max_entries=64)
+        now = 100
+        for epoch in (now - 1, now, now + 1):
+            for i in range(64):
+                replay.observe(bytes([epoch % 256, i]) + b'\x00' * 30, epoch,
+                               now)
+        assert len(replay) <= 64 + 64
+
+    def test_a_rejected_hello_does_not_enter_the_filter(self):
+        """observe() runs last, so a hello refused for its epoch or format
+        cannot be used to fill the filter and lock out a real client."""
+        replay = hs.ReplayFilter()
+        now = self.CASE['epoch']
+        stale = hs.ClientHello(
+            mode=self.CASE['mode'], defs=self.CASE['defs'],
+            format=self.CASE['format'],
+            client_public=unhex(self.CASE['client_ephemeral_public']),
+            epoch=now + 12).encode()
+        with pytest.raises(hs.InvalidHello):
+            accept(self.CASE, stale, replay=replay, now_epoch=now)
+        assert len(replay) == 0
+        # The same ephemeral key still works at a valid epoch.
+        accept(self.CASE, unhex(self.CASE['client_hello']), replay=replay,
+               now_epoch=now)
+
+
+class TestKeyGeneration:
+
+    def test_keys_are_fresh(self):
+        first_private, first_public = fteproxy.generate_server_key()
+        second_private, second_public = fteproxy.generate_server_key()
+        assert len(first_private) == 32 and len(first_public) == 32
+        assert first_private != second_private
+        assert first_public != second_public
+
+    def test_public_half_is_derivable(self):
+        private, public = fteproxy.generate_server_key()
+        assert fteproxy.server_id(private) == public
+
+    @pytest.mark.parametrize('bad', [b'', b'\x00' * 31, b'\x00' * 33, 'text'])
+    def test_wrong_length_is_rejected(self, bad):
+        with pytest.raises(ValueError):
+            hs.server_id(bad)
+
+
+class TestRejectDelay:
+
+    def test_within_one_to_five_seconds(self):
+        for _ in range(200):
+            delay = hs.reject_delay()
+            assert 1.0 <= delay <= 5.0
+
+    def test_varies(self):
+        assert len({hs.reject_delay() for _ in range(50)}) > 1

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -8,6 +8,8 @@ import sys
 import io
 import socket
 import contextlib
+import threading
+import time
 
 import pytest
 
@@ -47,19 +49,21 @@ class TestPython3Compatibility:
         assert len(padded) == 10
         assert padded == "000000test"
 
-    def test_negotiate_cell_bytes_handling(self):
-        """Test NegotiateCell bytes operations."""
-        cell = fteproxy.NegotiateCell()
-        cell.setDefFile("20131224")
-        cell.setLanguage("manual-http")
-        
-        cell_bytes = cell.toBytes()
-        assert len(cell_bytes) == fteproxy.NegotiateCell._CELL_SIZE
-        
-        # Verify padding
-        padding_len = fteproxy.NegotiateCell._PADDING_LEN
-        padding_char = fteproxy.NegotiateCell._PADDING_CHAR
-        assert cell_bytes[:padding_len] == padding_char * padding_len
+    def test_client_hello_bytes_handling(self):
+        """The client hello encodes to bytes and decodes back unchanged."""
+        import fteproxy.handshake as hs
+
+        hello = hs.ClientHello(mode='hybrid', defs=20131224,
+                               format='manual-http',
+                               client_public=bytes(range(32)), epoch=490000)
+        raw = hello.encode()
+        assert isinstance(raw, bytes)
+        back = hs.ClientHello.decode(raw)
+        assert back.format == 'manual-http'
+        assert back.defs == 20131224
+        assert back.mode == 'hybrid'
+        assert back.client_public == bytes(range(32))
+        assert back.epoch == 490000
 
     def test_unicode_handling(self):
         """Test that unicode strings work correctly."""
@@ -128,180 +132,170 @@ class TestNetworkIOBytes:
             server_sock.close()
 
 
-class TestWrapSocket:
-    """Test fteproxy.wrap_socket functionality."""
+class TestCipherCaching:
+    """The DFA is cached; the keyed cipher is not."""
 
-    def test_wrap_socket_no_negotiate(self):
-        """Test wrap_socket with negotiate=False (fixes issue #175)."""
-        import threading
-        
-        client_server_regex = '^(0|1)+$'
-        server_client_regex = '^(A|B)+$'
-        # These are 1-bit-per-character formats. libfte 0.4's expanding cipher
-        # has fixed frame overhead and no unformatted overflow, so the length
-        # must be large enough to hold the payload plus that frame. 520 gives a
-        # 32-byte capacity here (256 would be rejected as too small).
-        length = 520
-        test_data = b'Hello, world!'
-        received_data = []
-        
-        def server_thread(port):
-            server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            server_sock = fteproxy.wrap_socket(server_sock,
-                outgoing_regex=server_client_regex,
-                outgoing_length=length,
-                incoming_regex=client_server_regex,
-                incoming_length=length,
-                negotiate=False)
-            server_sock.bind(('127.0.0.1', port))
-            server_sock.listen(1)
-            
-            conn, addr = server_sock.accept()
-            conn.settimeout(5)
+    def test_regex_format_is_cached(self):
+        """``fte.RegexFormat`` compiles a DFA and depends only on the pattern
+        and the length, so one instance serves every connection."""
+        a = fteproxy._regex_format('^[a-z]+$', 64)
+        assert fteproxy._regex_format('^[a-z]+$', 64) is a
+        assert fteproxy._regex_format('^[a-z]+$', 96) is not a
+
+    def test_make_cipher_is_per_session(self):
+        """Every connection derives its own header keys, so caching the keyed
+        cipher would add an entry per connection and never hit."""
+        key = bytes(range(32))
+        a = fteproxy._make_cipher('^[a-z]+$', 64, key)
+        b = fteproxy._make_cipher('^[a-z]+$', 64, key)
+        assert a is not b
+        # ... but they share the expensive half.
+        assert a.output_format is b.output_format
+
+    def test_cover_cipher_is_cached(self):
+        """K_cover is the same for every connection to a given server, and the
+        first-record scan builds several per connection."""
+        key = bytes(range(32))
+        a = fteproxy._cover_cipher('^[a-z]+$', 64, key)
+        assert fteproxy._cover_cipher('^[a-z]+$', 64, key) is a
+
+
+class TestWrapSocket:
+    """End-to-end use of the 0.4 wrap_socket."""
+
+    @staticmethod
+    def _echo_server(port, private, received, ready):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock = fteproxy.wrap_socket(sock, server_key=private)
+        sock.bind(('127.0.0.1', port))
+        sock.listen(1)
+        ready.set()
+        conn, _ = sock.accept()
+        conn.settimeout(10)
+        try:
+            buf = b''
+            while True:
+                try:
+                    data = conn.recv(65536)
+                except socket.timeout:
+                    continue
+                if not data:
+                    break
+                buf += data
+                if buf == received['expected']:
+                    break
+            received['data'] = buf
+            conn.sendall(buf)
+            # Give the client time to drain before the socket goes away.
+            time.sleep(0.3)
+        finally:
+            conn.close()
+            sock.close()
+
+    def _run(self, payload, mode, format='manual-http'):
+        private, public = fteproxy.generate_server_key()
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(('127.0.0.1', 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        received = {'expected': payload}
+        ready = threading.Event()
+        server = threading.Thread(target=self._echo_server,
+                                  args=(port, private, received, ready))
+        server.start()
+        assert ready.wait(5)
+
+        client = fteproxy.wrap_socket(socket.socket(), server_id=public,
+                                      format=format, mode=mode)
+        try:
+            client.connect(('127.0.0.1', port))
+            client.settimeout(10)
+            client.sendall(payload)
+            echo = b''
+            while len(echo) < len(payload):
+                data = client.recv(65536)
+                if not data:
+                    break
+                echo += data
+        finally:
+            client.close()
+        server.join(timeout=10)
+        return received.get('data'), echo, client
+
+    @pytest.mark.parametrize('mode', ['hybrid', 'format'])
+    def test_bulk_round_trip(self, mode):
+        payload = b'bulk payload ' * 4096  # ~53 KiB, many records
+        got, echo, client = self._run(payload, mode)
+        assert got == payload
+        assert echo == payload
+        assert client.negotiated_mode == mode
+        assert client.negotiated_format == 'manual-http'
+
+    def test_server_learns_a_non_default_format(self):
+        """The server is told nothing; it recovers the format from the first
+        record."""
+        got, echo, client = self._run(b'a non-default format', 'hybrid',
+                                      format='words')
+        assert got == b'a non-default format'
+        assert echo == got
+        assert client.negotiated_format == 'words'
+
+    def test_wrong_server_id_gets_no_reply(self):
+        """A client with the wrong connection string times out rather than
+        receiving an error that would confirm the server."""
+        private, _ = fteproxy.generate_server_key()
+        _, other_public = fteproxy.generate_server_key()
+
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(('127.0.0.1', 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        replies = {}
+
+        def serve():
+            conn, _ = listener.accept()
+            wrapped = fteproxy.wrap_socket(conn, server_key=private)
+            wrapped.settimeout(10)
             try:
-                data = conn.recv(1024)
-                received_data.append(data)
-                conn.sendall(data)  # Echo back
+                replies['recv'] = wrapped.recv(65536)
+            except socket.timeout:
+                replies['recv'] = 'timeout'
             finally:
                 conn.close()
-                server_sock.close()
-        
-        # Find an available port
-        temp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        temp_sock.bind(('127.0.0.1', 0))
-        port = temp_sock.getsockname()[1]
-        temp_sock.close()
-        
-        # Start server in background
-        server = threading.Thread(target=server_thread, args=(port,))
+
+        server = threading.Thread(target=serve)
         server.start()
-        
-        import time
-        time.sleep(0.5)  # Give server time to start
-        
-        # Client connects and sends data
-        client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        client_sock = fteproxy.wrap_socket(client_sock,
-            outgoing_regex=client_server_regex,
-            outgoing_length=length,
-            incoming_regex=server_client_regex,
-            incoming_length=length,
-            negotiate=False)
-        
+
+        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 1)
+        client = fteproxy.wrap_socket(socket.socket(), server_id=other_public)
         try:
-            client_sock.connect(('127.0.0.1', port))
-            client_sock.settimeout(5)
-            client_sock.sendall(test_data)
-            echo_data = client_sock.recv(1024)
-        finally:
-            client_sock.close()
-        
-        server.join(timeout=5)
-
-        # Verify data was received correctly
-        assert len(received_data) == 1
-        assert received_data[0] == test_data
-        assert echo_data == test_data
-
-    def test_make_cipher_is_cached(self):
-        """One cipher per (pattern, length, key); libfte 0.4 does not cache DFAs."""
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-        a = fteproxy._make_cipher('^[a-z]+$', 64, key)
-        assert fteproxy._make_cipher('^[a-z]+$', 64, key) is a
-        assert fteproxy._make_cipher('^[a-z]+$', 96, key) is not a
-        assert fteproxy._make_cipher('^[a-z]+$', 64, bytes(range(32))) is not a
-
-    def test_default_key_warns(self, caplog):
-        """Starting with the public built-in key logs a warning; a real key does not."""
-        import logging
-
-        import fteproxy.cli
-        key = 'runtime.fteproxy.encrypter.key'
-        prev = fteproxy.conf.getValue(key)
-        try:
-            with caplog.at_level(logging.WARNING, logger='fteproxy'):
-                fteproxy.conf.setValue(key, fteproxy.conf.DEFAULT_KEY)
-                fteproxy.cli.warn_if_default_key()
-                assert 'default key' in caplog.text
-                caplog.clear()
-                fteproxy.conf.setValue(key, bytes(range(32)))
-                fteproxy.cli.warn_if_default_key()
-                assert caplog.text == ''
-        finally:
-            fteproxy.conf.setValue(key, prev)
-
-    @pytest.mark.parametrize("mode", ["format", "hybrid"])
-    def test_wrap_socket_bulk_end_to_end(self, mode):
-        """Full negotiation + bulk transfer, in each record-layer mode."""
-        import threading
-        import time
-
-        prev_mode = fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode')
-        fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', mode)
-        try:
-            fteproxy.conf.setValue('runtime.mode', 'client')
-            fteproxy.defs.load_definitions()
-            up = fteproxy.conf.getValue('runtime.state.upstream_language')
-            down = fteproxy.conf.getValue('runtime.state.downstream_language')
-            up_rx = fteproxy.defs.getRegex(up)
-            up_fs = fteproxy.defs.getLength(up)
-            dn_rx = fteproxy.defs.getRegex(down)
-            dn_fs = fteproxy.defs.getLength(down)
-            # Large enough to span many records (each body up to ~1 MiB).
-            payload = b'hybrid bulk payload ' * 4096  # ~80 KiB
-            received = {}
-
-            def server_thread(port):
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                s = fteproxy.wrap_socket(s)  # server auto-detects via negotiation
-                s.bind(('127.0.0.1', port))
-                s.listen(1)
-                conn, _ = s.accept()
-                conn.settimeout(5)
-                try:
-                    buf = b''
-                    while len(buf) < len(payload):
-                        data = conn.recv(65536)
-                        if not data:
-                            break
-                        buf += data
-                    received['data'] = buf
-                    conn.sendall(buf)  # echo
-                finally:
-                    conn.close()
-                    s.close()
-
-            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            probe.bind(('127.0.0.1', 0))
-            port = probe.getsockname()[1]
-            probe.close()
-
-            server = threading.Thread(target=server_thread, args=(port,))
-            server.start()
-            time.sleep(0.5)
-
-            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client = fteproxy.wrap_socket(
-                client,
-                outgoing_regex=up_rx, outgoing_length=up_fs,
-                incoming_regex=dn_rx, incoming_length=dn_fs)
-            try:
+            with pytest.raises(fteproxy.HandshakeFailedException):
                 client.connect(('127.0.0.1', port))
-                client.settimeout(5)
-                client.sendall(payload)
-                echo = b''
-                while len(echo) < len(payload):
-                    data = client.recv(65536)
-                    if not data:
-                        break
-                    echo += data
-            finally:
-                client.close()
-
-            server.join(timeout=5)
-            assert received.get('data') == payload
-            assert echo == payload
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', prev_mode)
+            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', previous)
+            client.close()
+            server.join(timeout=15)
+            listener.close()
+        # The server read and discarded, then reported EOF; it never replied.
+        assert replies.get('recv') == b''
+
+    def test_wrap_socket_needs_exactly_one_role(self):
+        private, public = fteproxy.generate_server_key()
+        with pytest.raises(fteproxy.InvalidRoleException):
+            fteproxy.wrap_socket(socket.socket())
+        with pytest.raises(fteproxy.InvalidRoleException):
+            fteproxy.wrap_socket(socket.socket(), server_key=private,
+                                 server_id=public)
+
+    def test_server_id_accepts_base64url(self):
+        import base64
+
+        _, public = fteproxy.generate_server_key()
+        text = base64.urlsafe_b64encode(public).rstrip(b'=').decode('ascii')
+        assert len(text) == 43
+        assert fteproxy._as_key_bytes(text, 'server_id') == public

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -10,6 +10,7 @@ import struct
 import pytest
 import fte
 
+import fteproxy
 import fteproxy.conf
 import fteproxy.defs
 import fteproxy.record_layer
@@ -113,16 +114,18 @@ class _RaisingCipher:
 
 
 class _FixedCellCipher:
-    """Cipher stub for a fixed-size covertext frame. Its plaintext seals the
-    covertext bytes (length, then the stream position it is decrypted at) so
-    the Decoder's unseal step recovers them."""
+    """Cipher stub for a fixed-size covertext frame. Its plaintext seals a DATA
+    record whose payload is the covertext bytes (length, then the stream
+    position it is decrypted at, then the record type) so the Decoder's unseal
+    and type-split steps recover them."""
 
     def __init__(self, cell_size=4):
         self.output_format = _Format(cell_size)
         self._seq = 0
 
     def decrypt(self, covertext):
-        sealed = struct.pack('>IQ', len(covertext), self._seq) + covertext
+        message = bytes((fteproxy.record_layer.DATA,)) + covertext
+        sealed = struct.pack('>IQ', len(message), self._seq) + message
         self._seq += 1
         return sealed
 
@@ -145,18 +148,18 @@ class TestDecoderExceptionHandling:
         decoder.push(b'some-ciphertext-bytes')
 
         with pytest.raises(SystemExit):
-            decoder.pop(oneCell=True)
+            decoder.pop(limit=1)
 
-    def test_onecell_returns_exactly_one_cell(self):
-        """oneCell=True returns a single decoded cell and advances the buffer."""
+    def test_limit_returns_exactly_one_record(self):
+        """limit=1 returns a single decoded record and advances the buffer."""
         decoder = fteproxy.record_layer.Decoder(cipher=_FixedCellCipher(4))
         decoder.push(b'AAAABBBBCCCC')
 
-        assert decoder.pop(oneCell=True) == b'AAAA'
+        assert decoder.pop(limit=1) == b'AAAA'
         assert decoder._buffer == b'BBBBCCCC'
 
-    def test_multicell_drains_entire_buffer(self):
-        """oneCell=False drains every cell from the buffer."""
+    def test_unlimited_drains_entire_buffer(self):
+        """Without a limit every record in the buffer is drained."""
         decoder = fteproxy.record_layer.Decoder(cipher=_FixedCellCipher(4))
         decoder.push(b'AAAABBBBCCCC')
 
@@ -336,3 +339,97 @@ def test_seal_fills_covertext_with_random_not_padding():
     for path in (fmt_path, hyb_path):
         assert len(path) > 100        # the path fills the covertext capacity
         assert len(set(path)) > 15    # random-looking, not a single-char run
+
+
+class TestRecordTypes:
+    """Every record carries a type byte; unknown types close the connection."""
+
+    def _pair(self, hybrid=True, language='manual-http-request'):
+        fteproxy.conf.setValue('runtime.mode', 'client')
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        cipher = fteproxy._make_cipher(
+            fteproxy.defs.getRegex(language),
+            fteproxy.defs.getLength(language), key)
+        body = fteproxy._make_body_cipher(key) if hybrid else None
+        return (fteproxy.record_layer.Encoder(cipher=cipher, body_cipher=body),
+                fteproxy.record_layer.Decoder(cipher=cipher, body_cipher=body))
+
+    @pytest.mark.parametrize('hybrid', [True, False])
+    @pytest.mark.parametrize('record_type,payload', [
+        (fteproxy.record_layer.DATA, b'application bytes'),
+        (fteproxy.record_layer.OPEN, b'\x03\x0bexample.com\x01\xbb'),
+        (fteproxy.record_layer.OPEN_RESULT, b'\x00'),
+        (fteproxy.record_layer.PADDING, b'\x00' * 32),
+        (fteproxy.record_layer.CLOSE, b''),
+    ])
+    def test_every_type_round_trips(self, hybrid, record_type, payload):
+        encoder, decoder = self._pair(hybrid=hybrid)
+        decoder.push(encoder.encode(record_type, payload))
+        assert decoder.pop_records() == [(record_type, payload)]
+
+    @pytest.mark.parametrize('hybrid', [True, False])
+    def test_types_interleave_with_data(self, hybrid):
+        encoder, decoder = self._pair(hybrid=hybrid)
+        wire = encoder.encode(fteproxy.record_layer.OPEN, b'dest')
+        encoder.push(b'payload')
+        wire += encoder.pop()
+        wire += encoder.encode(fteproxy.record_layer.CLOSE)
+        decoder.push(wire)
+        assert decoder.pop_records() == [
+            (fteproxy.record_layer.OPEN, b'dest'),
+            (fteproxy.record_layer.DATA, b'payload'),
+            (fteproxy.record_layer.CLOSE, b''),
+        ]
+
+    @pytest.mark.parametrize('hybrid', [True, False])
+    def test_unknown_type_raises(self, hybrid):
+        """Only a peer with the session keys can produce one, so this is a
+        version mismatch: the caller closes rather than guessing."""
+        encoder, decoder = self._pair(hybrid=hybrid)
+        # Reach past encode()'s validation to build a record no version
+        # defines.
+        decoder.push(encoder._emit(0x7f, b'from the future'))
+        with pytest.raises(fteproxy.record_layer.UnknownRecordType):
+            decoder.pop_records()
+
+    def test_encode_rejects_an_unknown_type(self):
+        encoder, _ = self._pair()
+        with pytest.raises(ValueError):
+            encoder.encode(0x7f, b'')
+
+    def test_encode_rejects_an_oversized_payload(self):
+        encoder, _ = self._pair(hybrid=False)
+        with pytest.raises(ValueError):
+            encoder.encode(fteproxy.record_layer.OPEN,
+                           b'x' * (encoder.capacity + 1))
+
+    def test_capacity_accounts_for_the_type_byte(self):
+        """In format mode the type byte comes out of the covertext's fixed
+        capacity. In hybrid mode the body has no fixed width, so it rides on
+        top and the chunk boundaries are unchanged: a 1 MiB write is still one
+        record, not one plus a one-byte straggler."""
+        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        cipher = fteproxy._make_cipher(
+            fteproxy.defs.getRegex('manual-http-request'),
+            fteproxy.defs.getLength('manual-http-request'), key)
+        formatted = fteproxy.record_layer.Encoder(cipher=cipher)
+        assert formatted.capacity == cipher.max_plaintext_bytes - 12 - 1
+        body = fteproxy._make_body_cipher(key)
+        hybrid = fteproxy.record_layer.Encoder(cipher=cipher, body_cipher=body)
+        assert hybrid.capacity == body.max_plaintext_bytes
+
+    def test_a_full_capacity_write_is_one_record(self):
+        encoder, decoder = self._pair(hybrid=True)
+        payload = b'z' * encoder.capacity
+        encoder.push(payload)
+        wire = encoder.pop()
+        decoder.push(wire)
+        assert decoder.pop_records() == [(fteproxy.record_layer.DATA, payload)]
+
+    def test_pop_refuses_a_control_record(self):
+        """pop() is the data-only convenience; a control record must not be
+        silently dropped by a caller that only wanted bytes."""
+        encoder, decoder = self._pair()
+        decoder.push(encoder.encode(fteproxy.record_layer.OPEN, b'dest'))
+        with pytest.raises(fteproxy.record_layer.UnknownRecordType):
+            decoder.pop()

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -1,22 +1,30 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Tests for _FTESocketWrapper.recv() connection-close (EOF) semantics.
+"""Tests for ``_FTESocketWrapper``: EOF semantics and the reject path.
 
-These exercise a gap in the existing suite: what recv() does when the peer
-closes the TCP connection while undecodable bytes remain buffered in the
-decoder (e.g. the peer was cut off part-way through a covertext cell).
+The EOF cases exercise what ``recv()`` does when the peer closes the TCP
+connection while undecodable bytes remain buffered (the peer was cut off
+part-way through a covertext), and what the server does with a first record it
+cannot validate. Both are places where returning "not ready yet" instead of
+EOF used to leave a relay worker polling a dead socket forever.
 """
+
+import socket
+import time
 
 import pytest
 
 import fteproxy
 import fteproxy.conf
 import fteproxy.defs
+import fteproxy.handshake
 import fteproxy.record_layer
 
 
-FORMAT = 'manual-http-request'
+FORMAT = 'manual-http'
+MODE = 'hybrid'
+
+SERVER_PRIVATE, SERVER_PUBLIC = fteproxy.generate_server_key()
 
 
 @pytest.fixture(autouse=True)
@@ -25,20 +33,26 @@ def _defs():
     fteproxy.defs.load_definitions()
 
 
-def _regex_length():
-    return (fteproxy.defs.getRegex(FORMAT), fteproxy.defs.getLength(FORMAT))
+def _session_keys():
+    """Deterministic session keys, standing in for a completed handshake."""
+    return fteproxy.handshake.derive_session_keys(
+        transcript=b'\x01' * 32, dh_ee=b'\x02' * 32, dh_es=b'\x03' * 32)
 
 
-def _make_cell(payload):
-    """Encode ``payload`` into one covertext record-layer cell."""
-    pattern, length = _regex_length()
-    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-    header = fteproxy._make_cipher(pattern, length, key)
-    # Build through _record_encoder so the cell matches the configured mode (the
-    # wrapper under test decodes with whatever mode conf says).
-    encoder = fteproxy._record_encoder(header, key)
-    encoder.push(payload)
-    return encoder.pop()
+def _completed(sock, keys, is_client, mode=MODE):
+    """A wrapper with the handshake already done, so a test can drive the
+    session stream without standing up a second endpoint."""
+    if is_client:
+        wrapper = fteproxy.wrap_socket(sock, server_id=SERVER_PUBLIC,
+                                       format=FORMAT, mode=mode)
+    else:
+        wrapper = fteproxy.wrap_socket(sock, server_key=SERVER_PRIVATE)
+    wrapper._encoder, wrapper._decoder = fteproxy._session_channel(
+        FORMAT, mode, keys, is_client=is_client)
+    wrapper._handshake_done = True
+    wrapper._negotiated_format = FORMAT
+    wrapper._negotiated_mode = mode
+    return wrapper
 
 
 class FakeSocket:
@@ -51,10 +65,12 @@ class FakeSocket:
     instead of hanging the test process.
     """
 
-    def __init__(self, chunks, spin_cap=5000):
+    def __init__(self, chunks=(), spin_cap=5000):
         self._chunks = list(chunks)
         self._spin_cap = spin_cap
         self.eof_reads = 0
+        self.sent = b''
+        self.timeout = None
 
     def recv(self, _bufsize):
         if self._chunks:
@@ -66,83 +82,281 @@ class FakeSocket:
                 "EOF" % self.eof_reads)
         return b''
 
-    # send()/sendall() are only reached during negotiation; unused here since
-    # these tests wrap with negotiate=False.
     def send(self, data):
+        self.sent += data
         return len(data)
 
     def sendall(self, data):
-        return None
+        self.sent += data
+
+    def gettimeout(self):
+        return self.timeout
+
+    def settimeout(self, value):
+        self.timeout = value
 
 
-def _wrap(fake):
-    regex, length = _regex_length()
-    return fteproxy.wrap_socket(
-        fake,
-        outgoing_regex=regex, outgoing_length=length,
-        incoming_regex=regex, incoming_length=length,
-        negotiate=False)
+class SilentSocket(FakeSocket):
+    """A peer that stays connected but says nothing more.
 
-
-class TestServerNegotiationEOF:
-    """A server-role wrapper whose peer closes before negotiating reports EOF.
-
-    Regression test for a relay worker leak: a failed negotiation used to raise
-    ``socket.timeout`` ("not ready yet") even after the peer had closed, so the
-    worker re-polled a closed socket at the throttle rate forever. Under libfte
-    0.4 every mismatched peer (a 0.3 client, a wrong key, a wrong
-    --record-layer-mode, a port scanner) takes this path.
+    Once its queued chunks run out, recv() honours the socket timeout and
+    raises, as a real socket does, instead of reporting EOF. This is what an
+    active prober looks like: it does not hang up when it gets no answer.
     """
 
-    def _server_wrap(self, fake):
-        return fteproxy.wrap_socket(fake)  # no formats given: server role
+    def __init__(self, chunks=()):
+        super().__init__(chunks)
+        self.reads = 0
+
+    def recv(self, _bufsize):
+        self.reads += 1
+        if self._chunks:
+            return self._chunks.pop(0)
+        time.sleep(self.timeout if self.timeout else 0.01)
+        raise socket.timeout()
+
+
+class TestServerHandshakeEOF:
+    """A server whose peer closes before a hello decodes reports EOF.
+
+    Regression test for a relay worker leak: a failed handshake that raised
+    ``socket.timeout`` ("not ready yet") after the peer had closed left the
+    worker re-polling a closed socket at the throttle rate forever. Every
+    mismatched peer -- a 0.3 client, a wrong connection string, a port
+    scanner -- takes this path.
+    """
 
     def test_close_without_data_returns_eof(self):
-        fake = FakeSocket([])
-        assert self._server_wrap(fake).recv(65536) == b''
+        fake = FakeSocket()
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
         assert fake.eof_reads == 1
+        assert fake.sent == b''
 
     def test_garbage_then_close_returns_eof(self):
-        import socket
-        fake = FakeSocket([b'not a negotiation cell'])
-        wrapper = self._server_wrap(fake)
-        with pytest.raises(socket.timeout):  # cell incomplete: keep waiting
-            wrapper.recv(65536)
-        assert wrapper.recv(65536) == b''    # peer gone: EOF, not another wait
-        assert fake.eof_reads == 1
+        fake = FakeSocket([b'not a client hello'])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b'', 'the server must never reply to a bad hello'
+
+
+class TestServerRejectPath:
+    """A hello that decodes but does not validate is answered with silence."""
+
+    def _hello_for(self, **overrides):
+        settings = dict(server_public=SERVER_PUBLIC, format=FORMAT,
+                        mode=MODE, defs=20260110)
+        settings.update(overrides)
+        return fteproxy.handshake.ClientHandshake(**settings)
+
+    def _seal(self, hello_bytes, cover_key):
+        cipher = fteproxy._cipher_for(FORMAT + '-request', cover_key,
+                                      cover=True)
+        return fteproxy.record_layer._seal(cipher, hello_bytes, 0)
+
+    def test_stale_epoch_gets_no_reply(self, monkeypatch):
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        driver = self._hello_for(epoch=fteproxy.handshake.current_epoch() - 48)
+        sealed = self._seal(driver.hello_bytes,
+                            fteproxy.handshake.cover_key(SERVER_PUBLIC))
+        fake = FakeSocket([sealed])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b''
+
+    def test_wrong_cover_key_gets_no_reply(self, monkeypatch):
+        """A hello sealed for a different server never decodes here, so the
+        server waits out its handshake deadline and then discards."""
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 0.2)
+        try:
+            _other_private, other_public = fteproxy.generate_server_key()
+            driver = self._hello_for(server_public=other_public)
+            sealed = self._seal(driver.hello_bytes,
+                                fteproxy.handshake.cover_key(other_public))
+            # The peer stays connected but silent after its bad hello.
+            fake = FakeSocket([sealed], spin_cap=10 ** 6)
+            server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+            assert server.recv(65536) == b''
+            assert fake.sent == b''
+        finally:
+            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+                                   previous)
+
+    def test_reject_discards_for_a_while_before_closing(self, monkeypatch):
+        """obfs4's behaviour: the connection stays open, reading and
+        discarding, so a prober that stays connected cannot time the failure
+        or tell it from a service with nothing to say."""
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.25)
+        driver = self._hello_for(epoch=0)
+        sealed = self._seal(driver.hello_bytes,
+                            fteproxy.handshake.cover_key(SERVER_PUBLIC))
+        fake = SilentSocket([sealed])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        started = time.monotonic()
+        assert server.recv(65536) == b''
+        assert time.monotonic() - started >= 0.2
+        assert fake.sent == b''
+        assert fake.reads > 1, 'the connection was read, not just held open'
+
+    def test_replayed_hello_gets_no_reply(self, monkeypatch):
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        driver = self._hello_for()
+        sealed = self._seal(driver.hello_bytes,
+                            fteproxy.handshake.cover_key(SERVER_PUBLIC))
+
+        first = FakeSocket([sealed])
+        assert fteproxy.wrap_socket(
+            first, server_key=SERVER_PRIVATE).recv(65536) == b''
+        assert first.sent, 'the first hello is answered'
+
+        second = FakeSocket([sealed])
+        assert fteproxy.wrap_socket(
+            second, server_key=SERVER_PRIVATE).recv(65536) == b''
+        assert second.sent == b'', 'the replay is not'
 
 
 class TestRecvEOF:
     """recv() must report EOF (return b'') once the peer has closed."""
 
+    def _peer_records(self, *payloads):
+        """Wire bytes as the *other* end of this session would produce them."""
+        keys = _session_keys()
+        peer = _completed(FakeSocket(), keys, is_client=False)
+        wire = b''
+        for payload in payloads:
+            peer._encoder.push(payload)
+            wire += peer._encoder.pop()
+        return wire
+
+    def _wrap(self, chunks):
+        fake = FakeSocket(chunks)
+        return fake, _completed(fake, _session_keys(), is_client=True)
+
     def test_clean_eof_returns_empty(self):
-        """Peer closes with nothing buffered -> recv() returns b''."""
-        wrapper = _wrap(FakeSocket([]))
+        _fake, wrapper = self._wrap([])
         assert wrapper.recv(65536) == b''
 
-    def test_complete_cell_then_eof(self):
-        """A full cell is delivered, then recv() reports EOF on the next call."""
-        wrapper = _wrap(FakeSocket([_make_cell(b'hello')]))
+    def test_complete_record_then_eof(self):
+        _fake, wrapper = self._wrap([self._peer_records(b'hello')])
         assert wrapper.recv(65536) == b'hello'
         assert wrapper.recv(65536) == b''
 
-    def test_truncated_cell_after_close_returns_eof(self):
-        """Peer closes mid-cell (truncated covertext left in the buffer).
-
-        The leftover bytes can never form a complete cell because the peer is
-        gone, so recv() must return b'' (EOF) rather than busy-looping on a
-        closed socket forever.
-        """
-        truncated = _make_cell(b'hello')[:-3]
-        fake = FakeSocket([truncated])
-        wrapper = _wrap(fake)
+    def test_truncated_record_after_close_returns_eof(self):
+        """Peer closes mid-record, so the leftover bytes can never complete."""
+        _fake, wrapper = self._wrap([self._peer_records(b'hello')[:-3]])
         assert wrapper.recv(65536) == b''
 
-    def test_good_cell_then_truncated_tail_then_eof(self):
-        """Decode the good cell, then report EOF for the truncated tail."""
-        good = _make_cell(b'hello')
-        truncated_tail = _make_cell(b'world')[:-3]
-        fake = FakeSocket([good + truncated_tail])
-        wrapper = _wrap(fake)
+    def test_good_record_then_truncated_tail_then_eof(self):
+        wire = self._peer_records(b'hello') + self._peer_records(b'world')[:-3]
+        _fake, wrapper = self._wrap([wire])
         assert wrapper.recv(65536) == b'hello'
         assert wrapper.recv(65536) == b''
+
+
+class TestControlRecords:
+    """CLOSE and the other types reach the caller, not the byte stream."""
+
+    def _peer(self):
+        keys = _session_keys()
+        peer = _completed(FakeSocket(), keys, is_client=False)
+        return keys, peer
+
+    def test_close_record_is_eof_for_the_data_stream(self):
+        keys, peer = self._peer()
+        peer._encoder.push(b'last bytes')
+        wire = peer._encoder.pop() + peer._encoder.encode(
+            fteproxy.record_layer.CLOSE)
+        fake = FakeSocket([wire], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b'last bytes'
+        assert wrapper.recv(65536) == b''
+        assert wrapper.peer_closed
+        # EOF came from the record, not from a closed socket.
+        assert fake.eof_reads == 0
+
+    def test_control_records_are_queued(self):
+        keys, peer = self._peer()
+        wire = peer._encoder.encode(fteproxy.record_layer.OPEN, b'dest')
+        peer._encoder.push(b'bytes')
+        wire += peer._encoder.pop()
+        fake = FakeSocket([wire])
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b'bytes'
+        assert wrapper.next_control_record() == (
+            fteproxy.record_layer.OPEN, b'dest')
+        assert wrapper.next_control_record() is None
+
+    def test_padding_is_ignored(self):
+        keys, peer = self._peer()
+        wire = peer._encoder.encode(fteproxy.record_layer.PADDING, b'\x00' * 8)
+        peer._encoder.push(b'bytes')
+        wire += peer._encoder.pop()
+        fake = FakeSocket([wire])
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b'bytes'
+        assert wrapper.next_control_record() is None
+
+    def test_unknown_type_closes_the_connection(self):
+        keys, peer = self._peer()
+        fake = FakeSocket([peer._encoder._emit(0x7f, b'future')], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b''
+
+
+class TestServerBuffersBeforeTheHandshake:
+    """A destination that speaks first (an SSH or SMTP banner) is held until
+    the client's hello arrives, rather than crashing on a missing encoder."""
+
+    def test_send_before_the_handshake_is_buffered(self):
+        fake = FakeSocket()
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.send(b'SSH-2.0-banner') == len(b'SSH-2.0-banner')
+        assert fake.sent == b''
+        assert server._pre_handshake_outgoing == b'SSH-2.0-banner'
+
+    def test_the_buffer_is_bounded(self):
+        fake = FakeSocket()
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        with pytest.raises(fteproxy.ChannelNotReadyException):
+            server.send(b'x' * (server._MAX_PRE_HANDSHAKE_BYTES + 1))
+
+
+class TestPreProtocolClient:
+    """A client speaking the pre-0.4 shared-key negotiation gets no reply.
+
+    On master the first record was a 64-byte cell sealed under a static shared
+    key, with no version, no keypair and no epoch. There is no compatibility
+    path (plan decision D1), so such a client must look exactly like any other
+    peer the server cannot validate: silence.
+    """
+
+    LEGACY_KEY = b'\xFF' * 16 + b'\x00' * 16
+    LEGACY_CELL = b'\x00' * 32 + b'20260110' + b'manual-http'
+
+    def test_no_reply_and_one_debug_line(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 0.2)
+        try:
+            cipher = fteproxy._make_cipher(
+                fteproxy.defs.getRegex(FORMAT + '-request'),
+                fteproxy.defs.getLength(FORMAT + '-request'),
+                self.LEGACY_KEY)
+            cell = self.LEGACY_CELL.rjust(64, b'\x00')
+            sealed = fteproxy.record_layer._seal(cipher, cell, 0)
+            fake = SilentSocket([sealed])
+            server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+            with caplog.at_level(logging.DEBUG, logger='fteproxy'):
+                assert server.recv(65536) == b''
+        finally:
+            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+                                   previous)
+        assert fake.sent == b''
+        rejections = [record for record in caplog.records
+                      if 'rejecting handshake without reply' in record.message]
+        assert len(rejections) == 1
+        assert rejections[0].levelno == logging.DEBUG

--- a/fteproxy/tests/vectors/handshake_v1.json
+++ b/fteproxy/tests/vectors/handshake_v1.json
@@ -1,0 +1,87 @@
+{
+  "cases": [
+    {
+      "client_ephemeral_private": "d6f69cb7ca67ca10db63890d5fa1ccae64a235451fb8b89fe233d256fae6d608",
+      "client_ephemeral_public": "0abd6e1705a18a41810163acc4ac6a9706ce8c8da4e73016c6775e5cf2e6ab57",
+      "client_hello": "01000135250e0b6d616e75616c2d687474700abd6e1705a18a41810163acc4ac6a9706ce8c8da4e73016c6775e5cf2e6ab5700077a10",
+      "cover_key": "20224e0b63828602ef3d0073b611469bed6b15faea46d355c8179657e11da488",
+      "defs": 20260110,
+      "dh_ee": "2ac76f183233e8855a601372581f4e6fff00b3285f6526b4751f1eccac6fd638",
+      "dh_es": "9fd338ff83af6205e5725274c20daf074b165cfda9161025564c4230e9cc6001",
+      "epoch": 490000,
+      "format": "manual-http",
+      "keys": {
+        "auth": "a859f573faf08980adc29d89ae3aa57ce9e951c4aeab090762b22327c650861e",
+        "c2s_body": "47ca09b807f6c2b8c57e6f01425ea0342ef8902cd1c89e93aaba4f34a348c7e7",
+        "c2s_header": "9545453c080e8282cf4da03aa04ae743562556a1b892e5e92beabc289b435b46",
+        "s2c_body": "816bbb88272a7a79d17a51756fa1f7df2bc529cb2a8df1c0c2c65882cf706ad8",
+        "s2c_header": "cfd0d0842a72515810c8898fcf5c2c93d4ffb17cad3bdab4c60df359b4d8cdd0"
+      },
+      "mode": "hybrid",
+      "name": "manual-http hybrid",
+      "server_ephemeral_private": "017b04ff89727221401b01a7fa728f430ca3d5bff55252250371fc0a24a0c4cd",
+      "server_ephemeral_public": "03eeac32096b74300f184ee422dc267c84a061b8f9314d489b65f4a1db7ad119",
+      "server_hello": "010003eeac32096b74300f184ee422dc267c84a061b8f9314d489b65f4a1db7ad11979a925597a953a45fb2caff521450bf5",
+      "server_mac": "79a925597a953a45fb2caff521450bf5",
+      "server_private": "589bd270ea528a90177de62911babb35b5ff59b4c68a8fd20ff8ebe322404414",
+      "server_public": "91ead206771bea597c3a7f1b0ecd26fe8692836ed5d061553de6ab0466843641",
+      "transcript_hash": "2e5dd259366fb439496c2fd746277b18af4b1925c650073fcf9fd4cec0c1d487"
+    },
+    {
+      "client_ephemeral_private": "0668b4eef8fecf7d5ec680bd133158f73b72849f5d7ec4e9063ad377e180af44",
+      "client_ephemeral_public": "a81b5fcff70a2a937ca9e06841936120d93792e6ca8641053c9ebab3d8a8c158",
+      "client_hello": "01010135250e05776f726473a81b5fcff70a2a937ca9e06841936120d93792e6ca8641053c9ebab3d8a8c15800077a11",
+      "cover_key": "80111c355bba4249f13ce8c95e35394d74d31e484cc356adf84c7be30fe1d5fb",
+      "defs": 20260110,
+      "dh_ee": "037e0a48ed588eade42bcc1a931a365dfb68d644e4063d5fa5c6570b4080020c",
+      "dh_es": "54881fe84e26d8a2270057d191e44a2fad207ac0c18771433bc2c29c5700f356",
+      "epoch": 490001,
+      "format": "words",
+      "keys": {
+        "auth": "469c40a855df1927b79d96f005062dfcb94e29aab2aee511c24c75d57d7ea755",
+        "c2s_body": "5a32136d6473b911ee43e49cd0325677cbe72350c9d5b4ac32d01d7869736ab0",
+        "c2s_header": "8f59f1fca95bd6808a394c26ae2bf9d7a6dc5795c879b821e9653819fc0b1ae2",
+        "s2c_body": "b92674c200b05e9b88006c912b3ea7388038daae4a456c367a3c4414374a9f01",
+        "s2c_header": "886505f01b6b4b03f247ff521e967a88581667646626e5e4d89691cce2cb6c7c"
+      },
+      "mode": "format",
+      "name": "words format",
+      "server_ephemeral_private": "5bbb7267d6edd788f39d0fddc1ae55ec370408d4a04190714941941a6757f693",
+      "server_ephemeral_public": "c5742ea59e11479517e7f2a750f7c2aaea69aee2a9b7ce649d06f2556ef3761e",
+      "server_hello": "0101c5742ea59e11479517e7f2a750f7c2aaea69aee2a9b7ce649d06f2556ef3761e8ec76a0d50880b082f8f3d50093f70f7",
+      "server_mac": "8ec76a0d50880b082f8f3d50093f70f7",
+      "server_private": "73c6a692b8af5ad9c0cab2f35ba0332803c5e4641d2310a65e43e38fa86ff7de",
+      "server_public": "9cc47300b1b84d0d7e8829c84511fe51abcb94642e01d20c34988fdf11359462",
+      "transcript_hash": "59efc78ec2256d954b0a1a19af5e59c89c8faa03c4fa9136eef5dc80be6e5d79"
+    },
+    {
+      "client_ephemeral_private": "4eeb6e5b291797a0b81f6eff10f21ecde7aff3d7311ab96fc13b7258e307e09b",
+      "client_ephemeral_public": "37ac32ff70fb1a6847b86a0c2642617ad932b5aebce76bb4bfe581af4d2bce6f",
+      "client_hello": "010001332d980c656d61696c2d73696d706c6537ac32ff70fb1a6847b86a0c2642617ad932b5aebce76bb4bfe581af4d2bce6f00000000",
+      "cover_key": "592250c73fe82e765322e6e8a9590d2c4a2db0dea06f195696e1837fa30f5966",
+      "defs": 20131224,
+      "dh_ee": "db7315457753a1527da05f9dcd8cbca5fa09e4b1dcdeaf1497349d6ef6827b0b",
+      "dh_es": "561e989c698a19eb33e04b56f23a7d1cbd3a4f2c0876a214b660345188f44608",
+      "epoch": 0,
+      "format": "email-simple",
+      "keys": {
+        "auth": "22fbee75eb9bea94decd10db4df498825ed046c25a281d6688dec05dba0fb025",
+        "c2s_body": "74b17f041349def84a90fc97b55641cb6cfc1e8cf8473735ab60d8120346c092",
+        "c2s_header": "211178046ac0a8938fc5fb3075c544c851675d9a6953cd2bb61cf20cf50ebd16",
+        "s2c_body": "6953b236cd04dc471af16d7c05b7fa29219fd1d4d6dc954e3f17339470fda874",
+        "s2c_header": "65474902e23edac48cd43a8ce9be950c0f7572f4c486fcaeaa142a0d98c190fb"
+      },
+      "mode": "hybrid",
+      "name": "email-simple hybrid, longest shipped base name",
+      "server_ephemeral_private": "c9aaf9b44e3dd8dd0baecdac2bf026eb7a9b4d025868bbac0a16dc555b2f6cb5",
+      "server_ephemeral_public": "05cf212647f4a25725a7f16e9c7f77a0e3ce8bf4238e2fd8774612a06da4b932",
+      "server_hello": "010005cf212647f4a25725a7f16e9c7f77a0e3ce8bf4238e2fd8774612a06da4b932e282c2b6cbb63668c8b2b719e539f412",
+      "server_mac": "e282c2b6cbb63668c8b2b719e539f412",
+      "server_private": "45a31d6f4c7c82c0c2fe7126e0f804fdc56351011b29d60796bb25a51b61e66d",
+      "server_public": "ded2c5ea177522eea06b16e56b2569e42335c30a0c0cba66e910ae82019a0f63",
+      "transcript_hash": "f58a5efc7593e020ceb68a3fa475d6d7a209178808c1c4e695069ece0f762000"
+    }
+  ],
+  "note": "Test vectors for the fteproxy protocol v1 handshake. Generated once by scripts kept out of the package; the ephemeral keys are derived from fixed labels so a regeneration reproduces the file byte for byte. Everything here is public test data.",
+  "protocol_version": 1
+}


### PR DESCRIPTION
Implements section 5 / PR2 of docs/plan-0.4.md: protocol version 1. The wire
format breaks with 0.3.x and with master's shared-key negotiation (decisions
D1, D2, D7); 0.4.0 has not been cut, so nothing shipped is being broken.

Handshake (fteproxy/handshake.py, new)
- X25519 + HKDF-SHA256 + HMAC-SHA256 from `cryptography`, in the Noise NK
  shape (e, es then e, ee): server authentication and forward secrecy, with
  the client authenticated only by possession of the connection string, as
  obfs4 does.
- Both hello records are libfte covertexts sealed under
  K_cover = HKDF(S_pub, "fteproxy/v1/cover"), in format mode regardless of the
  mode being negotiated, so the server never has to guess the mode to read the
  first record.
- H = SHA-256("fteproxy/v1" || S_pub || client hello || s_pub) is the HKDF
  salt and the server's MAC input, so every handshake byte is bound into the
  keys: a tampered hello yields different keys on the two ends rather than a
  session.
- Five 32-byte keys per connection: K_auth_s and a header and body key for
  each direction. Nothing is shared between connections or directions, which
  closes the cross-stream replay limitation in SECURITY.md and gives forward
  secrecy.
- An all-zero X25519 shared secret is refused explicitly, not left to the
  backend. Every MAC comparison is hmac.compare_digest. SessionKeys.__repr__
  renders "(redacted)".
- Epoch (hours, +/-1 hour) and a c_pub replay filter bucketed by epoch, with a
  bounded size and a documented eviction rule. observe() runs last, so a hello
  refused for any other reason cannot be used to fill the filter.
- Test vectors generated once from fixed seeds and checked in at
  fteproxy/tests/vectors/handshake_v1.json.

Server behaviour on the first record
- Scans request formats, most-recently-matched first, trying to unseal the
  leading covertext under K_cover; a wrong guess is libfte's
  InvalidCovertextError, so the scan falls through.
- Every rejection is answered identically: no reply, read and discard for a
  random 1 to 5 seconds, then close, and one DEBUG line.
- The covertext format and the name inside the hello must agree.

Record layer
- Every record's message now starts with a type byte: DATA, OPEN,
  OPEN_RESULT, PADDING, CLOSE. Unknown types close the connection.
  Decoder.pop_records() returns (type, payload); Encoder.encode() emits one
  record of any type. Framing, sealing, chunking and the body-length bound are
  otherwise untouched, and in hybrid mode the type byte rides on top of the
  body rather than out of the payload, so chunk boundaries (and the 1 MiB
  bulk path) are exactly where they were.
- Ciphers: fte.RegexFormat (the DFA) is cached by (pattern, length); the keyed
  fte.FTE is built per session, since per-connection keys would make a keyed
  cache grow by one entry per connection and never hit. Handshake ciphers keep
  a cache of their own, because K_cover is static per server.

Definitions
- load_definitions() now fails any release with a format that cannot carry a
  client hello (capacity below 128 bytes), which also proves every regex
  compiles at its configured length. 32 entries in 20260110.json had their
  length raised to clear it; only those numbers changed.

Library API
- wrap_socket(sock, server_key=...) or (sock, server_id=..., format=...,
  mode=...); K1, K2 and negotiate= are gone, as are NegotiateCell and
  NegotiationManager. generate_server_key() and server_id() are exported.
  send_record()/next_control_record() carry the new record types; PR3 builds
  OPEN and half-close on them.
- A logging redaction filter is installed on the package logger at import, so
  a connection string, a hex key or a bare server-id cannot reach a log file
  even if a call site formats one into a message.

Deviations from the plan, and why
- Plan 2.3 says to buffer "until at least the largest request-format covertext
  could be present" before scanning. Taken literally that deadlocks: a client
  using a short format sends one covertext and waits, so the buffer never
  reaches the largest format's length. The server instead tries each candidate
  whose covertext would fit in what has arrived, and bounds the wait with the
  negotiate timeout and a 64 KiB buffer cap.
- The server handshake is synchronous (read until the hello decodes or the
  deadline passes) rather than the old "not ready yet" polling. Without it a
  peer that sends a few bytes and falls silent holds a relay worker forever,
  which is the same failure the pre-existing socket-wrapper regression tests
  cover.
- The six socket-based Python examples move to the new wrap_socket here rather
  than in PR5, because PR2 removes the API they call and test_examples.py has
  to stay green. Their prose, the shell examples and examples/README.md remain
  PR5. They now use a published demo keypair and a base format name from the
  definitions file instead of ad-hoc regexes, since the handshake carries a
  name rather than a pattern.
- fteproxy/client.py keeps a temporary shim, marked TODO(PR4), that derives a
  fixed server keypair from the pre-0.4 shared secret so the flat --key /
  --key-file command line keeps working end to end until PR4 lands the
  connection string. The protocol path is the real one; only the provenance of
  the keypair is a stand-in.

Numbers on this machine (LAN loopback, benchmark.py --scenarios lan):
connection setup p50 0.7 ms -> 1.8 ms, which is the extra round trip plus four
X25519 exchanges and two key generations; caching the long-term key object
took 0.6 ms off the first measurement. Record-layer microbenchmark
(encode+decode, hybrid) 688 -> 669 MB/s at 256 KiB and 1003 -> 969 MB/s at
1 MiB, both within run-to-run noise.

Tests: fteproxy/tests/test_handshake.py (102 cases: vectors, every field of
both hellos tampered one at a time, every MAC byte, wrong server key, replay
inside and outside the window, epoch skew, degenerate shared secret);
test_record_layer.py gains every record type in both modes; test_socket_wrapper.py
covers the reject path, a pre-0.4 client getting no reply and one DEBUG line,
and CLOSE as stream EOF; test_cli.py covers log redaction; test_formats.py
covers the capacity check. 289 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
