### PR TITLE
PR4: the two-command CLI and connection string

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,6 @@
 # PYPI_README.md, pyproject.toml, the package sources and fteproxy/defs/*.json
 # via [tool.setuptools.package-data] -- setuptools includes on its own.
 recursive-include fteproxy/tests *.py
+# The handshake test vectors: the sdist should carry what proves the wire
+# format, not just the code that reads it.
+recursive-include fteproxy/tests/vectors *.json

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -15,7 +15,7 @@ pip install -e .                       # needs fte>=0.4.0,<0.5.0
 python3 benchmark.py --baseline        # default 6 scenarios
 python3 benchmark.py --scenarios lan --sizes 64K 1M 8M --repeat 2 --baseline
 python3 benchmark.py --scenarios lan --sizes 8M --direction upload --no-latency --no-setup
-python3 benchmark.py --scenarios lan --sizes 64K 1M --record-layer-mode format
+python3 benchmark.py --scenarios lan --sizes 64K 1M --mode format
 ```
 
 ---

--- a/benchmark.py
+++ b/benchmark.py
@@ -44,10 +44,12 @@ import functools
 import json
 import os
 import random
+import shutil
 import socket
 import statistics
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -398,31 +400,37 @@ class FteProxyTunnel:
         app -> client(entry_port) ==FTE==> [middle] ==> server -> dest(dest_port)
 
     where [middle] is either the server's own port, or a Shaper in front of it.
+
+    Since 0.4 the client is the end that names the destination, so the client
+    runs one `-L entry_port:127.0.0.1:dest_port` forward and the server is
+    given exactly that destination as its allow rule. The server generates its
+    keypair into a throwaway state directory on first start and writes the
+    connection string there; the client reads it from the same directory.
     """
 
-    def __init__(self, dest_port, upstream_format=None, downstream_format=None,
-                 record_layer_mode=None,
+    def __init__(self, dest_port, format=None, mode=None,
                  shaper_kwargs=None, verbose=False):
         self.dest_port = dest_port
         self.entry_port = free_port()
         self.server_port = free_port()
-        self.upstream_format = upstream_format
-        self.downstream_format = downstream_format
-        self.record_layer_mode = record_layer_mode
+        self.format = format
+        self.mode = mode
         self.verbose = verbose
         self.procs = []
         self.shaper = None
+        self.state_dir = None
         self._shaper_kwargs = shaper_kwargs
 
     def start(self):
         py = sys.executable
         out = None if self.verbose else subprocess.DEVNULL
+        self.state_dir = tempfile.mkdtemp(prefix='fteproxy-benchmark-')
 
-        server_cmd = [py, '-m', 'fteproxy', '--mode', 'server', '--quiet',
-                      '--server_ip', '127.0.0.1', '--server_port', str(self.server_port),
-                      '--proxy_ip', '127.0.0.1', '--proxy_port', str(self.dest_port)]
-        if self.record_layer_mode:
-            server_cmd += ['--record-layer-mode', self.record_layer_mode]
+        server_cmd = [py, '-m', 'fteproxy', 'server', '-q',
+                      '--listen', '127.0.0.1:%d' % self.server_port,
+                      '--advertise', '127.0.0.1:%d' % self.server_port,
+                      '--allow', '127.0.0.1:%d' % self.dest_port,
+                      '--state-dir', self.state_dir]
         self.procs.append(subprocess.Popen(server_cmd, stdout=out, stderr=out))
 
         # Client connects either straight to the server, or via the shaper.
@@ -434,27 +442,49 @@ class FteProxyTunnel:
         else:
             client_target = self.server_port
 
-        # The destination travels in band since 0.4, so the client is the end
-        # that names it.
-        client_cmd = [py, '-m', 'fteproxy', '--mode', 'client', '--quiet',
-                      '--client_ip', '127.0.0.1', '--client_port', str(self.entry_port),
-                      '--server_ip', '127.0.0.1', '--server_port', str(client_target),
-                      '--proxy_ip', '127.0.0.1', '--proxy_port', str(self.dest_port)]
-        if self.upstream_format:
-            client_cmd += ['--upstream-format', self.upstream_format]
-        if self.downstream_format:
-            client_cmd += ['--downstream-format', self.downstream_format]
-        if self.record_layer_mode:
-            client_cmd += ['--record-layer-mode', self.record_layer_mode]
-        self.procs.append(subprocess.Popen(client_cmd, stdout=out, stderr=out))
-
         if not wait_listening(self.server_port):
             raise RuntimeError("fteproxy server did not come up")
+        uri = self._connection_string(client_target)
+
+        client_cmd = [py, '-m', 'fteproxy', 'client', uri, '-q',
+                      '--no-check',
+                      '-L', '127.0.0.1:%d:127.0.0.1:%d' % (self.entry_port,
+                                                           self.dest_port),
+                      '--state-dir', self.state_dir]
+        if self.format:
+            client_cmd += ['--format', self.format]
+        if self.mode:
+            client_cmd += ['--mode', self.mode]
+        self.procs.append(subprocess.Popen(client_cmd, stdout=out, stderr=out))
+
         if not wait_listening(self.entry_port):
             raise RuntimeError("fteproxy client did not come up")
         # small settle so the first real connection isn't racing startup
         time.sleep(0.3)
         return self
+
+    def _connection_string(self, port):
+        """The string the server wrote, pointed at whatever the client dials.
+
+        With a shaper in the middle the client connects to the shaper, not to
+        the server's own port, so the host:port has to be rewritten.
+        """
+        path = os.path.join(self.state_dir, 'connection.txt')
+        deadline = time.time() + 30
+        text = ''
+        while time.time() < deadline:
+            try:
+                with open(path) as handle:
+                    text = handle.read().strip()
+                if text:
+                    break
+            except OSError:
+                pass
+            time.sleep(0.05)
+        if not text:
+            raise RuntimeError("fteproxy server wrote no connection string")
+        head, _, _tail = text.partition('@')
+        return '%s@127.0.0.1:%d' % (head, port)
 
     def stop(self):
         if self.shaper:
@@ -465,6 +495,8 @@ class FteProxyTunnel:
         for p in self.procs:
             with contextlib.suppress(Exception):
                 p.wait(timeout=5)
+        if self.state_dir:
+            shutil.rmtree(self.state_dir, ignore_errors=True)
 
 
 class PlainTunnel:
@@ -741,9 +773,7 @@ def run_matrix(args):
             shaper_kwargs = scen['shaper']
             try:
                 tunnel = TunnelCls(dest.port, shaper_kwargs=shaper_kwargs,
-                                   upstream_format=args.upstream_format,
-                                   downstream_format=args.downstream_format,
-                                   record_layer_mode=args.record_layer_mode,
+                                   format=args.format, mode=args.mode,
                                    verbose=args.verbose)
             except TypeError:
                 tunnel = TunnelCls(dest.port, shaper_kwargs=shaper_kwargs)
@@ -863,11 +893,10 @@ def main():
     ap.add_argument('--setup-count', type=int, default=20)
     ap.add_argument('--resilience', action='store_true',
                     help="run the mid-transfer link-drop resilience probe")
-    ap.add_argument('--upstream-format', default=None,
-                    help="fteproxy --upstream-format (e.g. manual-http-request)")
-    ap.add_argument('--downstream-format', default=None)
-    ap.add_argument('--record-layer-mode', choices=['hybrid', 'format'], default=None,
-                    help="fteproxy --record-layer-mode for both endpoints "
+    ap.add_argument('--format', default=None, dest='format',
+                    help="fteproxy client --format, a base name (e.g. manual-http)")
+    ap.add_argument('--mode', choices=['hybrid', 'format'], default=None,
+                    help="fteproxy client --mode; the server follows "
                          "(default: fteproxy's own default, hybrid)")
     ap.add_argument('--json', default=None, metavar='PATH',
                     help="write raw results as JSON")

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -985,9 +985,7 @@ def wrap_socket(sock, server_key=None, server_id=None,
         server_public = _as_key_bytes(server_id, 'server_id')
 
     if format is None:
-        format = fteproxy.conf.getValue('runtime.state.upstream_language')
-        if format.endswith('-request'):
-            format = format[:-len('-request')]
+        format = fteproxy.conf.getValue('fteproxy.default_format')
     if mode is None:
         mode = (fteproxy.handshake.MODE_HYBRID if _hybrid_mode()
                 else fteproxy.handshake.MODE_FORMAT)

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -2,26 +2,33 @@
 # -*- coding: utf-8 -*-
 """The fteproxy command line.
 
+Four subcommands::
+
+    fteproxy server  [--listen [HOST]:PORT] [--allow RULE]... [--advertise HOST[:PORT]]
+                     [--state-dir DIR] [--defs RELEASE] [-q | -v]
+    fteproxy client  [URI] [-D [BIND:]PORT] [-L [BIND:]PORT:HOST:PORT]...
+                     [--format NAME] [--mode hybrid|format] [--no-check]
+                     [--state-dir DIR] [-q | -v]
+    fteproxy keygen  [--state-dir DIR] [--advertise HOST[:PORT]]
+    fteproxy formats [--defs RELEASE]
+
 Both ``python -m fteproxy`` and the ``fteproxy`` console script call
 :func:`main`, which returns a process exit status:
 
 ===  ==========================================================
   0  clean shutdown
-  1  runtime failure (bad format name, unusable key, bind refused)
-  2  usage error (argparse rejected the command line, or a required
-     argument is missing)
+  1  runtime failure (bad format name, unusable key, bind refused,
+     a startup check that could not reach the server)
+  2  usage error
 ===  ==========================================================
 
-Parsing is a plain ``argparse`` parse followed by one
-:func:`apply_args_to_conf` step. The previous ``setConfValue`` action wrote
-``fteproxy.conf`` as a side effect of parsing, which meant a value that came
-from a default never reached the configuration at all (argparse does not run
-actions for defaults). That is why a no-argument run used to die with a
-``TypeError`` deep in the relay, and why it still exited 0.
+Command output -- a connection string, the format table -- goes to stdout, so
+it can be piped. Everything else goes to stderr through the ``fteproxy``
+logger, which carries a redaction filter so that no key, server-id or
+connection string can reach a log file.
 """
 
 import argparse
-import glob
 import logging
 import os
 import signal
@@ -30,6 +37,7 @@ import threading
 
 import fteproxy
 import fteproxy.conf
+import fteproxy.config
 import fteproxy.defs
 import fteproxy.relay
 import fteproxy.stream
@@ -40,10 +48,35 @@ EXIT_OK = 0
 EXIT_FAILURE = 1
 EXIT_USAGE = 2
 
+DEFAULT_LISTEN = ':8080'
+DEFAULT_SOCKS = '127.0.0.1:1080'
+DEFAULT_FORMAT = 'manual-http'
+DEFAULT_MODE = 'hybrid'
+
+SUBCOMMANDS = ('server', 'client', 'keygen', 'formats')
+
+#: Flags from the pre-0.4 command line. They are recognised only so that a
+#: script carrying one gets a pointer instead of "unrecognized arguments", and
+#: are never aliased: the destination is chosen on the client now and the
+#: shared key is gone, so a silent alias would run a different topology than
+#: the operator asked for.
+REMOVED_FLAGS = (
+    '--mode', '--stop', '--quiet', '--key', '--key-file', '--release',
+    '--client_ip', '--client_port', '--server_ip', '--server_port',
+    '--proxy_ip', '--proxy_port',
+    '--upstream-format', '--downstream-format', '--record-layer-mode',
+)
+
 _LICENSE_BANNER = """fteproxy %s
 Copyright (C) 2012-2026 Kevin P. Dyer <kpdyer@gmail.com>
 This program comes with ABSOLUTELY NO WARRANTY. This is free software, and
 you are welcome to redistribute it under certain conditions.""" % FTEPROXY_VERSION
+
+_UPGRADE_POINTER = (
+    "fteproxy: %s was removed in 0.4. The destination is chosen on the client "
+    "now and the shared key is replaced by a connection string, so the old "
+    "flags would run a different topology than you asked for. See 'Upgrading "
+    "to 0.4.0' in the README.")
 
 
 class _PrintVersion(argparse.Action):
@@ -66,14 +99,14 @@ class _PrintVersion(argparse.Action):
 class UsageError(Exception):
     """The command line parsed, but one of its values cannot be used.
 
-    Reported like any other argparse error: the message on stderr and exit
-    status 2.
+    Reported like any other argparse error: the message on stderr, exit 2.
     """
 
 
 class StartupError(Exception):
-    """A resource the run needs could not be obtained: an unknown format name,
-    a format the key cannot drive, or a port that will not bind. Exit status 1.
+    """A resource the run needs could not be obtained: an unknown format, a
+    key that cannot be read, a port that will not bind, or a server the
+    startup check could not reach. Exit status 1.
     """
 
 
@@ -84,8 +117,9 @@ class StartupError(Exception):
 def configure_logging(quiet=False, verbose=False):
     """Point the ``fteproxy`` logger at stderr and set its level.
 
-    Default INFO, ``-q`` ERROR, ``-v`` DEBUG. stderr, not stdout, so that a
-    command whose stdout is data (``fteproxy formats``) stays pipeable.
+    Default INFO, ``-q`` ERROR, ``-v`` DEBUG. The package logger already
+    carries :class:`fteproxy.RedactingFilter`, so a key or a connection string
+    that reaches a message is stripped before any handler sees it.
     """
     if quiet:
         level = logging.ERROR
@@ -108,235 +142,207 @@ def configure_logging(quiet=False, verbose=False):
     return level
 
 
-# --------------------------------------------------------------------------- #
-# Keys
-# --------------------------------------------------------------------------- #
-
-def parse_hex_key(hex_key):
-    """Validate a hex-encoded key and return it as bytes.
-
-    The key must be exactly 64 hexadecimal characters (a 32-byte key).
-    Surrounding whitespace is ignored so keys read from a file may end in a
-    trailing newline. Raises :class:`UsageError` on invalid input; the message
-    never contains the key material.
-    """
-    hex_key = hex_key.strip()
-    if len(hex_key) != 64:
-        raise UsageError('invalid key length: %d hex characters, expected 64'
-                         % len(hex_key))
-    try:
-        return bytes.fromhex(hex_key)
-    except ValueError:
-        raise UsageError('invalid key format: must contain only 0-9a-fA-F')
-
-
-def read_key_file(path):
-    """Read a hex-encoded key from a file and return it as bytes.
-
-    Storing the key in a file keeps it out of shell history and process
-    listings (e.g., ``ps``), unlike passing it via ``--key``. Raises
-    :class:`UsageError` if the file cannot be read or holds an invalid key.
-    """
-    try:
-        with open(path) as key_file:
-            contents = key_file.read()
-    except OSError as e:
-        raise UsageError('failed to read key file "%s": %s' % (path, e))
-    return parse_hex_key(contents)
-
-
-def warn_if_default_key():
-    """Warn when the built-in default key is in use.
-
-    libfte 0.4 requires a key, and fteproxy falls back to the constant in
-    ``fteproxy.conf`` when neither ``--key`` nor ``--key-file`` is given. That
-    key is public, so anyone can read and forge the tunnel's traffic.
-    """
-    if fteproxy.conf.getValue('runtime.fteproxy.encrypter.key') == fteproxy.conf.DEFAULT_KEY:
-        fteproxy.warn('using the built-in default key, which is public: pass '
-                      '--key or --key-file with a secret shared by both endpoints')
+def _report(args, message, stream=None):
+    """Progress for a person, on stderr, silenced by ``-q``."""
+    if getattr(args, 'quiet', False):
+        return
+    print(message, file=stream or sys.stderr)
 
 
 # --------------------------------------------------------------------------- #
 # Argument parsing
 # --------------------------------------------------------------------------- #
 
-def build_parser():
-    """Build the argument parser.
+def _verbosity(parser):
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-q', action='store_true', dest='quiet',
+                       help='Log errors only.')
+    group.add_argument('-v', action='store_true', dest='verbose',
+                       help='Log per-connection detail.')
 
-    One flat command (the relay, selected with ``--mode``) plus subcommands.
-    ``formats`` is the first subcommand; the 0.4 command line replaces the flat
-    interface with ``server``/``client``/``keygen`` alongside it.
-    """
+
+def _state_dir_flag(parser):
+    parser.add_argument('--state-dir', metavar='DIR', default=None,
+                        help='Where server.key and connection.txt live '
+                             '(default: $FTEPROXY_STATE_DIR, then '
+                             '$XDG_STATE_HOME/fteproxy, then '
+                             '~/.local/state/fteproxy).')
+
+
+def build_parser():
     parser = argparse.ArgumentParser(
         prog='fteproxy',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        description='A format-transforming-encryption tunnel.')
     parser.add_argument('--version', action=_PrintVersion,
-                        help='Output the version of fteproxy, then quit.')
-    parser.add_argument('--mode', default=None,
-                        metavar='(client|server)',
-                        choices=['client', 'server'],
-                        help='Relay mode: client or server')
-    parser.add_argument('--stop', action='store_true',
-                        help='Shutdown daemon process')
-    parser.add_argument('--upstream-format', dest='upstream_format',
-                        help='Client-to-server language format',
-                        default=fteproxy.conf.getValue('runtime.state.upstream_language'))
-    parser.add_argument('--downstream-format', dest='downstream_format',
-                        help='Server-to-client language format',
-                        default=fteproxy.conf.getValue('runtime.state.downstream_language'))
-    parser.add_argument('--client_ip',
-                        help='Client-side listening IP',
-                        default=fteproxy.conf.getValue('runtime.client.ip'))
-    parser.add_argument('--client_port', type=int,
-                        help='Client-side listening port',
-                        default=fteproxy.conf.getValue('runtime.client.port'))
-    parser.add_argument('--server_ip',
-                        help='Server-side listening IP',
-                        default=fteproxy.conf.getValue('runtime.server.ip'))
-    parser.add_argument('--server_port', type=int,
-                        help='Server-side listening port',
-                        default=fteproxy.conf.getValue('runtime.server.port'))
-    parser.add_argument('--proxy_ip',
-                        help='Forwarding-proxy listening IP',
-                        default=fteproxy.conf.getValue('runtime.proxy.ip'))
-    parser.add_argument('--proxy_port', type=int,
-                        help='Forwarding-proxy listening port',
-                        default=fteproxy.conf.getValue('runtime.proxy.port'))
-    parser.add_argument('--release',
-                        help='Definitions file to use, specified as YYYYMMDD',
-                        default=fteproxy.conf.getValue('fteproxy.defs.release'))
-    parser.add_argument('--record-layer-mode', dest='record_layer_mode',
-                        metavar='(format|hybrid)',
-                        choices=['format', 'hybrid'],
-                        help='Record framing. "hybrid" (default) formats a '
-                             'header per record and sends the body as raw '
+                        help='Print the version and licence, then quit.')
+    subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
+
+    server = subparsers.add_parser(
+        'server', help='Accept tunnelled connections and dial where they ask.')
+    server.add_argument('--listen', metavar='[HOST]:PORT', default=DEFAULT_LISTEN,
+                        help='Address to listen on. ":PORT" means every '
+                             'interface; IPv6 literals go in brackets.')
+    server.add_argument('--allow', metavar='RULE', action='append', default=[],
+                        help='A destination clients may reach: "any", '
+                             'HOST[:PORT], CIDR[:PORT] or *.example.com[:PORT]. '
+                             'Repeatable. Without any rule the policy is every '
+                             'destination except this host\'s loopback and '
+                             'link-local addresses.')
+    server.add_argument('--advertise', metavar='HOST[:PORT]', default=None,
+                        help='The address to put in the connection string. '
+                             'Without it the string carries a placeholder for '
+                             'you to fill in.')
+    server.add_argument('--defs', metavar='RELEASE',
+                        default=fteproxy.conf.getValue('fteproxy.defs.release'),
+                        help='Definitions release to serve, as YYYYMMDD.')
+    _state_dir_flag(server)
+    _verbosity(server)
+
+    client = subparsers.add_parser(
+        'client', help='Listen locally and tunnel to an fteproxy server.')
+    client.add_argument('uri', nargs='?', metavar='URI', default=None,
+                        help='fte://SERVER-ID@HOST:PORT. Falls back to '
+                             '$FTEPROXY_URI, then connection.txt in the state '
+                             'directory.')
+    client.add_argument('-D', metavar='[BIND:]PORT', action='append',
+                        dest='socks', default=[],
+                        help='SOCKS5 listener. The default when neither -D nor '
+                             '-L is given is ' + DEFAULT_SOCKS + '.')
+    client.add_argument('-L', metavar='[BIND:]PORT:HOST:PORT', action='append',
+                        dest='forwards', default=[],
+                        help='Forward a local port to one destination through '
+                             'the tunnel. Repeatable.')
+    client.add_argument('--format', metavar='NAME', default=None,
+                        help='Base format name; see "fteproxy formats" '
+                             '(default: the URI\'s hint, else %s).'
+                             % DEFAULT_FORMAT)
+    client.add_argument('--mode', choices=['hybrid', 'format'], default=None,
+                        help='Record framing. "hybrid" formats a header per '
+                             'record and sends the body as raw authenticated '
                              'bytes: fast, but only the header blends in with '
                              'the target protocol. "format" transforms every '
-                             'byte into the format for full-stream realism at '
-                             'much lower throughput. Both endpoints must match.',
-                        default=fteproxy.conf.getValue(
-                            'runtime.fteproxy.record_layer.mode'))
+                             'byte for full-stream realism at much lower '
+                             'throughput (default: the URI\'s hint, else %s).'
+                             % DEFAULT_MODE)
+    client.add_argument('--no-check', action='store_true',
+                        help='Skip the startup check, which otherwise opens '
+                             'one short session so a bad connection string '
+                             'fails now instead of on first use.')
+    _state_dir_flag(client)
+    _verbosity(client)
 
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument('-q', '--quiet', action='store_true',
-                           help='Log errors only.')
-    verbosity.add_argument('-v', '--verbose', action='store_true',
-                           help='Log per-connection detail.')
+    keygen = subparsers.add_parser(
+        'keygen', help='Create server.key if absent and print the connection '
+                       'string.')
+    keygen.add_argument('--advertise', metavar='HOST[:PORT]', default=None,
+                        help='The address to put in the connection string.')
+    _state_dir_flag(keygen)
+    _verbosity(keygen)
 
-    key_group = parser.add_mutually_exclusive_group()
-    key_group.add_argument('--key',
-                           help='Shared secret, hex, exactly 64 characters; must '
-                                'match on both endpoints. The built-in default '
-                                'is public and gives no protection: always '
-                                'supply your own (see --key-file).',
-                           default=fteproxy.conf.getValue(
-                               'runtime.fteproxy.encrypter.key').hex())
-    key_group.add_argument('--key-file', dest='key_file',
-                           metavar='PATH', default=None,
-                           help='Path to a file containing the cryptographic key '
-                                '(64 hex characters). Use instead of --key to keep '
-                                'the key out of shell history and process listings.')
-
-    subparsers = parser.add_subparsers(dest='command', metavar='COMMAND')
-    formats_parser = subparsers.add_parser(
-        'formats',
-        help='List the formats in a definitions file, then quit.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    # SUPPRESS so that "fteproxy --release X formats" keeps the value given
-    # before the subcommand; a subparser default would otherwise overwrite it.
-    formats_parser.add_argument('--release', default=argparse.SUPPRESS,
-                                help='Definitions file to list, as YYYYMMDD')
+    formats = subparsers.add_parser(
+        'formats', help='List the formats in a definitions file.')
+    formats.add_argument('--defs', metavar='RELEASE',
+                         default=fteproxy.conf.getValue('fteproxy.defs.release'),
+                         help='Definitions release to list, as YYYYMMDD.')
+    _verbosity(formats)
 
     return parser
 
 
-def apply_args_to_conf(args):
-    """Copy every parsed argument into ``fteproxy.conf``, defaults included.
+def removed_flag(argv):
+    """The first pre-0.4 flag in ``argv``, or None.
 
-    One step, run after parsing, so the configuration a run sees is exactly
-    what the command line says, whether a value was typed or defaulted.
+    Only the part before a subcommand is scanned, because ``--mode`` means
+    something else under ``client``.
     """
-    conf = fteproxy.conf
-    conf.setValue('runtime.mode', args.mode)
-    conf.setValue('runtime.client.ip', args.client_ip)
-    conf.setValue('runtime.client.port', args.client_port)
-    conf.setValue('runtime.server.ip', args.server_ip)
-    conf.setValue('runtime.server.port', args.server_port)
-    conf.setValue('runtime.proxy.ip', args.proxy_ip)
-    conf.setValue('runtime.proxy.port', args.proxy_port)
-    conf.setValue('runtime.state.upstream_language', args.upstream_format)
-    conf.setValue('runtime.state.downstream_language', args.downstream_format)
-    conf.setValue('runtime.fteproxy.record_layer.mode', args.record_layer_mode)
+    head = argv
+    for index, token in enumerate(argv):
+        if token in SUBCOMMANDS:
+            head = argv[:index]
+            break
+    for token in head:
+        name = token.split('=', 1)[0]
+        if name in REMOVED_FLAGS:
+            return name
+    return None
 
-    if conf.getValue('fteproxy.defs.release') != args.release:
-        conf.setValue('fteproxy.defs.release', args.release)
+
+# --------------------------------------------------------------------------- #
+# Shared startup
+# --------------------------------------------------------------------------- #
+
+def select_defs(release):
+    """Point the definitions loader at ``release`` and load it now.
+
+    Loading validates every format in the file, so a release that cannot carry
+    a handshake fails here rather than as a client that hangs.
+    """
+    if fteproxy.conf.getValue('fteproxy.defs.release') != release:
+        fteproxy.conf.setValue('fteproxy.defs.release', release)
         fteproxy.defs._definitions = None
-
-    if args.key_file is not None:
-        conf.setValue('runtime.fteproxy.encrypter.key', read_key_file(args.key_file))
-    else:
-        conf.setValue('runtime.fteproxy.encrypter.key', parse_hex_key(args.key))
-
-
-# --------------------------------------------------------------------------- #
-# Startup validation
-# --------------------------------------------------------------------------- #
-
-def check_format(format_name):
-    """Build the cipher for ``format_name`` so an unusable format fails now.
-
-    libfte raises ``FormatCapacityError`` when a format is too small to carry
-    the cipher's frame, and the definitions lookup raises for an unknown name.
-    Both used to surface only on the first connection, as a client-side
-    timeout.
-    """
     try:
-        pattern = fteproxy.defs.getRegex(format_name)
-    except fteproxy.defs.InvalidRegexName:
-        raise StartupError('invalid format name: ' + format_name)
+        return fteproxy.defs.load_definitions()
     except (OSError, fteproxy.defs.DefinitionsError) as e:
-        raise StartupError('failed to load the definitions file: ' + str(e))
+        raise StartupError('cannot load definitions release %s: %s'
+                           % (release, e))
 
-    length = fteproxy.defs.getLength(format_name)
-    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+
+def check_format(base):
+    """Build both directions of ``base`` so an unusable format fails now."""
     try:
-        fteproxy._make_cipher(pattern, length, key)
-    except Exception as e:
-        raise StartupError('format %s is unusable: %s' % (format_name, e))
-
-
-def check_startup(mode):
-    """Validate every format this role will use, before anything is printed,
-    bound, or written to disk."""
-    if mode == 'client':
-        upstream = fteproxy.conf.getValue('runtime.state.upstream_language')
-        downstream = fteproxy.conf.getValue('runtime.state.downstream_language')
-        check_format(upstream)
-        check_format(downstream)
-        # TODO(PR4): the 0.4 handshake carries one base name and the server
-        # derives both directions from it, so the two flags can no longer
-        # express a mixed pair. The new command line has a single --format.
-        if fteproxy.defs.base_name(upstream) != fteproxy.defs.base_name(downstream):
-            fteproxy.warn(
-                'the format pair is chosen by base name now: using %s for '
-                'both directions and ignoring --downstream-format %s'
-                % (fteproxy.defs.base_name(upstream), downstream))
-    else:
+        request, response = fteproxy.defs.getRegex(base + '-request'), \
+            fteproxy.defs.getRegex(base + '-response')
+    except fteproxy.defs.InvalidRegexName:
+        raise StartupError(
+            'unknown format %r; "fteproxy formats" lists the base names' % base)
+    for name, pattern in ((base + '-request', request),
+                          (base + '-response', response)):
         try:
-            definitions = fteproxy.defs.load_definitions()
-        except (OSError, fteproxy.defs.DefinitionsError) as e:
-            raise StartupError('failed to load the definitions file: ' + str(e))
-        # The server accepts any format the client asks for, so all of them
-        # have to work here.
-        for format_name in definitions.keys():
-            check_format(format_name)
-    warn_if_default_key()
+            fteproxy._regex_format(pattern, fteproxy.defs.getLength(name))
+        except Exception as e:
+            raise StartupError('format %s is unusable: %s' % (name, e))
+
+
+def resolve_state_dir(args, create=True):
+    directory = fteproxy.config.state_dir(getattr(args, 'state_dir', None))
+    if create:
+        fteproxy.config.ensure_state_dir(directory)
+    return directory
+
+
+def parse_advertise(text, default_port):
+    try:
+        host, port = fteproxy.config.split_host_port(
+            text, default_port=default_port)
+    except ValueError as e:
+        raise UsageError('--advertise %s' % e)
+    if not host:
+        raise UsageError('--advertise needs a host')
+    return host, port
 
 
 # --------------------------------------------------------------------------- #
 # Subcommands
 # --------------------------------------------------------------------------- #
+
+def do_keygen(args):
+    directory = resolve_state_dir(args)
+    private, public, created = fteproxy.config.ensure_server_key(directory)
+    del private
+
+    host, port = fteproxy.config.HOST_PLACEHOLDER, fteproxy.config.DEFAULT_PORT
+    if args.advertise:
+        host, port = parse_advertise(args.advertise, fteproxy.config.DEFAULT_PORT)
+    uri = fteproxy.config.ConnectionString(public, host, port)
+    path = fteproxy.config.write_connection_string(directory, uri)
+
+    _report(args, '%s %s'
+            % ('wrote' if created else 'kept',
+               fteproxy.config.server_key_path(directory)))
+    _report(args, 'connection string also written to %s' % path)
+    print(uri.format())
+    return EXIT_OK
+
 
 def do_formats(args):
     """Print each base format name with its covertext length and capacity.
@@ -347,18 +353,15 @@ def do_formats(args):
     bounds a record.
     """
     try:
-        definitions = fteproxy.defs.load_definitions()
-    except OSError as e:
-        fteproxy.warn('failed to read the definitions file: ' + str(e))
+        definitions = select_defs(args.defs)
+    except StartupError as e:
+        fteproxy.logger.error(str(e))
         return EXIT_FAILURE
 
-    default_base = _base_name(
-        fteproxy.conf.getValue('runtime.state.upstream_language'))
-    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-
+    key = b'\x00' * 32
     bases = {}
     for name in definitions:
-        base = _base_name(name)
+        base = fteproxy.defs.base_name(name)
         direction = name[len(base) + 1:] if name != base else ''
         if direction not in ('request', 'response'):
             continue
@@ -375,18 +378,18 @@ def do_formats(args):
             length = fteproxy.defs.getLength(name)
             try:
                 capacity = fteproxy._make_cipher(
-                    fteproxy.defs.getRegex(name), length, key).max_plaintext_bytes
+                    fteproxy.defs.getRegex(name), length,
+                    key).max_plaintext_bytes
             except Exception:
                 row += [str(length), 'unusable']
                 continue
             row += [str(length), str(capacity)]
-        row.append('(default)' if base == default_base else '')
+        row.append('(default)' if base == DEFAULT_FORMAT else '')
         rows.append(row)
 
     header = ['name', 'req len', 'req cap', 'resp len', 'resp cap', '']
     widths = [max(len(r[i]) for r in [header] + rows) for i in range(len(header))]
-    print('definitions release %s'
-          % fteproxy.conf.getValue('fteproxy.defs.release'))
+    print('definitions release %s' % args.defs)
     print('covertext length and message capacity, in bytes, per direction')
     print()
     for row in [header] + rows:
@@ -396,130 +399,161 @@ def do_formats(args):
     return EXIT_OK
 
 
-def _base_name(format_name):
-    """``manual-http-request`` -> ``manual-http``."""
-    for suffix in ('-request', '-response'):
-        if format_name.endswith(suffix):
-            return format_name[:-len(suffix)]
-    return format_name
+def do_server(args):
+    select_defs(args.defs)
+    directory = resolve_state_dir(args)
+    private, public, created = fteproxy.config.ensure_server_key(directory)
 
-
-# --------------------------------------------------------------------------- #
-# PID files (removed with --stop in the 0.4 command line)
-# --------------------------------------------------------------------------- #
-
-def get_pid_file():
-    return os.path.join(
-        fteproxy.conf.getValue('general.pid_dir'),
-        '.' + str(fteproxy.conf.getValue('runtime.mode'))
-        + '-' + str(os.getpid()) + '.pid')
-
-
-def write_pid_file():
-    pid_file = get_pid_file()
     try:
-        with open(pid_file, 'w') as f:
-            f.write(str(os.getpid()))
-    except OSError:
-        fteproxy.warn('failed to write PID file to disk: ' + pid_file)
-        return None
-    return pid_file
+        host, port = fteproxy.config.split_host_port(args.listen)
+    except ValueError as e:
+        raise UsageError('--listen %s' % e)
 
+    try:
+        rules = fteproxy.stream.AllowRules(args.allow)
+    except fteproxy.stream.InvalidRule as e:
+        raise UsageError(str(e))
 
-def do_stop(mode):
-    """Signal every running fteproxy of ``mode`` recorded in the PID directory."""
-    pattern = os.path.join(fteproxy.conf.getValue('general.pid_dir'),
-                           '.' + mode + '-*.pid')
-    for pid_file in glob.glob(pattern):
-        try:
-            with open(pid_file) as f:
-                pid = int(f.read())
-        except (OSError, ValueError):
-            fteproxy.warn('failed to read PID file: ' + pid_file)
-            continue
-        try:
-            os.kill(pid, signal.SIGINT)
-        except OSError:
-            fteproxy.warn('failed to signal process ' + str(pid))
-        try:
-            os.unlink(pid_file)
-        except OSError:
-            fteproxy.warn('failed to remove PID file: ' + pid_file)
-    return EXIT_OK
+    advertise_host, advertise_port = fteproxy.config.HOST_PLACEHOLDER, port
+    if args.advertise:
+        advertise_host, advertise_port = parse_advertise(args.advertise, port)
+    uri = fteproxy.config.ConnectionString(public, advertise_host,
+                                           advertise_port,
+                                           defs=str(args.defs))
+    connection_file = fteproxy.config.write_connection_string(directory, uri)
 
-
-# --------------------------------------------------------------------------- #
-# The relay
-# --------------------------------------------------------------------------- #
-
-# TODO(PR4): delete with the flat command line.
-def shim_keypair_from_shared_key(key):
-    """Derive a fixed server keypair from the pre-0.4 shared secret.
-
-    The 0.4 protocol authenticates the server with a keypair, and the 0.4
-    command line hands the client that keypair's public half in a connection
-    string. Until PR4 lands the new command line, ``--key``/``--key-file``
-    still name a secret both endpoints hold, so both derive the same keypair
-    from it and the real handshake runs unchanged. Nothing about the protocol
-    is weakened by this; what it lacks is the operational property that the
-    client only ever needs a public key.
-    """
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
-    private = HKDF(algorithm=hashes.SHA256(), length=32, salt=b'',
-                   info=b'fteproxy/shim/shared-key-server-identity').derive(key)
-    return private, fteproxy.server_id(private)
-
-
-def init_listener(mode):
-    """Build the listener for ``mode`` out of the flat command line.
-
-    TODO(PR4): the flat interface still describes a fixed-destination
-    topology, so the client becomes a single ``-L`` forward to
-    ``--proxy_ip:--proxy_port`` and the server is given exactly that
-    destination as its allow rule. The new command line replaces both with a
-    connection string, ``-D``/``-L`` and ``--allow``.
-    """
-    server_ip = fteproxy.conf.getValue('runtime.server.ip')
-    server_port = fteproxy.conf.getValue('runtime.server.port')
-    proxy_ip = fteproxy.conf.getValue('runtime.proxy.ip')
-    proxy_port = fteproxy.conf.getValue('runtime.proxy.port')
-    private, public = shim_keypair_from_shared_key(
-        fteproxy.conf.getValue('runtime.fteproxy.encrypter.key'))
-
-    if mode == 'client':
-        base = fteproxy.defs.base_name(
-            fteproxy.conf.getValue('runtime.state.upstream_language'))
-        return fteproxy.relay.ForwardListener(
-            fteproxy.conf.getValue('runtime.client.ip'),
-            fteproxy.conf.getValue('runtime.client.port'),
-            (server_ip, server_port), public,
-            destination=(proxy_ip, proxy_port),
-            format=base,
-            mode=fteproxy.conf.getValue('runtime.fteproxy.record_layer.mode'))
-
-    return fteproxy.relay.ServerListener(
-        server_ip, server_port, private,
-        rules=fteproxy.stream.AllowRules(['%s:%d' % (proxy_ip, proxy_port)]))
-
-
-def run_relay(mode):
-    """Bind, then relay until SIGINT or SIGTERM. Returns the exit status.
-
-    The bind happens on this thread so a refused port is a startup failure with
-    a non-zero status, not a listener thread that dies while the process goes
-    on to exit 0.
-    """
-    listener = init_listener(mode)
+    listener = fteproxy.relay.ServerListener(host, port, private, rules=rules)
     try:
         listener.bind()
     except OSError as e:
-        raise StartupError('failed to bind %s: %s'
-                           % (_bind_address(mode), e))
+        raise StartupError('cannot listen on %s: %s' % (args.listen, e))
 
-    pid_file = write_pid_file()
+    bound_host, bound_port = listener.address
+    _report(args, 'listening on %s' % _render_address(bound_host, bound_port))
+    if not args.quiet:
+        print('key: %s%s' % (fteproxy.config.server_key_path(directory),
+                             ' (created)' if created else ''))
+        print('allowing: %s' % rules.describe())
+        print('clients connect with:')
+        print('  fteproxy client %s' % uri.format())
+        print('(also written to %s)' % connection_file)
+        sys.stdout.flush()
+    return serve_forever([listener])
 
+
+def do_client(args):
+    directory = resolve_state_dir(args, create=False)
+    try:
+        uri, source = fteproxy.config.resolve_client_uri(args.uri, directory)
+    except fteproxy.config.ConfigError as e:
+        raise UsageError(str(e))
+    if uri is None:
+        raise UsageError(
+            'no connection string. Pass one as an argument, set %s, or run '
+            'the server once so it writes %s.'
+            % (fteproxy.config.ENV_URI,
+               fteproxy.config.connection_path(directory)))
+    fteproxy.debug('connection string from %s' % source)
+
+    # The definitions release is the server operator's to choose: the client
+    # takes it from the URI's hint, since a mismatch is refused at the far end.
+    defs = uri.defs or fteproxy.conf.getValue('fteproxy.defs.release')
+    select_defs(str(defs))
+
+    # Flags beat the URI's hints, which beat the built-in defaults.
+    base = args.format or uri.format_name or DEFAULT_FORMAT
+    mode = args.mode or uri.mode or DEFAULT_MODE
+    check_format(base)
+
+    try:
+        socks_specs = [fteproxy.config.split_socks_spec(spec)
+                       for spec in args.socks]
+        forwards = [fteproxy.config.split_forward_spec(spec)
+                    for spec in args.forwards]
+    except ValueError as e:
+        raise UsageError(str(e))
+    if not socks_specs and not forwards:
+        socks_specs = [fteproxy.config.split_socks_spec(DEFAULT_SOCKS)]
+
+    common = dict(server_address=uri.address, server_id=uri.server_id,
+                  format=base, mode=mode, defs=str(defs))
+
+    listeners = []
+    for bind, port in socks_specs:
+        listeners.append(fteproxy.relay.SocksListener(bind, port, **common))
+    for (bind, port), destination in forwards:
+        listeners.append(fteproxy.relay.ForwardListener(
+            bind, port, destination=destination, **common))
+
+    if not args.no_check:
+        run_startup_check(args, listeners[0], uri)
+
+    for listener in listeners:
+        try:
+            listener.bind()
+        except OSError as e:
+            for started in listeners:
+                started.stop()
+            raise StartupError('cannot listen on %s: %s'
+                               % (_render_address(*listener.address), e))
+
+    for listener, spec in zip(listeners,
+                              [('SOCKS5', None) for _ in socks_specs]
+                              + [('forward', destination)
+                                 for _, destination in forwards]):
+        kind, destination = spec
+        where = _render_address(*listener.address)
+        if destination is None:
+            _report(args, 'SOCKS5 on %s' % where)
+        else:
+            _report(args, 'forwarding %s to %s through the tunnel'
+                    % (where, _render_address(*destination)))
+    return serve_forever(listeners)
+
+
+def run_startup_check(args, listener, uri):
+    """Open one short session so a bad connection string fails now.
+
+    On the wire it is an ordinary session start, and it costs one round trip.
+    The alternative is a first connection that hangs until a timeout with
+    nothing to say about why.
+    """
+    where = _render_address(uri.host, uri.port)
+    if not args.quiet:
+        sys.stderr.write('checking %s ... ' % where)
+        sys.stderr.flush()
+    try:
+        format_name, mode = listener.check()
+    except Exception as e:
+        if not args.quiet:
+            sys.stderr.write('failed\n')
+        raise StartupError(
+            '%s: %s\n  (wrong connection string, or the server is not running '
+            'fteproxy 0.4)' % (where, e))
+    if not args.quiet:
+        sys.stderr.write('ok (protocol %d, %s, %s)\n'
+                         % (fteproxy.handshake.PROTOCOL_VERSION, format_name,
+                            mode))
+        sys.stderr.flush()
+
+
+def _render_address(host, port):
+    if not host:
+        return '[::]:%d' % port
+    return '[%s]:%d' % (host, port) if ':' in host else '%s:%d' % (host, port)
+
+
+# --------------------------------------------------------------------------- #
+# Running
+# --------------------------------------------------------------------------- #
+
+def serve_forever(listeners):
+    """Run ``listeners`` in the foreground until SIGINT or SIGTERM.
+
+    No PID file and no ``--stop``: the process runs in the foreground and a
+    service manager, a shell job or a container runtime stops it the way it
+    stops anything else.
+    """
     stopping = threading.Event()
 
     def _stop(signum, frame):
@@ -533,65 +567,55 @@ def run_relay(mode):
             # Not the main thread (an embedding program calling main()).
             pass
 
-    listener.daemon = True
-    listener.start()
-    fteproxy.info('%s listening on %s' % (mode, _bind_address(mode)))
+    for listener in listeners:
+        listener.daemon = True
+        listener.start()
     try:
-        while listener.is_alive() and not stopping.is_set():
+        while not stopping.is_set() and any(l.is_alive() for l in listeners):
             stopping.wait(0.5)
     finally:
-        listener.stop()
+        for listener in listeners:
+            listener.stop()
         for signum, handler in previous.items():
             signal.signal(signum, handler)
-        if pid_file and os.path.exists(pid_file):
-            try:
-                os.unlink(pid_file)
-            except OSError:
-                pass
     return EXIT_OK
-
-
-def _bind_address(mode):
-    if mode == 'client':
-        return '%s:%d' % (fteproxy.conf.getValue('runtime.client.ip'),
-                          fteproxy.conf.getValue('runtime.client.port'))
-    return '%s:%d' % (fteproxy.conf.getValue('runtime.server.ip'),
-                      fteproxy.conf.getValue('runtime.server.port'))
 
 
 # --------------------------------------------------------------------------- #
 # Entry point
 # --------------------------------------------------------------------------- #
 
+_COMMANDS = {
+    'server': do_server,
+    'client': do_client,
+    'keygen': do_keygen,
+    'formats': do_formats,
+}
+
+
 def main(argv=None):
     """Parse ``argv``, run the requested command, and return an exit status."""
     argv = sys.argv[1:] if argv is None else list(argv)
+
+    removed = removed_flag(argv)
+    if removed is not None:
+        print(_UPGRADE_POINTER % removed, file=sys.stderr)
+        return EXIT_USAGE
+
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return EXIT_USAGE
 
     configure_logging(quiet=args.quiet, verbose=args.verbose)
 
     try:
-        apply_args_to_conf(args)
+        return _COMMANDS[args.command](args)
     except UsageError as e:
         parser.error(str(e))  # exits 2
-
-    if args.command == 'formats':
-        return do_formats(args)
-
-    if args.mode is None:
-        parser.print_usage(sys.stderr)
-        print('fteproxy: --mode (client|server) is required, '
-              'or name a subcommand (formats).', file=sys.stderr)
-        return EXIT_USAGE
-
-    if args.stop:
-        return do_stop(args.mode)
-
-    try:
-        check_startup(args.mode)
-        return run_relay(args.mode)
-    except StartupError as e:
+    except (StartupError, fteproxy.config.ConfigError) as e:
         fteproxy.logger.error(str(e))
         return EXIT_FAILURE
     except KeyboardInterrupt:

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""Process-wide defaults.
 
+What is left here is what a *library* user might want to change and what has
+no better home: buffer sizes, timeouts, and which definitions file to read.
+Everything that describes one run -- the listen address, the destination, the
+formats, the keys -- comes from the command line or from
+:func:`fteproxy.wrap_socket`, not from here. Until 0.4 those lived in this
+dictionary too, which is why a value that never reached it could stop the
+process working.
+"""
 
 
 import os
 import sys
-import tempfile
 
 
 def getValue(key):
@@ -38,13 +46,6 @@ else:
     conf['general.base_dir'] = os.path.join(module_path(), '..')
 
 
-"""Directory containing binary executables"""
-if we_are_frozen():
-    conf['general.bin_dir'] = os.path.join(module_path())
-else:
-    conf['general.bin_dir'] = os.path.join(module_path(), '..', 'bin')
-
-
 """The path for fte *.json definition files."""
 if we_are_frozen():
     conf['general.defs_dir'] = os.path.join(module_path(), 'fteproxy', 'defs')
@@ -52,31 +53,8 @@ else:
     conf['general.defs_dir'] = os.path.join(module_path(), '..', 'fteproxy', 'defs')
 
 
-"""The location that we store *.pid files, such that we can kill fteproxy from the command line."""
-conf['general.pid_dir'] = tempfile.gettempdir()
-
-
-"""Our runtime mode: client|server|test"""
-conf['runtime.mode'] = None
-
-
 """The maximum number of queued connections for sockets"""
 conf['runtime.fteproxy.relay.backlog'] = 100
-
-
-"""Our client-side ip:port to listen for incoming connections"""
-conf['runtime.client.ip'] = '127.0.0.1'
-conf['runtime.client.port'] = 8079
-
-
-"""Our server-side ip:port to listen for connections from fteproxy clients"""
-conf['runtime.server.ip'] = '127.0.0.1'
-conf['runtime.server.port'] = 8080
-
-
-"""Our proxy server, where the fteproxy server forwards outgoing connections."""
-conf['runtime.proxy.ip'] = '127.0.0.1'
-conf['runtime.proxy.port'] = 8081
 
 
 """The default socket timeout."""
@@ -87,11 +65,15 @@ conf['runtime.fteproxy.relay.socket_timeout'] = 30
 conf['runtime.fteproxy.relay.accept_timeout'] = 0.1
 
 
-"""The default penalty after polling for network data, and not recieving anything."""
+"""The default penalty after polling for network data, and not recieving anything.
+
+Load-bearing, despite looking like a busy-wait tax: it is a GIL yield that
+keeps a connection's two relay workers from convoying, and deleting it costs
+an order of magnitude in a real two-process deployment. See PERFORMANCE.md."""
 conf['runtime.fteproxy.relay.throttle'] = 0.01
 
 
-"""The default timeout when establishing a new fteproxy socket."""
+"""How long either end waits for the handshake to complete."""
 conf['runtime.fteproxy.negotiate.timeout'] = 5
 
 
@@ -106,23 +88,19 @@ high-entropy ciphertext. This is the behavior fteproxy shipped on libfte 0.3.
 'format' transforms every covertext byte into the target format, so the whole
 stream is indistinguishable from the protocol: stronger against entropy or
 statistical detectors, but much slower. Turn it on when you want full-stream
-realism and can spend the throughput. Both endpoints must use the same mode."""
+realism and can spend the throughput.
+
+Since 0.4 this is the *client's* default choice, not a setting both endpoints
+must match by hand: the client puts its choice in the handshake and the server
+follows."""
 conf['runtime.fteproxy.record_layer.mode'] = 'hybrid'
 
 
-"""The default client-to-server language."""
-conf['runtime.state.upstream_language'] = 'manual-http-request'
+"""The base format name a client uses when it is given none.
 
-
-"""The default server-to-client language."""
-conf['runtime.state.downstream_language'] = 'manual-http-response'
-
-
-"""The key used when neither --key nor --key-file is given. It is public (it
-is in this file), so it gives no confidentiality or integrity; fteproxy warns at
-startup when it is in use. Always supply a secret shared by both endpoints."""
-DEFAULT_KEY = b'\xFF' * 16 + b'\x00' * 16
-conf['runtime.fteproxy.encrypter.key'] = DEFAULT_KEY
+A base name, not a direction: the request and response formats are derived
+from it, and only the base travels in the handshake."""
+conf['fteproxy.default_format'] = 'manual-http'
 
 
 """Covertext length for definitions that carry no "length" key (the manual-*

--- a/fteproxy/config.py
+++ b/fteproxy/config.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The connection string and the state directory.
+
+A 0.4 client needs one argument, and this is what it holds::
+
+    fte://<server-id>@<host>:<port>[?format=<base>&mode=<hybrid|format>&defs=<YYYYMMDD>]
+
+``server-id`` is the server's X25519 public key in base64url without padding,
+43 characters. The query parameters are hints the operator recommends; a flag
+on the command line beats them, and an unknown parameter is ignored so a later
+version can add one without breaking today's clients.
+
+Treat the whole string like a Tor bridge line: whoever holds it can connect,
+and its secrecy is what stops an active prober confirming the server. It does
+not let the holder impersonate the server or read another client's traffic --
+see :mod:`fteproxy.handshake`.
+
+The state directory is where a server keeps the private half and the string it
+hands out. Resolution order: ``--state-dir``, ``FTEPROXY_STATE_DIR``,
+``$XDG_STATE_HOME/fteproxy``, ``~/.local/state/fteproxy``.
+"""
+
+import base64
+import os
+import stat
+import urllib.parse
+
+import fteproxy
+import fteproxy.handshake
+
+
+SCHEME = 'fte'
+DEFAULT_PORT = 8080
+
+SERVER_KEY_FILE = 'server.key'
+CONNECTION_FILE = 'connection.txt'
+
+#: What a connection string carries in place of a host the server cannot know.
+#: A server does not learn its own public address by starting up, so it writes
+#: this and the operator substitutes the address clients should dial, or passes
+#: ``--advertise``.
+HOST_PLACEHOLDER = '<server-ip>'
+
+#: Directory mode 0700 and file mode 0600: the private key and the connection
+#: string are both secrets, and a state directory readable by other local users
+#: hands them over.
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+ENV_STATE_DIR = 'FTEPROXY_STATE_DIR'
+ENV_URI = 'FTEPROXY_URI'
+
+
+class ConfigError(Exception):
+    """A connection string or a state directory that cannot be used."""
+
+
+# --------------------------------------------------------------------------- #
+# Server identity encoding
+# --------------------------------------------------------------------------- #
+
+def encode_server_id(public_bytes):
+    """32 bytes -> the 43-character base64url server-id."""
+    return base64.urlsafe_b64encode(public_bytes).rstrip(b'=').decode('ascii')
+
+
+def decode_server_id(text):
+    """The 43-character base64url server-id -> 32 bytes."""
+    padded = text + '=' * (-len(text) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode('ascii'))
+    except (ValueError, UnicodeEncodeError):
+        raise ConfigError('server-id is not valid base64url')
+    if len(raw) != fteproxy.handshake.KEY_BYTES:
+        raise ConfigError('server-id must decode to %d bytes, got %d'
+                          % (fteproxy.handshake.KEY_BYTES, len(raw)))
+    return raw
+
+
+# --------------------------------------------------------------------------- #
+# The connection string
+# --------------------------------------------------------------------------- #
+
+class ConnectionString:
+    """One parsed ``fte://`` URI.
+
+    ``server_id`` is the 32-byte public key; ``format_name``, ``mode`` and
+    ``defs`` are the operator's hints and are None when the string carries
+    none.
+    """
+
+    __slots__ = ('server_id', 'host', 'port', 'format_name', 'mode', 'defs')
+
+    def __init__(self, server_id, host, port=DEFAULT_PORT, format_name=None,
+                 mode=None, defs=None):
+        if len(server_id) != fteproxy.handshake.KEY_BYTES:
+            raise ConfigError('server-id must be %d bytes'
+                              % fteproxy.handshake.KEY_BYTES)
+        if not host:
+            raise ConfigError('a connection string needs a host')
+        if not 0 < port <= 0xFFFF:
+            raise ConfigError('port %r is out of range' % (port,))
+        if mode is not None and mode not in fteproxy.handshake.MODES:
+            raise ConfigError('mode must be one of %s'
+                              % ', '.join(fteproxy.handshake.MODES))
+        self.server_id = bytes(server_id)
+        self.host = host
+        self.port = port
+        self.format_name = format_name
+        self.mode = mode
+        self.defs = defs
+
+    # -- parsing ----------------------------------------------------------- #
+
+    @classmethod
+    def parse(cls, text):
+        """Parse an ``fte://`` URI, raising :class:`ConfigError`.
+
+        No error message ever quotes the string: an unparseable one is still a
+        secret, and error output is the easiest place for it to leak.
+        """
+        text = text.strip()
+        if not text:
+            raise ConfigError('empty connection string')
+        parsed = urllib.parse.urlsplit(text)
+        if parsed.scheme != SCHEME:
+            raise ConfigError('connection string must start with %s://'
+                              % SCHEME)
+        if parsed.path not in ('', '/') or parsed.fragment:
+            raise ConfigError('a connection string carries no path or fragment')
+        if '@' not in parsed.netloc:
+            raise ConfigError('connection string has no server-id before @')
+
+        raw_id, _, authority = parsed.netloc.rpartition('@')
+        if ':' in raw_id:
+            raise ConfigError('a connection string carries no password')
+        server_id = decode_server_id(raw_id)
+
+        try:
+            host, port = split_host_port(authority, default_port=DEFAULT_PORT)
+        except ValueError as e:
+            raise ConfigError(str(e))
+        if not host:
+            raise ConfigError('a connection string needs a host')
+
+        hints = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+        mode = hints.get('mode', [None])[0]
+        if mode is not None and mode not in fteproxy.handshake.MODES:
+            raise ConfigError('mode hint must be one of %s'
+                              % ', '.join(fteproxy.handshake.MODES))
+        defs = hints.get('defs', [None])[0]
+        if defs is not None and not defs.isdigit():
+            raise ConfigError('defs hint must be a YYYYMMDD release')
+        return cls(server_id=server_id, host=host, port=port,
+                   format_name=hints.get('format', [None])[0], mode=mode,
+                   defs=defs)
+
+    # -- rendering --------------------------------------------------------- #
+
+    def format(self):
+        """The URI this object round-trips from."""
+        host = '[%s]' % self.host if _is_ipv6_literal(self.host) else self.host
+        query = [('format', self.format_name), ('mode', self.mode),
+                 ('defs', self.defs)]
+        suffix = urllib.parse.urlencode(
+            [(key, value) for key, value in query if value is not None])
+        return '%s://%s@%s:%d%s' % (SCHEME, encode_server_id(self.server_id),
+                                    host, self.port,
+                                    '?' + suffix if suffix else '')
+
+    def redacted(self):
+        """The string with the server-id removed, for logs and messages."""
+        host = '[%s]' % self.host if _is_ipv6_literal(self.host) else self.host
+        return '%s://…@%s:%d' % (SCHEME, host, self.port)
+
+    @property
+    def address(self):
+        return (self.host, self.port)
+
+    def with_host(self, host, port=None):
+        """A copy pointed at a different address.
+
+        Used for the placeholder a server writes before it knows what clients
+        should dial.
+        """
+        return ConnectionString(self.server_id, host,
+                                self.port if port is None else port,
+                                self.format_name, self.mode, self.defs)
+
+    def __str__(self):
+        # Never the URI: a ConnectionString can reach a log line or a
+        # traceback, and format() is the deliberate way to render one.
+        return self.redacted()
+
+    def __repr__(self):
+        return '<ConnectionString %s>' % self.redacted()
+
+    def __eq__(self, other):
+        if not isinstance(other, ConnectionString):
+            return NotImplemented
+        return all(getattr(self, name) == getattr(other, name)
+                   for name in self.__slots__)
+
+
+def _is_ipv6_literal(host):
+    return ':' in host
+
+
+def split_host_port(text, default_port=None, allow_bare_port=False):
+    """``host``, ``host:port``, ``:port``, ``[v6]`` or ``[v6]:port``.
+
+    Returns ``(host, port)``; the host is ``''`` for ``:port``, which means
+    every interface. IPv6 literals need brackets whenever a port follows,
+    because ``::1:8080`` is a valid address on its own. Raises ``ValueError``.
+    """
+    text = text.strip()
+    if not text:
+        raise ValueError('empty address')
+    if text.startswith('['):
+        end = text.find(']')
+        if end < 0:
+            raise ValueError('unclosed [ in %r' % text)
+        host = text[1:end]
+        rest = text[end + 1:]
+        if not rest:
+            return host, _require_port(default_port, text)
+        if not rest.startswith(':'):
+            raise ValueError('expected :PORT after ] in %r' % text)
+        return host, _parse_port(rest[1:], text)
+    if text.count(':') == 1:
+        host, _, port = text.partition(':')
+        return host, _parse_port(port, text)
+    if ':' in text:
+        # Several colons and no brackets: a bare IPv6 literal.
+        return text, _require_port(default_port, text)
+    if allow_bare_port and text.isdigit():
+        return '', _parse_port(text, text)
+    return text, _require_port(default_port, text)
+
+
+def _parse_port(text, whole):
+    if not text.isdigit():
+        raise ValueError('port %r in %r is not a number' % (text, whole))
+    port = int(text)
+    if not 0 < port <= 0xFFFF:
+        raise ValueError('port %d in %r is out of range' % (port, whole))
+    return port
+
+
+def _require_port(default_port, whole):
+    if default_port is None:
+        raise ValueError('%r needs a port' % whole)
+    return default_port
+
+
+def split_forward_spec(text):
+    """``[BIND:]PORT:HOST:PORT`` -> ``((bind, port), (host, port))``.
+
+    ssh's ``-L`` spelling. Splitting happens outside brackets, so
+    ``[::1]:2222:[2001:db8::1]:22`` means what it looks like.
+    """
+    parts = _split_outside_brackets(text)
+    if len(parts) == 3:
+        bind, local_port, host, port = '127.0.0.1', parts[0], parts[1], parts[2]
+    elif len(parts) == 4:
+        bind, local_port, host, port = parts
+    else:
+        raise ValueError('expected [BIND:]PORT:HOST:PORT, got %r' % text)
+    return ((_strip_brackets(bind), _parse_port(local_port, text)),
+            (_strip_brackets(host), _parse_port(port, text)))
+
+
+def split_socks_spec(text):
+    """``[BIND:]PORT`` -> ``(bind, port)``, defaulting the bind to loopback."""
+    parts = _split_outside_brackets(text)
+    if len(parts) == 1:
+        return '127.0.0.1', _parse_port(parts[0], text)
+    if len(parts) == 2:
+        return _strip_brackets(parts[0]), _parse_port(parts[1], text)
+    raise ValueError('expected [BIND:]PORT, got %r' % text)
+
+
+def _split_outside_brackets(text):
+    parts, current, depth = [], '', 0
+    for char in text:
+        if char == '[':
+            depth += 1
+        elif char == ']':
+            depth -= 1
+            if depth < 0:
+                raise ValueError('unbalanced ] in %r' % text)
+        if char == ':' and depth == 0:
+            parts.append(current)
+            current = ''
+        else:
+            current += char
+    if depth != 0:
+        raise ValueError('unclosed [ in %r' % text)
+    parts.append(current)
+    return parts
+
+
+def _strip_brackets(text):
+    if text.startswith('[') and text.endswith(']'):
+        return text[1:-1]
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# The state directory
+# --------------------------------------------------------------------------- #
+
+def state_dir(explicit=None, environ=None):
+    """Where the server keeps its key, by the order in the plan's 1.3."""
+    environ = os.environ if environ is None else environ
+    if explicit:
+        return os.path.abspath(os.path.expanduser(explicit))
+    from_env = environ.get(ENV_STATE_DIR)
+    if from_env:
+        return os.path.abspath(os.path.expanduser(from_env))
+    xdg = environ.get('XDG_STATE_HOME')
+    if xdg:
+        return os.path.join(os.path.abspath(os.path.expanduser(xdg)),
+                            'fteproxy')
+    return os.path.expanduser(os.path.join('~', '.local', 'state', 'fteproxy'))
+
+
+def ensure_state_dir(path):
+    """Create the state directory at mode 0700, tightening it if it is looser.
+
+    A directory another local user can read is a directory they can read the
+    private key out of, so a pre-existing loose one is corrected rather than
+    accepted.
+    """
+    try:
+        os.makedirs(path, mode=DIR_MODE, exist_ok=True)
+        current = stat.S_IMODE(os.stat(path).st_mode)
+        if current & 0o077:
+            os.chmod(path, DIR_MODE)
+    except OSError as e:
+        raise ConfigError('cannot use state directory %s: %s' % (path, e))
+    return path
+
+
+def _write_private(path, text):
+    """Write ``text`` to ``path`` at mode 0600, creating it exclusively."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    descriptor = os.open(path, flags, FILE_MODE)
+    try:
+        os.chmod(path, FILE_MODE)
+        with os.fdopen(descriptor, 'w') as handle:
+            handle.write(text)
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def server_key_path(directory):
+    return os.path.join(directory, SERVER_KEY_FILE)
+
+
+def connection_path(directory):
+    return os.path.join(directory, CONNECTION_FILE)
+
+
+def load_server_key(directory):
+    """Read ``server.key``, or None if it is not there.
+
+    Warns when the file is readable by anyone else: a key that has been world
+    readable should be replaced, not silently used.
+    """
+    path = server_key_path(directory)
+    try:
+        with open(path) as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        raise ConfigError('cannot read %s: %s' % (path, e))
+    try:
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+    except OSError:
+        mode = 0
+    if mode & 0o077:
+        fteproxy.warn('%s is readable by other users (mode %o); '
+                      'fix it with chmod 600 and consider generating a new key'
+                      % (path, mode))
+    if len(text) != 64:
+        raise ConfigError('%s should hold 64 hex characters, found %d'
+                          % (path, len(text)))
+    try:
+        return bytes.fromhex(text)
+    except ValueError:
+        raise ConfigError('%s is not hexadecimal' % path)
+
+
+def save_server_key(directory, private_bytes):
+    path = server_key_path(directory)
+    try:
+        _write_private(path, private_bytes.hex() + '\n')
+    except OSError as e:
+        raise ConfigError('cannot write %s: %s' % (path, e))
+    return path
+
+
+def ensure_server_key(directory):
+    """Return ``(private, public, created)``, generating a key on first use."""
+    private = load_server_key(directory)
+    if private is not None:
+        return private, fteproxy.server_id(private), False
+    private, public = fteproxy.generate_server_key()
+    save_server_key(directory, private)
+    return private, public, True
+
+
+def write_connection_string(directory, uri):
+    path = connection_path(directory)
+    try:
+        _write_private(path, uri.format() + '\n')
+    except OSError as e:
+        raise ConfigError('cannot write %s: %s' % (path, e))
+    return path
+
+
+def read_connection_string(directory):
+    """The connection string from ``connection.txt``, or None."""
+    path = connection_path(directory)
+    try:
+        with open(path) as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        raise ConfigError('cannot read %s: %s' % (path, e))
+    return text or None
+
+
+def resolve_client_uri(argument=None, directory=None, environ=None):
+    """The client's URI, from the argument, the environment, or the file.
+
+    Returns ``(ConnectionString, source)``. A string that still carries the
+    ``<server-ip>`` placeholder can only have been written by a server on this
+    host, so it is pointed at loopback; that is what makes ``fteproxy server``
+    then ``fteproxy client`` work on one machine with no arguments at all.
+    """
+    environ = os.environ if environ is None else environ
+    if argument:
+        text, source = argument, 'the command line'
+    elif environ.get(ENV_URI):
+        text, source = environ[ENV_URI], ENV_URI
+    elif directory is not None:
+        text = read_connection_string(directory)
+        source = connection_path(directory)
+        if not text:
+            return None, None
+    else:
+        return None, None
+
+    uri = ConnectionString.parse(text)
+    if uri.host == HOST_PLACEHOLDER:
+        uri = uri.with_host('127.0.0.1')
+    return uri, source

--- a/fteproxy/relay.py
+++ b/fteproxy/relay.py
@@ -172,19 +172,38 @@ class listener(threading.Thread):
         thread and report a bind failure with a non-zero exit status. Binding
         inside the thread instead only killed the thread, and the process went
         on to exit 0.
+
+        An empty host means every interface, which is one socket on the usual
+        Unix system (``::`` with ``IPV6_V6ONLY`` off accepts IPv4 too) and two
+        families on one that will not allow that, so the fallback is a plain
+        IPv4 bind rather than an error.
         """
+        if not self._local_ip:
+            try:
+                self._sock = self._bind_socket(socket.AF_INET6, '::',
+                                               dual_stack=True)
+                return
+            except OSError as e:
+                fteproxy.debug('dual-stack bind failed (%s); using IPv4' % e)
+                self._sock = self._bind_socket(socket.AF_INET, '0.0.0.0')
+                return
         family = socket.AF_INET6 if ':' in self._local_ip else socket.AF_INET
+        self._sock = self._bind_socket(family, self._local_ip)
+
+    def _bind_socket(self, family, host, dual_stack=False):
         sock = socket.socket(family, socket.SOCK_STREAM)
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((self._local_ip, self._local_port))
+            if dual_stack:
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            sock.bind((host, self._local_port))
             sock.listen(fteproxy.conf.getValue('runtime.fteproxy.relay.backlog'))
             sock.settimeout(
                 fteproxy.conf.getValue('runtime.fteproxy.relay.accept_timeout'))
         except OSError:
             sock.close()
             raise
-        self._sock = sock
+        return sock
 
     def run(self):
         if self._sock is None:

--- a/fteproxy/tests/conftest.py
+++ b/fteproxy/tests/conftest.py
@@ -10,13 +10,11 @@ import fteproxy
 import fteproxy.conf
 
 
-@pytest.fixture(autouse=True)
-def setup_test_mode():
-    """Automatically set runtime mode for all tests."""
-    fteproxy.conf.setValue('runtime.mode', 'client')
-    yield
-    # Reset after test if needed
-    fteproxy.conf.setValue('runtime.mode', None)
+#: A fixed key for tests that exercise the record layer directly, where the
+#: value does not matter but both ends must agree. Real connections derive
+#: their keys per direction from the handshake; nothing in the package ships a
+#: default key any more.
+TEST_KEY = bytes(range(32))
 
 
 @pytest.fixture(autouse=True)
@@ -41,5 +39,5 @@ def restore_fteproxy_logger():
 
 @pytest.fixture
 def sample_key():
-    """Provide a sample encryption key for testing."""
-    return b'\xff' * 16 + b'\x00' * 16
+    """A 32-byte key for tests that need one but not a real handshake."""
+    return TEST_KEY

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for the command line: parsing, applying to conf, and exit statuses.
+"""Tests for the command line and the configuration it reads.
 
 These call :func:`fteproxy.cli.main` in process, so they assert on the status
 the process would exit with rather than on a subprocess return code.
@@ -8,21 +8,28 @@ the process would exit with rather than on a subprocess return code.
 """
 
 import logging
+import os
+import stat
 
 import pytest
 
 import fteproxy
 import fteproxy.cli
 import fteproxy.conf
+import fteproxy.config
 import fteproxy.defs
+
+
+PUBLIC = bytes(range(32))
+SERVER_ID = fteproxy.config.encode_server_id(PUBLIC)
 
 
 @pytest.fixture(autouse=True)
 def restore_conf():
     """Snapshot and restore the global configuration around each test.
 
-    ``apply_args_to_conf`` writes process-global state; without this a test
-    that sets a non-default release or key would leak into the next one.
+    The CLI writes process-global state; without this a test that selects a
+    non-default definitions release would leak into the next one.
     """
     saved = dict(fteproxy.conf.conf)
     saved_defs = fteproxy.defs._definitions
@@ -36,195 +43,329 @@ def parse(argv):
     return fteproxy.cli.build_parser().parse_args(argv)
 
 
+# --------------------------------------------------------------------------- #
+# The connection string
+# --------------------------------------------------------------------------- #
+
+class TestConnectionString:
+
+    @pytest.mark.parametrize('host', [
+        'example.com', '203.0.113.5', '2001:db8::1', '::1',
+    ])
+    def test_round_trip(self, host):
+        uri = fteproxy.config.ConnectionString(PUBLIC, host, 8080)
+        assert fteproxy.config.ConnectionString.parse(uri.format()) == uri
+
+    def test_round_trip_with_hints(self):
+        uri = fteproxy.config.ConnectionString(
+            PUBLIC, 'example.com', 443, format_name='words', mode='format',
+            defs='20260110')
+        text = uri.format()
+        assert 'format=words' in text
+        assert 'mode=format' in text
+        assert 'defs=20260110' in text
+        assert fteproxy.config.ConnectionString.parse(text) == uri
+
+    def test_ipv6_is_bracketed(self):
+        uri = fteproxy.config.ConnectionString(PUBLIC, '2001:db8::1', 8080)
+        assert '@[2001:db8::1]:8080' in uri.format()
+
+    def test_the_server_id_is_43_characters(self):
+        assert len(SERVER_ID) == 43
+        assert '=' not in SERVER_ID
+
+    def test_parse_recovers_the_key(self):
+        uri = fteproxy.config.ConnectionString.parse(
+            'fte://%s@203.0.113.5:8080' % SERVER_ID)
+        assert uri.server_id == PUBLIC
+        assert uri.address == ('203.0.113.5', 8080)
+
+    def test_port_defaults_to_8080(self):
+        uri = fteproxy.config.ConnectionString.parse(
+            'fte://%s@203.0.113.5' % SERVER_ID)
+        assert uri.port == 8080
+
+    def test_unknown_query_parameters_are_ignored(self):
+        """So a later version can add one without breaking today's clients."""
+        uri = fteproxy.config.ConnectionString.parse(
+            'fte://%s@host:1?pk2=abc&future=1&mode=format' % SERVER_ID)
+        assert uri.mode == 'format'
+
+    @pytest.mark.parametrize('text', [
+        '',
+        'http://%s@host:8080' % SERVER_ID,
+        'fte://host:8080',
+        'fte://short@host:8080',
+        'fte://%s@host:8080/path' % SERVER_ID,
+        'fte://%s@host:8080#frag' % SERVER_ID,
+        'fte://%s@host:0' % SERVER_ID,
+        'fte://%s@host:99999' % SERVER_ID,
+        'fte://%s@host:8080?mode=nonsense' % SERVER_ID,
+        'fte://%s@host:8080?defs=lastweek' % SERVER_ID,
+        'fte://%s@:8080' % SERVER_ID,
+    ])
+    def test_bad_strings_are_refused(self, text):
+        with pytest.raises(fteproxy.config.ConfigError):
+            fteproxy.config.ConnectionString.parse(text)
+
+    def test_errors_never_quote_the_string(self):
+        """An unparseable connection string is still a secret."""
+        with pytest.raises(fteproxy.config.ConfigError) as excinfo:
+            fteproxy.config.ConnectionString.parse(
+                'fte://%s@host:99999' % SERVER_ID)
+        assert SERVER_ID not in str(excinfo.value)
+
+    def test_str_and_repr_are_redacted(self):
+        uri = fteproxy.config.ConnectionString(PUBLIC, '203.0.113.5', 8080)
+        assert SERVER_ID not in str(uri)
+        assert SERVER_ID not in repr(uri)
+        assert str(uri) == 'fte://…@203.0.113.5:8080'
+        assert uri.redacted() in repr(uri)
+
+
+class TestSpecParsers:
+
+    @pytest.mark.parametrize('text,expected', [
+        (':8080', ('', 8080)),
+        ('1.2.3.4:8080', ('1.2.3.4', 8080)),
+        ('[::]:8080', ('::', 8080)),
+        ('[2001:db8::1]:443', ('2001:db8::1', 443)),
+        ('example.com:80', ('example.com', 80)),
+    ])
+    def test_host_port(self, text, expected):
+        assert fteproxy.config.split_host_port(text) == expected
+
+    @pytest.mark.parametrize('text', [
+        '', 'example.com', '[::1', '[::1]80', 'host:http', 'host:0',
+        'host:65536',
+    ])
+    def test_bad_host_port(self, text):
+        with pytest.raises(ValueError):
+            fteproxy.config.split_host_port(text)
+
+    @pytest.mark.parametrize('text,expected', [
+        ('2222:127.0.0.1:22', (('127.0.0.1', 2222), ('127.0.0.1', 22))),
+        ('0.0.0.0:2222:example.com:22',
+         (('0.0.0.0', 2222), ('example.com', 22))),
+        ('[::1]:2222:[2001:db8::1]:22',
+         (('::1', 2222), ('2001:db8::1', 22))),
+    ])
+    def test_forward_spec(self, text, expected):
+        assert fteproxy.config.split_forward_spec(text) == expected
+
+    @pytest.mark.parametrize('text', [
+        '2222', '2222:host', '2222:host:22:extra', 'a:b:c', '[::1:2222:h:22',
+    ])
+    def test_bad_forward_spec(self, text):
+        with pytest.raises(ValueError):
+            fteproxy.config.split_forward_spec(text)
+
+    @pytest.mark.parametrize('text,expected', [
+        ('1080', ('127.0.0.1', 1080)),
+        ('0.0.0.0:1080', ('0.0.0.0', 1080)),
+        ('[::1]:1080', ('::1', 1080)),
+    ])
+    def test_socks_spec(self, text, expected):
+        assert fteproxy.config.split_socks_spec(text) == expected
+
+    @pytest.mark.parametrize('text', ['', 'http', '1:2:3'])
+    def test_bad_socks_spec(self, text):
+        with pytest.raises(ValueError):
+            fteproxy.config.split_socks_spec(text)
+
+
+class TestStateDirectory:
+
+    def test_resolution_order(self, tmp_path):
+        explicit = str(tmp_path / 'explicit')
+        environ = {'FTEPROXY_STATE_DIR': str(tmp_path / 'env'),
+                   'XDG_STATE_HOME': str(tmp_path / 'xdg')}
+        assert fteproxy.config.state_dir(explicit, environ) == explicit
+        assert fteproxy.config.state_dir(None, environ) == \
+            str(tmp_path / 'env')
+        assert fteproxy.config.state_dir(None, {'XDG_STATE_HOME':
+                                                str(tmp_path / 'xdg')}) == \
+            str(tmp_path / 'xdg' / 'fteproxy')
+        assert fteproxy.config.state_dir(None, {}).endswith(
+            os.path.join('.local', 'state', 'fteproxy'))
+
+    def test_created_with_mode_0700(self, tmp_path):
+        directory = str(tmp_path / 'state')
+        fteproxy.config.ensure_state_dir(directory)
+        assert stat.S_IMODE(os.stat(directory).st_mode) == 0o700
+
+    def test_a_loose_directory_is_tightened(self, tmp_path):
+        """A state directory other local users can read is a directory they
+        can read the private key out of."""
+        directory = tmp_path / 'state'
+        directory.mkdir(mode=0o755)
+        fteproxy.config.ensure_state_dir(str(directory))
+        assert stat.S_IMODE(os.stat(directory).st_mode) == 0o700
+
+    def test_key_and_connection_files_are_0600(self, tmp_path):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        _private, public, created = fteproxy.config.ensure_server_key(directory)
+        assert created
+        uri = fteproxy.config.ConnectionString(public, 'example.com', 8080)
+        fteproxy.config.write_connection_string(directory, uri)
+        for path in (fteproxy.config.server_key_path(directory),
+                     fteproxy.config.connection_path(directory)):
+            assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+    def test_an_existing_key_is_kept(self, tmp_path):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        first, public, created = fteproxy.config.ensure_server_key(directory)
+        assert created
+        again, public_again, created_again = \
+            fteproxy.config.ensure_server_key(directory)
+        assert (again, public_again) == (first, public)
+        assert not created_again
+
+    def test_a_world_readable_key_warns(self, tmp_path, caplog):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        fteproxy.config.ensure_server_key(directory)
+        os.chmod(fteproxy.config.server_key_path(directory), 0o644)
+        with caplog.at_level(logging.WARNING, logger='fteproxy'):
+            fteproxy.config.load_server_key(directory)
+        assert 'readable by other users' in caplog.text
+
+    @pytest.mark.parametrize('contents', ['', 'abcdef', 'z' * 64])
+    def test_a_corrupt_key_file_is_an_error(self, tmp_path, contents):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        with open(fteproxy.config.server_key_path(directory), 'w') as handle:
+            handle.write(contents)
+        with pytest.raises(fteproxy.config.ConfigError):
+            fteproxy.config.load_server_key(directory)
+
+
+class TestResolveClientUri:
+
+    def _write(self, tmp_path, text):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        with open(fteproxy.config.connection_path(directory), 'w') as handle:
+            handle.write(text + '\n')
+        return directory
+
+    def test_the_argument_wins(self, tmp_path):
+        directory = self._write(tmp_path, 'fte://%s@from-file:1' % SERVER_ID)
+        uri, source = fteproxy.config.resolve_client_uri(
+            'fte://%s@from-argument:2' % SERVER_ID, directory,
+            {'FTEPROXY_URI': 'fte://%s@from-env:3' % SERVER_ID})
+        assert uri.host == 'from-argument'
+        assert source == 'the command line'
+
+    def test_the_environment_is_next(self, tmp_path):
+        directory = self._write(tmp_path, 'fte://%s@from-file:1' % SERVER_ID)
+        uri, source = fteproxy.config.resolve_client_uri(
+            None, directory, {'FTEPROXY_URI': 'fte://%s@from-env:3' % SERVER_ID})
+        assert uri.host == 'from-env'
+        assert source == 'FTEPROXY_URI'
+
+    def test_the_file_is_last(self, tmp_path):
+        directory = self._write(tmp_path, 'fte://%s@from-file:1' % SERVER_ID)
+        uri, source = fteproxy.config.resolve_client_uri(None, directory, {})
+        assert uri.host == 'from-file'
+        assert source.endswith('connection.txt')
+
+    def test_nothing_anywhere(self, tmp_path):
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        assert fteproxy.config.resolve_client_uri(None, directory, {}) == \
+            (None, None)
+
+    def test_the_placeholder_becomes_loopback(self, tmp_path):
+        """A string still carrying <server-ip> can only have been written by a
+        server on this host, which is what makes `fteproxy server` then
+        `fteproxy client` work with no arguments at all."""
+        directory = self._write(
+            tmp_path, 'fte://%s@%s:9999'
+            % (SERVER_ID, fteproxy.config.HOST_PLACEHOLDER))
+        uri, _source = fteproxy.config.resolve_client_uri(None, directory, {})
+        assert uri.address == ('127.0.0.1', 9999)
+
+
+# --------------------------------------------------------------------------- #
+# The parser
+# --------------------------------------------------------------------------- #
+
 class TestParser:
-    """The parse step alone: no configuration is written."""
 
-    def test_ports_are_integers(self):
-        args = parse(['--mode', 'client', '--client_port', '1234',
-                      '--server_port', '5678', '--proxy_port', '9012'])
-        assert args.client_port == 1234
-        assert args.server_port == 5678
-        assert args.proxy_port == 9012
+    def test_subcommands(self):
+        for name in ('server', 'client', 'keygen', 'formats'):
+            assert parse([name]).command == name
 
-    def test_non_integer_port_is_a_usage_error(self):
+    def test_no_subcommand(self):
+        assert parse([]).command is None
+
+    def test_client_flags(self):
+        args = parse(['client', 'fte://x@h:1', '-D', '1080',
+                      '-L', '2222:127.0.0.1:22', '-L', '3333:h:80',
+                      '--format', 'words', '--mode', 'format', '--no-check'])
+        assert args.uri == 'fte://x@h:1'
+        assert args.socks == ['1080']
+        assert args.forwards == ['2222:127.0.0.1:22', '3333:h:80']
+        assert args.format == 'words'
+        assert args.mode == 'format'
+        assert args.no_check
+
+    def test_server_flags(self):
+        args = parse(['server', '--listen', ':9000', '--allow', 'any',
+                      '--allow', '10.0.0.0/8', '--advertise', 'vpn.example:9000',
+                      '--defs', '20131224'])
+        assert args.listen == ':9000'
+        assert args.allow == ['any', '10.0.0.0/8']
+        assert args.advertise == 'vpn.example:9000'
+        assert args.defs == '20131224'
+
+    def test_mode_choices(self):
         with pytest.raises(SystemExit) as excinfo:
-            parse(['--mode', 'client', '--client_port', 'http'])
+            parse(['client', '--mode', 'nonsense'])
         assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
-
-    def test_mode_has_no_default(self):
-        """A bare run must be a usage error, not a client that was never
-        configured. The old default hid the no-argument crash."""
-        assert parse([]).mode is None
-
-    def test_invalid_mode_is_a_usage_error(self):
-        with pytest.raises(SystemExit) as excinfo:
-            parse(['--mode', 'invalid'])
-        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
-
-    def test_parsing_does_not_write_conf(self):
-        before = fteproxy.conf.getValue('runtime.client.port')
-        parse(['--mode', 'client', '--client_port', str(before + 1)])
-        assert fteproxy.conf.getValue('runtime.client.port') == before
 
     def test_quiet_and_verbose_are_mutually_exclusive(self):
         with pytest.raises(SystemExit) as excinfo:
-            parse(['--mode', 'client', '-q', '-v'])
-        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
-
-    def test_key_and_key_file_are_mutually_exclusive(self, tmp_path):
-        key_file = tmp_path / 'k'
-        key_file.write_text('a' * 64)
-        with pytest.raises(SystemExit) as excinfo:
-            parse(['--mode', 'server', '--key', 'a' * 64,
-                   '--key-file', str(key_file)])
-        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
-
-    def test_formats_subcommand_is_recognised(self):
-        assert parse(['formats']).command == 'formats'
-        assert parse(['--mode', 'client']).command is None
-
-    def test_release_before_the_subcommand_is_kept(self):
-        """The subcommand's own --release defaults to SUPPRESS so it does not
-        clobber a value given ahead of it."""
-        assert parse(['--release', '20131224', 'formats']).release == '20131224'
-        assert parse(['formats', '--release', '20131224']).release == '20131224'
-
-
-class TestApplyArgsToConf:
-    """Every value reaches conf, whether typed or defaulted."""
-
-    def test_defaults_reach_conf(self):
-        args = parse(['--mode', 'client'])
-        # Poison conf after parsing: applying must put the default back. The
-        # old setConfValue action ran only for values the user typed, so a
-        # default never reached conf at all.
-        fteproxy.conf.setValue('runtime.client.port', 1)
-        fteproxy.conf.setValue('runtime.mode', None)
-        fteproxy.cli.apply_args_to_conf(args)
-        assert fteproxy.conf.getValue('runtime.mode') == 'client'
-        assert fteproxy.conf.getValue('runtime.client.port') == args.client_port
-
-    def test_typed_values_reach_conf(self):
-        fteproxy.cli.apply_args_to_conf(parse([
-            '--mode', 'server',
-            '--client_ip', '10.0.0.1', '--client_port', '1111',
-            '--server_ip', '10.0.0.2', '--server_port', '2222',
-            '--proxy_ip', '10.0.0.3', '--proxy_port', '3333',
-            '--upstream-format', 'ssh-request',
-            '--downstream-format', 'ssh-response',
-            '--record-layer-mode', 'format',
-        ]))
-        get = fteproxy.conf.getValue
-        assert get('runtime.mode') == 'server'
-        assert get('runtime.client.ip') == '10.0.0.1'
-        assert get('runtime.client.port') == 1111
-        assert get('runtime.server.ip') == '10.0.0.2'
-        assert get('runtime.server.port') == 2222
-        assert get('runtime.proxy.ip') == '10.0.0.3'
-        assert get('runtime.proxy.port') == 3333
-        assert get('runtime.state.upstream_language') == 'ssh-request'
-        assert get('runtime.state.downstream_language') == 'ssh-response'
-        assert get('runtime.fteproxy.record_layer.mode') == 'format'
-
-    def test_key_reaches_conf_as_bytes(self):
-        fteproxy.cli.apply_args_to_conf(
-            parse(['--mode', 'client', '--key', '0123456789abcdef' * 4]))
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
-        assert key == bytes.fromhex('0123456789abcdef' * 4)
-
-    def test_key_file_reaches_conf(self, tmp_path):
-        key_file = tmp_path / 'fteproxy.key'
-        key_file.write_text('0123456789abcdef' * 4 + '\n')
-        fteproxy.cli.apply_args_to_conf(
-            parse(['--mode', 'client', '--key-file', str(key_file)]))
-        assert fteproxy.conf.getValue('runtime.fteproxy.encrypter.key') == \
-            bytes.fromhex('0123456789abcdef' * 4)
-
-    def test_changing_the_release_drops_the_definitions_cache(self):
-        fteproxy.defs.load_definitions()
-        assert fteproxy.defs._definitions is not None
-        fteproxy.cli.apply_args_to_conf(
-            parse(['--mode', 'client', '--release', '20131224']))
-        assert fteproxy.defs._definitions is None
-        assert fteproxy.conf.getValue('fteproxy.defs.release') == '20131224'
-
-
-class TestKeyValidation:
-    """Key errors are usage errors and never quote the key material."""
-
-    def test_short_key_rejected(self):
-        with pytest.raises(fteproxy.cli.UsageError) as excinfo:
-            fteproxy.cli.parse_hex_key('abcdef')
-        assert 'abcdef' not in str(excinfo.value)
-
-    def test_non_hex_key_rejected(self):
-        with pytest.raises(fteproxy.cli.UsageError):
-            fteproxy.cli.parse_hex_key('z' * 64)
-
-    def test_trailing_newline_accepted(self):
-        assert fteproxy.cli.parse_hex_key('ab' * 32 + '\n') == b'\xab' * 32
-
-    def test_missing_key_file_rejected(self, tmp_path):
-        with pytest.raises(fteproxy.cli.UsageError):
-            fteproxy.cli.read_key_file(str(tmp_path / 'nope.key'))
-
-    def test_bad_key_file_is_exit_2(self, tmp_path):
-        key_file = tmp_path / 'short.key'
-        key_file.write_text('abcdef')
-        with pytest.raises(SystemExit) as excinfo:
-            fteproxy.cli.main(['--mode', 'server', '--key-file', str(key_file)])
+            parse(['server', '-q', '-v'])
         assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
 
 
-class TestStartupChecks:
-    """Formats are validated before anything is printed or bound."""
+class TestRemovedFlags:
+    """Every pre-0.4 flag is recognised only to point at the upgrade notes."""
 
-    def test_unknown_format_raises(self):
-        with pytest.raises(fteproxy.cli.StartupError) as excinfo:
-            fteproxy.cli.check_format('no-such-format')
-        assert 'no-such-format' in str(excinfo.value)
+    @pytest.mark.parametrize('flag', fteproxy.cli.REMOVED_FLAGS)
+    def test_each_removed_flag(self, flag, capsys):
+        assert fteproxy.cli.main([flag, 'whatever']) == fteproxy.cli.EXIT_USAGE
+        err = capsys.readouterr().err
+        assert flag in err
+        assert 'Upgrading to 0.4.0' in err
 
-    def test_known_format_passes(self):
-        fteproxy.cli.check_format('manual-http-request')
+    def test_flag_with_an_equals_sign(self, capsys):
+        assert fteproxy.cli.main(['--key=deadbeef']) == fteproxy.cli.EXIT_USAGE
+        assert '--key' in capsys.readouterr().err
+
+    def test_mode_still_works_under_client(self):
+        """--mode means the record-layer mode now, so it is only a removed
+        flag before a subcommand."""
+        assert fteproxy.cli.removed_flag(['client', '--mode', 'hybrid']) is None
+        assert fteproxy.cli.removed_flag(['--mode', 'client']) == '--mode'
+
+    def test_no_alias_is_offered(self, capsys):
+        """A silent alias would run a different topology than was asked for."""
+        fteproxy.cli.main(['--proxy_ip', '127.0.0.1'])
+        err = capsys.readouterr().err
+        assert 'destination is chosen on the client' in err
 
 
-class TestMainExitStatus:
-    """The statuses the plan fixes: 0 clean, 1 runtime failure, 2 usage."""
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
 
-    def test_no_arguments_is_usage(self, capsys):
+class TestBareInvocation:
+
+    def test_prints_usage_and_exits_2(self, capsys):
         assert fteproxy.cli.main([]) == fteproxy.cli.EXIT_USAGE
         err = capsys.readouterr().err
         assert 'usage:' in err
-        assert '--mode' in err
-
-    def test_unknown_upstream_format_is_failure(self, capsys):
-        status = fteproxy.cli.main(
-            ['--mode', 'client', '--upstream-format', 'nope'])
-        assert status == fteproxy.cli.EXIT_FAILURE
-        assert 'nope' in capsys.readouterr().err
-
-    def test_unknown_downstream_format_is_failure(self):
-        assert fteproxy.cli.main(
-            ['--mode', 'client', '--downstream-format', 'nope']) == \
-            fteproxy.cli.EXIT_FAILURE
-
-    def test_bind_failure_is_failure(self):
-        """A port already taken exits 1 rather than leaving a dead thread and
-        exiting 0."""
-        import socket
-
-        taken = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        taken.bind(('127.0.0.1', 0))
-        taken.listen(1)
-        port = taken.getsockname()[1]
-        try:
-            status = fteproxy.cli.main([
-                '--mode', 'client',
-                '--client_ip', '127.0.0.1', '--client_port', str(port),
-            ])
-        finally:
-            taken.close()
-        assert status == fteproxy.cli.EXIT_FAILURE
+        for name in ('server', 'client', 'keygen', 'formats'):
+            assert name in err
 
     def test_version_exits_zero(self, capsys):
         with pytest.raises(SystemExit) as excinfo:
@@ -235,7 +376,42 @@ class TestMainExitStatus:
         assert 'NO WARRANTY' in out
 
 
-class TestFormatsSubcommand:
+class TestKeygen:
+
+    def test_creates_a_key_and_prints_the_string(self, tmp_path, capsys):
+        directory = str(tmp_path / 'state')
+        assert fteproxy.cli.main(['keygen', '--state-dir', directory]) == \
+            fteproxy.cli.EXIT_OK
+        out = capsys.readouterr().out.strip()
+        assert out.startswith('fte://')
+        assert fteproxy.config.HOST_PLACEHOLDER in out
+        uri = fteproxy.config.ConnectionString.parse(out)
+        private = fteproxy.config.load_server_key(directory)
+        assert fteproxy.server_id(private) == uri.server_id
+
+    def test_advertise(self, tmp_path, capsys):
+        directory = str(tmp_path / 'state')
+        fteproxy.cli.main(['keygen', '--state-dir', directory,
+                           '--advertise', 'vpn.example.com:9000'])
+        uri = fteproxy.config.ConnectionString.parse(
+            capsys.readouterr().out.strip())
+        assert uri.address == ('vpn.example.com', 9000)
+
+    def test_is_idempotent(self, tmp_path, capsys):
+        directory = str(tmp_path / 'state')
+        fteproxy.cli.main(['keygen', '--state-dir', directory])
+        first = capsys.readouterr().out
+        fteproxy.cli.main(['keygen', '--state-dir', directory])
+        assert capsys.readouterr().out == first
+
+    def test_a_bad_advertise_is_a_usage_error(self, tmp_path):
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['keygen', '--state-dir', str(tmp_path),
+                               '--advertise', '[::1'])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+
+class TestFormats:
 
     def test_lists_base_names_with_capacity(self, capsys):
         assert fteproxy.cli.main(['formats']) == fteproxy.cli.EXIT_OK
@@ -247,21 +423,93 @@ class TestFormatsSubcommand:
         # manual-http-response carries 192 bytes per covertext at length 256.
         assert '192' in out
 
-    def test_marks_the_configured_default(self, capsys):
-        fteproxy.cli.main(['--upstream-format', 'ssh-request', 'formats'])
-        for line in capsys.readouterr().out.splitlines():
-            if '(default)' in line:
-                assert line.split()[0] == 'ssh'
-                break
-        else:
-            pytest.fail('no format marked as the default')
-
     def test_honours_the_release(self, capsys):
-        assert fteproxy.cli.main(['--release', '20131224', 'formats']) == \
+        assert fteproxy.cli.main(['formats', '--defs', '20131224']) == \
             fteproxy.cli.EXIT_OK
         out = capsys.readouterr().out
         assert '20131224' in out
+        assert 'manual-ssh' in out
 
+    def test_an_unknown_release_is_a_failure(self, capsys):
+        assert fteproxy.cli.main(['formats', '--defs', '19700101']) == \
+            fteproxy.cli.EXIT_FAILURE
+
+
+class TestClientStartup:
+
+    def test_an_unknown_format_is_a_failure(self, tmp_path, capsys):
+        assert fteproxy.cli.main([
+            'client', 'fte://%s@127.0.0.1:1' % SERVER_ID,
+            '--format', 'no-such-format', '--no-check',
+            '--state-dir', str(tmp_path)]) == fteproxy.cli.EXIT_FAILURE
+        assert 'no-such-format' in capsys.readouterr().err
+
+    def test_a_bad_forward_spec_is_a_usage_error(self, tmp_path):
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main([
+                'client', 'fte://%s@127.0.0.1:1' % SERVER_ID,
+                '-L', 'nonsense', '--no-check', '--state-dir', str(tmp_path)])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_the_startup_check_fails_with_a_reason(self, tmp_path, capsys):
+        import socket
+
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(('127.0.0.1', 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        status = fteproxy.cli.main([
+            'client', 'fte://%s@127.0.0.1:%d' % (SERVER_ID, port),
+            '--state-dir', str(tmp_path)])
+        assert status == fteproxy.cli.EXIT_FAILURE
+        captured = capsys.readouterr()
+        assert 'checking 127.0.0.1:%d' % port in captured.err
+        assert 'not running fteproxy 0.4' in captured.err
+
+    def test_no_uri_anywhere_is_a_usage_error(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('FTEPROXY_URI', raising=False)
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['client', '--no-check',
+                               '--state-dir', str(tmp_path / 'empty')])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+
+class TestServerStartup:
+
+    def test_a_bad_allow_rule_is_a_usage_error(self, tmp_path):
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['server', '--listen', ':0',
+                               '--allow', 'host:not-a-port',
+                               '--state-dir', str(tmp_path)])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_a_bad_listen_spec_is_a_usage_error(self, tmp_path):
+        with pytest.raises(SystemExit) as excinfo:
+            fteproxy.cli.main(['server', '--listen', '[::1',
+                               '--state-dir', str(tmp_path)])
+        assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+    def test_a_taken_port_is_a_failure(self, tmp_path, capsys):
+        import socket
+
+        taken = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        taken.bind(('127.0.0.1', 0))
+        taken.listen(1)
+        port = taken.getsockname()[1]
+        try:
+            status = fteproxy.cli.main([
+                'server', '--listen', '127.0.0.1:%d' % port,
+                '--state-dir', str(tmp_path)])
+        finally:
+            taken.close()
+        assert status == fteproxy.cli.EXIT_FAILURE
+        assert 'cannot listen' in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# Logging
+# --------------------------------------------------------------------------- #
 
 class TestLogging:
     """Verbosity flags set the package logger's level; output is on stderr.
@@ -310,10 +558,8 @@ class TestLogRedaction:
         assert '<redacted>' in caplog.text
 
     def test_a_bare_server_id_is_removed(self, caplog):
-        import base64
-
         _private, public = fteproxy.generate_server_key()
-        text = base64.urlsafe_b64encode(public).rstrip(b'=').decode('ascii')
+        text = fteproxy.config.encode_server_id(public)
         with caplog.at_level(logging.INFO, logger='fteproxy'):
             fteproxy.info('server-id ' + text)
         assert text not in caplog.text

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -13,13 +13,14 @@ import re
 
 import fte
 import fteproxy
+from fteproxy.tests import conftest
 import fteproxy.conf
 import fteproxy.defs
 import fteproxy.record_layer
 
 
 # libfte 0.4 requires an explicit key; use fteproxy's configured shared key.
-_KEY = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+_KEY = conftest.TEST_KEY
 
 
 def _cipher(pattern, length):

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -14,6 +14,7 @@ import time
 import pytest
 
 import fteproxy
+from fteproxy.tests import conftest
 import fteproxy.conf
 import fteproxy.defs
 import fteproxy.network_io
@@ -28,7 +29,7 @@ class TestPython3Compatibility:
 
     def test_bytes_key_config(self):
         """Test that the encryption key is properly stored as bytes."""
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        key = conftest.TEST_KEY
         assert isinstance(key, bytes)
         assert len(key) == 32
 

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -11,6 +11,7 @@ import pytest
 import fte
 
 import fteproxy
+from fteproxy.tests import conftest
 import fteproxy.conf
 import fteproxy.defs
 import fteproxy.record_layer
@@ -25,9 +26,8 @@ STEP = 64
 @pytest.fixture
 def record_layer_pairs():
     """Create encoder/decoder pairs for all defined languages."""
-    fteproxy.conf.setValue('runtime.mode', 'client')
     
-    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+    key = conftest.TEST_KEY
     pairs = []
     definitions = fteproxy.defs.load_definitions()
     for language in definitions.keys():
@@ -171,8 +171,7 @@ class TestHybridRecordLayer:
     """The hybrid framing: a formatted header covertext + a raw authenticated body."""
 
     def _pair(self, language='manual-http-request'):
-        fteproxy.conf.setValue('runtime.mode', 'client')
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        key = conftest.TEST_KEY
         pattern = fteproxy.defs.getRegex(language)
         length = fteproxy.defs.getLength(language)
         header = fteproxy._make_cipher(pattern, length, key)
@@ -282,8 +281,7 @@ class TestFormatModeRecordLayer:
     """'format' mode: one sealed covertext per record, stamped with its position."""
 
     def _pair(self, language='manual-http-request'):
-        fteproxy.conf.setValue('runtime.mode', 'client')
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
             fteproxy.defs.getRegex(language), fteproxy.defs.getLength(language), key)
         return (fteproxy.record_layer.Encoder(cipher=cipher),
@@ -318,9 +316,8 @@ class TestFormatModeRecordLayer:
 def test_seal_fills_covertext_with_random_not_padding():
     """A short message fills the covertext with random format text, so there is
     no 'GET /0000...' low-rank padding run in either mode."""
-    fteproxy.conf.setValue('runtime.mode', 'client')
     fteproxy.defs.load_definitions()
-    key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+    key = conftest.TEST_KEY
     pattern = fteproxy.defs.getRegex('http-simple-request')
     header = fteproxy._make_cipher(pattern, 256, key)
 
@@ -345,8 +342,7 @@ class TestRecordTypes:
     """Every record carries a type byte; unknown types close the connection."""
 
     def _pair(self, hybrid=True, language='manual-http-request'):
-        fteproxy.conf.setValue('runtime.mode', 'client')
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
             fteproxy.defs.getRegex(language),
             fteproxy.defs.getLength(language), key)
@@ -408,7 +404,7 @@ class TestRecordTypes:
         capacity. In hybrid mode the body has no fixed width, so it rides on
         top and the chunk boundaries are unchanged: a 1 MiB write is still one
         record, not one plus a one-byte straggler."""
-        key = fteproxy.conf.getValue('runtime.fteproxy.encrypter.key')
+        key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
             fteproxy.defs.getRegex('manual-http-request'),
             fteproxy.defs.getLength('manual-http-request'), key)

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -29,7 +29,6 @@ SERVER_PRIVATE, SERVER_PUBLIC = fteproxy.generate_server_key()
 
 @pytest.fixture(autouse=True)
 def _defs():
-    fteproxy.conf.setValue('runtime.mode', 'client')
     fteproxy.defs.load_definitions()
 
 

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -1,424 +1,431 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-System tests that spin up actual fteproxy client and server processes.
+"""System tests that run real ``fteproxy`` processes.
 
-These tests verify end-to-end functionality by:
-1. Starting a fteproxy server
-2. Starting a fteproxy client
-3. Sending data through the proxy chain
-4. Verifying data integrity
+These are the plan's section 1 transcript, executed: a server that generates a
+key on first start and writes a connection string, a client that finds it and
+opens a SOCKS5 listener or a forwarded port, and a transfer through the
+result.
+
+The ports here are fixed, so no two sessions of this file may run at once.
 """
 
 import os
-import sys
-import time
-import socket
-import signal
-import subprocess
 import random
+import socket
 import string
+import subprocess
+import sys
+import threading
+import time
 
 import pytest
 
+import fteproxy
+import fteproxy.config
+import fteproxy.stream
 
-# Test configuration
+
 BIND_IP = '127.0.0.1'
-CLIENT_PORT = 18079
 SERVER_PORT = 18080
-PROXY_PORT = 18081
+SOCKS_PORT = 18079
+FORWARD_PORT = 18078
 STARTUP_TIMEOUT = 30
 DATA_TIMEOUT = 30
 
 
 def random_bytes(size):
     """Generate random bytes for testing."""
-    return ''.join(random.choices(string.ascii_letters + string.digits, k=size)).encode('utf-8')
+    return ''.join(random.choices(string.ascii_letters + string.digits,
+                                  k=size)).encode('utf-8')
 
 
 def wait_for_port(host, port, timeout=STARTUP_TIMEOUT):
-    """Wait for a port to become available."""
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    """Wait for a port to accept connections."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1)
             sock.connect((host, port))
             sock.close()
             return True
-        except (socket.error, socket.timeout):
-            time.sleep(0.5)
+        except (OSError, socket.timeout):
+            time.sleep(0.25)
     return False
 
 
 def get_fteproxy_cmd():
-    """Get the command to run fteproxy."""
-    # Use module execution - the canonical way to run fteproxy
+    """The command that runs fteproxy: module execution, the canonical way."""
     return [sys.executable, '-m', 'fteproxy']
 
 
-def _attempt_transfer(test_data, client_port=CLIENT_PORT, proxy_port=PROXY_PORT):
-    """Run a single end-to-end transfer through the proxy chain.
+def run_cli(args, timeout=60, env=None):
+    return subprocess.run(get_fteproxy_cmd() + args, capture_output=True,
+                          text=True, timeout=timeout, env=env)
 
-    Opens a fresh destination server on ``proxy_port``, connects to the
-    fteproxy client on ``client_port``, sends ``test_data`` and returns the
-    bytes received on the destination side. Any socket error/timeout
-    propagates so callers can retry.
-    """
-    received_data = b''
-    dest_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    dest_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    dest_server.bind((BIND_IP, proxy_port))
-    dest_server.listen(1)
-    dest_server.settimeout(DATA_TIMEOUT)
 
-    client_conn = None
-    proxy_conn = None
+def start(args, env=None):
+    return subprocess.Popen(get_fteproxy_cmd() + args, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, env=env)
+
+
+def terminate(proc):
+    proc.terminate()
     try:
-        client_conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        client_conn.connect((BIND_IP, client_port))
-        client_conn.settimeout(DATA_TIMEOUT)
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
 
-        proxy_conn, _ = dest_server.accept()
-        proxy_conn.settimeout(DATA_TIMEOUT)
 
-        # Send data in chunks so large payloads don't overflow send buffers.
-        sent = 0
-        while sent < len(test_data):
-            chunk_size = min(4096, len(test_data) - sent)
-            client_conn.sendall(test_data[sent:sent + chunk_size])
-            sent += chunk_size
+class EchoDestination:
+    """A destination the tunnel can reach, echoing whatever it is sent."""
 
-        while len(received_data) < len(test_data):
-            chunk = proxy_conn.recv(4096)
+    def __init__(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((BIND_IP, 0))
+        self._sock.listen(16)
+        self._sock.settimeout(0.2)
+        self.port = self._sock.getsockname()[1]
+        self._running = True
+        threading.Thread(target=self._run, daemon=True).start()
+
+    def _run(self):
+        while self._running:
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._serve, args=(conn,),
+                             daemon=True).start()
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+    @staticmethod
+    def _serve(conn):
+        conn.settimeout(DATA_TIMEOUT)
+        try:
+            while True:
+                data = conn.recv(65536)
+                if not data:
+                    break
+                conn.sendall(data)
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def stop(self):
+        self._running = False
+
+
+def transfer(address, payload):
+    """Send ``payload`` through ``address`` and read the echo back."""
+    sock = socket.create_connection(address, timeout=DATA_TIMEOUT)
+    sock.settimeout(DATA_TIMEOUT)
+    try:
+        sock.sendall(payload)
+        received = b''
+        while len(received) < len(payload):
+            chunk = sock.recv(65536)
             if not chunk:
                 break
-            received_data += chunk
-
-        return received_data
+            received += chunk
+        return received
     finally:
-        for sock in (client_conn, proxy_conn, dest_server):
-            if sock is not None:
-                try:
-                    sock.close()
-                except OSError:
-                    pass
+        sock.close()
 
 
-def transfer_through_proxy(test_data, attempts=3, client_port=CLIENT_PORT, proxy_port=PROXY_PORT):
-    """End-to-end transfer with retries to absorb proxy startup races.
+def socks_connect(port, host, dest_port):
+    """A SOCKS5 CONNECT by hand; returns ``(socket, reply status)``."""
+    sock = socket.create_connection((BIND_IP, port), timeout=DATA_TIMEOUT)
+    sock.settimeout(DATA_TIMEOUT)
+    sock.sendall(b'\x05\x01\x00')
+    assert sock.recv(2) == b'\x05\x00'
+    sock.sendall(b'\x05\x01\x00'
+                 + fteproxy.stream.encode_address(host, dest_port))
+    head = sock.recv(4)
+    width = {0x01: 4, 0x04: 16}.get(head[3]) or sock.recv(1)[0]
+    sock.recv(width + 2)
+    return sock, head[1]
 
-    A freshly started proxy chain occasionally drops the very first
-    connection while the FTE client/server handshake settles. Each attempt
-    uses a brand new connection, so a retry still exercises a real transfer;
-    the last attempt's bytes are returned for the caller to assert on.
-    """
-    received_data = b''
-    for attempt in range(attempts):
+
+# --------------------------------------------------------------------------- #
+# Fixtures: the transcript from section 1 of the plan
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def destination():
+    echo = EchoDestination()
+    yield echo
+    echo.stop()
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    return str(tmp_path / 'state')
+
+
+@pytest.fixture
+def server(destination, state_dir):
+    """``fteproxy server``: makes a key on first start, writes the string."""
+    proc = start([
+        'server',
+        '--listen', '%s:%d' % (BIND_IP, SERVER_PORT),
+        '--advertise', '%s:%d' % (BIND_IP, SERVER_PORT),
+        '--allow', '%s:%d' % (BIND_IP, destination.port),
+        '--state-dir', state_dir,
+    ])
+    if not wait_for_port(BIND_IP, SERVER_PORT):
+        terminate(proc)
+        stdout, stderr = proc.communicate(timeout=5)
+        pytest.fail('server failed to start. stdout: %s stderr: %s'
+                    % (stdout, stderr))
+    yield proc
+    terminate(proc)
+
+
+@pytest.fixture
+def socks_client(server, state_dir):
+    """``fteproxy client`` with no URI: it finds connection.txt."""
+    proc = start(['client', '-D', '%s:%d' % (BIND_IP, SOCKS_PORT),
+                  '--state-dir', state_dir])
+    if not wait_for_port(BIND_IP, SOCKS_PORT):
+        terminate(proc)
+        stdout, stderr = proc.communicate(timeout=5)
+        pytest.fail('client failed to start. stdout: %s stderr: %s'
+                    % (stdout, stderr))
+    yield proc
+    terminate(proc)
+
+
+class TestServerStartup:
+
+    def test_the_first_start_writes_a_key_and_a_connection_string(
+            self, server, state_dir):
+        assert os.path.exists(fteproxy.config.server_key_path(state_dir))
+        text = fteproxy.config.read_connection_string(state_dir)
+        uri = fteproxy.config.ConnectionString.parse(text)
+        assert uri.address == (BIND_IP, SERVER_PORT)
+        private = fteproxy.config.load_server_key(state_dir)
+        assert fteproxy.server_id(private) == uri.server_id
+
+    def test_a_restart_keeps_the_same_identity(self, server, state_dir,
+                                               destination):
+        first = fteproxy.config.read_connection_string(state_dir)
+        terminate(server)
+        proc = start([
+            'server', '--listen', '%s:%d' % (BIND_IP, SERVER_PORT),
+            '--advertise', '%s:%d' % (BIND_IP, SERVER_PORT),
+            '--allow', '%s:%d' % (BIND_IP, destination.port),
+            '--state-dir', state_dir])
         try:
-            received_data = _attempt_transfer(test_data, client_port=client_port, proxy_port=proxy_port)
-            if received_data == test_data:
-                return received_data
-        except (socket.timeout, OSError):
-            received_data = b''
-        if attempt < attempts - 1:
-            time.sleep(1)
-    return received_data
+            assert wait_for_port(BIND_IP, SERVER_PORT)
+            assert fteproxy.config.read_connection_string(state_dir) == first
+        finally:
+            terminate(proc)
 
 
-class TestSystemEndToEnd:
-    """End-to-end system tests with actual client/server processes."""
+class TestEndToEnd:
 
-    @pytest.fixture
-    def fteproxy_server(self):
-        """Start an fteproxy server process."""
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'server',
-            '--quiet',
-            '--server_ip', BIND_IP,
-            '--server_port', str(SERVER_PORT),
-            '--proxy_ip', BIND_IP,
-            '--proxy_port', str(PROXY_PORT),
-        ]
-        
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        
-        # Wait for server to start
-        if not wait_for_port(BIND_IP, SERVER_PORT):
-            proc.terminate()
-            stdout, stderr = proc.communicate(timeout=5)
-            pytest.fail(f"Server failed to start. stdout: {stdout}, stderr: {stderr}")
-        # Give the listener a moment to settle after the readiness probe.
-        time.sleep(1)
-
-        yield proc
-        
-        # Cleanup
-        proc.terminate()
+    def test_socks_transfer(self, socks_client, destination):
+        sock, status = socks_connect(SOCKS_PORT, BIND_IP, destination.port)
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+            assert status == fteproxy.stream.SUCCEEDED
+            payload = b'Hello, fteproxy!'
+            sock.sendall(payload)
+            assert sock.recv(4096) == payload
+        finally:
+            sock.close()
 
-    @pytest.fixture
-    def fteproxy_client(self, fteproxy_server):
-        """Start an fteproxy client process (requires server)."""
-        # TODO(PR4): the destination is chosen client-side now that it
-        # travels in band, so the flat client needs --proxy_* too. The new
-        # command line spells this -L CLIENT_PORT:HOST:PORT.
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'client',
-            '--quiet',
-            '--client_ip', BIND_IP,
-            '--client_port', str(CLIENT_PORT),
-            '--server_ip', BIND_IP,
-            '--server_port', str(SERVER_PORT),
-            '--proxy_ip', BIND_IP,
-            '--proxy_port', str(PROXY_PORT),
-        ]
-        
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        
-        # Wait for client to start
-        if not wait_for_port(BIND_IP, CLIENT_PORT):
-            proc.terminate()
-            stdout, stderr = proc.communicate(timeout=5)
-            pytest.fail(f"Client failed to start. stdout: {stdout}, stderr: {stderr}")
-        # Give the listener a moment to settle after the readiness probe.
-        time.sleep(1)
-
-        yield proc
-        
-        # Cleanup
-        proc.terminate()
+    def test_socks_large_transfer(self, socks_client, destination):
+        payload = random_bytes(64 * 1024)
+        sock, status = socks_connect(SOCKS_PORT, BIND_IP, destination.port)
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+            assert status == fteproxy.stream.SUCCEEDED
+            sock.sendall(payload)
+            received = b''
+            while len(received) < len(payload):
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                received += chunk
+        finally:
+            sock.close()
+        assert received == payload
 
-    def test_basic_data_transfer(self, fteproxy_client):
-        """Test basic data transfer through the proxy."""
-        test_data = b'Hello, fteproxy!'
-        received_data = transfer_through_proxy(test_data)
-        assert received_data == test_data, f"Data mismatch: {received_data!r} != {test_data!r}"
+    def test_several_socks_connections(self, socks_client, destination):
+        for index in range(3):
+            payload = ('connection %d: ' % index).encode() + random_bytes(100)
+            sock, status = socks_connect(SOCKS_PORT, BIND_IP, destination.port)
+            try:
+                assert status == fteproxy.stream.SUCCEEDED
+                sock.sendall(payload)
+                received = b''
+                while len(received) < len(payload):
+                    chunk = sock.recv(65536)
+                    if not chunk:
+                        break
+                    received += chunk
+                assert received == payload
+            finally:
+                sock.close()
 
-    def test_large_data_transfer(self, fteproxy_client):
-        """Test transfer of larger data through the proxy."""
-        test_data = random_bytes(64 * 1024)  # 64KB
-        received_data = transfer_through_proxy(test_data)
-        assert len(received_data) == len(test_data), \
-            f"Size mismatch: {len(received_data)} != {len(test_data)}"
-        assert received_data == test_data, "Data content mismatch"
+    def test_the_allow_rules_are_enforced(self, socks_client, destination):
+        """A destination outside --allow comes back as SOCKS5's 0x02."""
+        sock, status = socks_connect(SOCKS_PORT, BIND_IP, destination.port + 1)
+        sock.close()
+        assert status == fteproxy.stream.NOT_ALLOWED
 
-    def test_multiple_connections(self, fteproxy_client):
-        """Test multiple sequential connections through the proxy."""
-        for i in range(3):
-            test_data = f'Connection {i}: {random_bytes(100).decode()}'.encode('utf-8')
-            received_data = transfer_through_proxy(test_data)
-            assert received_data == test_data, f"Connection {i} failed"
-            time.sleep(0.5)  # Brief pause between connections
+    def test_forward_transfer(self, server, state_dir, destination):
+        """The old fixed-destination topology, spelled -L."""
+        proc = start(['client', '-L', '%s:%d:%s:%d'
+                      % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
+                      '--state-dir', state_dir])
+        try:
+            assert wait_for_port(BIND_IP, FORWARD_PORT)
+            payload = random_bytes(8 * 1024)
+            assert transfer((BIND_IP, FORWARD_PORT), payload) == payload
+        finally:
+            terminate(proc)
+
+    def test_the_uri_can_come_from_the_environment(self, server, state_dir,
+                                                   destination):
+        env = dict(os.environ)
+        env['FTEPROXY_URI'] = fteproxy.config.read_connection_string(state_dir)
+        proc = start(['client', '-L', '%s:%d:%s:%d'
+                      % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
+                      '--state-dir', state_dir + '-empty'], env=env)
+        try:
+            assert wait_for_port(BIND_IP, FORWARD_PORT)
+            assert transfer((BIND_IP, FORWARD_PORT),
+                            b'from the environment') == b'from the environment'
+        finally:
+            terminate(proc)
+
+    def test_format_mode_end_to_end(self, server, state_dir, destination):
+        """The client picks the record-layer mode; the server follows."""
+        proc = start(['client', '--mode', 'format',
+                      '-L', '%s:%d:%s:%d'
+                      % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
+                      '--state-dir', state_dir])
+        try:
+            assert wait_for_port(BIND_IP, FORWARD_PORT)
+            payload = b'every byte in the format' * 8
+            assert transfer((BIND_IP, FORWARD_PORT), payload) == payload
+        finally:
+            terminate(proc)
+
+    def test_a_non_default_format_end_to_end(self, server, state_dir,
+                                             destination):
+        """The server is told no format; it learns it from the first record."""
+        proc = start(['client', '--format', 'words',
+                      '-L', '%s:%d:%s:%d'
+                      % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
+                      '--state-dir', state_dir])
+        try:
+            assert wait_for_port(BIND_IP, FORWARD_PORT)
+            payload = b'traffic that looks like words'
+            assert transfer((BIND_IP, FORWARD_PORT), payload) == payload
+        finally:
+            terminate(proc)
 
 
 class TestCLI:
-    """Tests for the fteproxy CLI."""
+    """The command line as a process: statuses, output streams, old flags."""
 
     def test_version(self):
-        """Test --version flag."""
-        cmd = get_fteproxy_cmd() + ['--version']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        result = run_cli(['--version'], timeout=30)
         assert result.returncode == 0
-        # Version should be in the output
-        assert result.stdout.strip() or result.stderr.strip()
+        assert fteproxy.__version__ in result.stdout
 
-    def test_help(self):
-        """Test --help flag."""
-        cmd = get_fteproxy_cmd() + ['--help']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    def test_help_lists_the_subcommands(self):
+        result = run_cli(['--help'], timeout=30)
         assert result.returncode == 0
-        assert '--mode' in result.stdout
-        assert 'client' in result.stdout
-        assert 'server' in result.stdout
-
-    def test_invalid_mode(self):
-        """Test that invalid mode is rejected."""
-        cmd = get_fteproxy_cmd() + ['--mode', 'invalid']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode == 2
+        for name in ('server', 'client', 'keygen', 'formats'):
+            assert name in result.stdout
 
     def test_no_arguments_prints_usage_and_exits_2(self):
-        """A bare run used to crash with a TypeError deep in the relay and
-        still exit 0, because argparse never applied the defaults to conf."""
-        result = subprocess.run(get_fteproxy_cmd(), capture_output=True,
-                                text=True, timeout=10)
+        result = run_cli([], timeout=30)
         assert result.returncode == 2
         assert 'usage:' in result.stderr
         assert 'Traceback' not in result.stderr
 
-    def test_invalid_format_exits_1(self):
-        """A startup failure is a runtime failure, not a silent success."""
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'client', '--upstream-format', 'no-such-format']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        assert result.returncode == 1
-        assert 'no-such-format' in result.stderr
-
-    def test_formats_subcommand(self):
-        """``fteproxy formats`` lists the base names on stdout and exits 0."""
-        cmd = get_fteproxy_cmd() + ['formats']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    def test_formats_goes_to_stdout(self):
+        result = run_cli(['formats'], timeout=60)
         assert result.returncode == 0
         assert 'manual-http' in result.stdout
         assert '(default)' in result.stdout
 
-    def test_key_file_in_help(self):
-        """Test that --key-file appears in the help output."""
-        cmd = get_fteproxy_cmd() + ['--help']
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    def test_keygen_prints_the_connection_string(self, tmp_path):
+        result = run_cli(['keygen', '--state-dir', str(tmp_path / 'state')],
+                         timeout=30)
         assert result.returncode == 0
-        assert '--key-file' in result.stdout
+        assert result.stdout.strip().startswith('fte://')
 
-    def test_key_file_missing(self, tmp_path):
-        """Test that a nonexistent key file is rejected."""
-        missing = tmp_path / 'does-not-exist.key'
-        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(missing)]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    @pytest.mark.parametrize('flag', [
+        '--mode', '--key', '--key-file', '--server_ip', '--proxy_port',
+        '--upstream-format', '--record-layer-mode', '--stop', '--quiet',
+    ])
+    def test_removed_flags_point_at_the_upgrade_notes(self, flag):
+        result = run_cli([flag, 'value'], timeout=30)
         assert result.returncode == 2
+        assert flag in result.stderr
+        assert 'Upgrading to 0.4.0' in result.stderr
 
-    def test_key_file_invalid_length(self, tmp_path):
-        """Test that a key file with the wrong length is rejected."""
-        key_file = tmp_path / 'short.key'
-        key_file.write_text('abcdef')
-        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    def test_an_unknown_format_exits_1(self, tmp_path):
+        _private, public = fteproxy.generate_server_key()
+        uri = fteproxy.config.ConnectionString(public, BIND_IP, 1)
+        result = run_cli(['client', uri.format(), '--format', 'no-such-format',
+                          '--no-check', '--state-dir', str(tmp_path)],
+                         timeout=60)
+        assert result.returncode == 1
+        assert 'no-such-format' in result.stderr
+
+    def test_a_client_with_nowhere_to_connect_exits_1(self, tmp_path):
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind((BIND_IP, 0))
+        port = probe.getsockname()[1]
+        probe.close()
+        _private, public = fteproxy.generate_server_key()
+        uri = fteproxy.config.ConnectionString(public, BIND_IP, port)
+        result = run_cli(['client', uri.format(),
+                          '--state-dir', str(tmp_path / 'state')], timeout=60)
+        assert result.returncode == 1
+        assert 'checking %s:%d' % (BIND_IP, port) in result.stderr
+
+    def test_no_connection_string_anywhere_exits_2(self, tmp_path):
+        env = dict(os.environ)
+        env.pop('FTEPROXY_URI', None)
+        result = run_cli(['client', '--state-dir', str(tmp_path / 'nothing')],
+                         timeout=30, env=env)
         assert result.returncode == 2
-
-    def test_key_file_invalid_characters(self, tmp_path):
-        """Test that a key file with non-hex characters is rejected."""
-        key_file = tmp_path / 'nonhex.key'
-        key_file.write_text('z' * 64)
-        cmd = get_fteproxy_cmd() + ['--mode', 'server', '--key-file', str(key_file)]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode == 2
-
-    def test_key_and_key_file_mutually_exclusive(self, tmp_path):
-        """Test that --key and --key-file cannot be used together."""
-        key_file = tmp_path / 'good.key'
-        key_file.write_text('a' * 64)
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'server',
-            '--key', 'a' * 64,
-            '--key-file', str(key_file),
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        assert result.returncode == 2
-        assert '--key-file' in result.stderr and '--key' in result.stderr
+        assert 'FTEPROXY_URI' in result.stderr
+        assert 'connection.txt' in result.stderr
 
 
-# A non-default 64-hex-character key, so a successful transfer proves both the
-# server and the client actually loaded the key from the shared key file.
-KEYFILE_TEST_KEY = '0123456789abcdef' * 4
-KEYFILE_CLIENT_PORT = 18179
-KEYFILE_SERVER_PORT = 18180
-KEYFILE_PROXY_PORT = 18181
-
-
-class TestKeyFileEndToEnd:
-    """End-to-end test that server and client interoperate via a key file."""
-
-    @pytest.fixture
-    def key_file(self, tmp_path):
-        """Write a shared key file used by both the server and the client."""
-        path = tmp_path / 'fteproxy.key'
-        path.write_text(KEYFILE_TEST_KEY + '\n')
-        return str(path)
-
-    @pytest.fixture
-    def fteproxy_server(self, key_file):
-        """Start an fteproxy server that reads its key from a file."""
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'server',
-            '--quiet',
-            '--server_ip', BIND_IP,
-            '--server_port', str(KEYFILE_SERVER_PORT),
-            '--proxy_ip', BIND_IP,
-            '--proxy_port', str(KEYFILE_PROXY_PORT),
-            '--key-file', key_file,
-        ]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not wait_for_port(BIND_IP, KEYFILE_SERVER_PORT):
-            proc.terminate()
-            stdout, stderr = proc.communicate(timeout=5)
-            pytest.fail(f"Server failed to start. stdout: {stdout}, stderr: {stderr}")
-        # Give the listener a moment to settle after the readiness probe.
-        time.sleep(1)
-        yield proc
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-
-    @pytest.fixture
-    def fteproxy_client(self, fteproxy_server, key_file):
-        """Start an fteproxy client that reads the same key from a file."""
-        cmd = get_fteproxy_cmd() + [
-            '--mode', 'client',
-            '--quiet',
-            '--client_ip', BIND_IP,
-            '--client_port', str(KEYFILE_CLIENT_PORT),
-            '--server_ip', BIND_IP,
-            '--server_port', str(KEYFILE_SERVER_PORT),
-            '--proxy_ip', BIND_IP,
-            '--proxy_port', str(KEYFILE_PROXY_PORT),
-            '--key-file', key_file,
-        ]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not wait_for_port(BIND_IP, KEYFILE_CLIENT_PORT):
-            proc.terminate()
-            stdout, stderr = proc.communicate(timeout=5)
-            pytest.fail(f"Client failed to start. stdout: {stdout}, stderr: {stderr}")
-        # Give the listener a moment to settle after the readiness probe.
-        time.sleep(1)
-        yield proc
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-
-    def test_key_file_data_transfer(self, fteproxy_client):
-        """Data should flow end-to-end when both sides load a key from file."""
-        test_data = b'Hello, key file!'
-        received_data = transfer_through_proxy(
-            test_data,
-            client_port=KEYFILE_CLIENT_PORT,
-            proxy_port=KEYFILE_PROXY_PORT,
-        )
-        assert received_data == test_data, \
-            f"Data mismatch: {received_data!r} != {test_data!r}"
-
+# --------------------------------------------------------------------------- #
+# The library API, without the command line
+# --------------------------------------------------------------------------- #
 
 class TestLibraryEndToEnd:
-    """The 0.4 topology, driven through the library API.
+    """The same topology built with the library API.
 
-    The command line that spells these ``-D`` and ``-L`` lands in PR4; what
-    these check is that a whole tunnel -- handshake, OPEN, allow rules, relay,
-    half-close -- carries a real transfer in one piece.
+    The command line above is one way to reach it; a program embedding
+    fteproxy is the other, and both have to work.
     """
 
     @pytest.fixture
     def stack(self):
-        import fteproxy
         import fteproxy.relay
-        import fteproxy.stream
         from fteproxy.tests.test_relay import EchoServer
 
         echo = EchoServer()
@@ -455,27 +462,14 @@ class TestLibraryEndToEnd:
 
     def test_forward_transfer(self, stack):
         payload = random_bytes(64 * 1024)
-        sock = socket.create_connection(stack['forward'].address, timeout=30)
-        sock.settimeout(30)
-        try:
-            sock.sendall(payload)
-            received = b''
-            while len(received) < len(payload):
-                chunk = sock.recv(65536)
-                if not chunk:
-                    break
-                received += chunk
-        finally:
-            sock.close()
-        assert received == payload
+        assert transfer(stack['forward'].address, payload) == payload
 
     def test_socks_transfer(self, stack):
-        from fteproxy.tests.test_relay import socks_connect
-        import fteproxy.stream
+        from fteproxy.tests.test_relay import socks_connect as connect
 
         payload = random_bytes(64 * 1024)
-        sock, status = socks_connect(stack['socks'].address[1], BIND_IP,
-                                     stack['echo'].port)
+        sock, status = connect(stack['socks'].address[1], BIND_IP,
+                               stack['echo'].port)
         try:
             assert status == fteproxy.stream.SUCCEEDED
             sock.sendall(payload)
@@ -490,10 +484,9 @@ class TestLibraryEndToEnd:
         assert received == payload
 
     def test_socks_refuses_a_destination_outside_the_rules(self, stack):
-        from fteproxy.tests.test_relay import socks_connect
-        import fteproxy.stream
+        from fteproxy.tests.test_relay import socks_connect as connect
 
-        sock, status = socks_connect(stack['socks'].address[1], BIND_IP,
-                                     stack['echo'].port + 1)
+        sock, status = connect(stack['socks'].address[1], BIND_IP,
+                               stack['echo'].port + 1)
         sock.close()
         assert status == fteproxy.stream.NOT_ALLOWED


### PR DESCRIPTION
Implements section 5 / PR4 of docs/plan-0.4.md. The plan's section 1
transcript now works verbatim:

    $ fteproxy server
    listening on [::]:8080
    key: ~/.local/state/fteproxy/server.key
    clients connect with:
      fteproxy client fte://…@<server-ip>:8080
    (also written to ~/.local/state/fteproxy/connection.txt)

    $ fteproxy client
    checking 127.0.0.1:8080 ... ok (protocol 1, manual-http, hybrid)
    SOCKS5 on 127.0.0.1:1080

    $ curl --socks5-hostname 127.0.0.1:1080 http://…/

fteproxy/config.py (new)
- ConnectionString.parse/.format round-trip fte://<server-id>@host:port with
  the format, mode and defs hints; unknown query parameters are ignored so a
  later version can add one. __str__ and __repr__ are redacted, and no parse
  error ever quotes the string: an unparseable one is still a secret.
- The state directory (--state-dir, FTEPROXY_STATE_DIR, $XDG_STATE_HOME, then
  ~/.local/state/fteproxy) at mode 0700, tightened if it was looser, with
  server.key and connection.txt at 0600 and a warning on a key another user
  can read.
- The HOST:PORT, -D and -L spec parsers, with IPv6 in brackets.

fteproxy/cli.py
- server, client, keygen and formats subcommands as in 1.1. -q and -v set the
  log level; command output (a connection string, the format table) goes to
  stdout so it can be piped, and everything else to stderr.
- The client resolves its URI from the argument, then FTEPROXY_URI, then
  connection.txt, and a flag beats the URI's hints, which beat the defaults.
- The startup check (D5) opens one short session before binding anything, so a
  wrong connection string fails in a round trip with a reason instead of as a
  timeout on first use; --no-check skips it.
- Every pre-0.4 flag is recognised only to print one line pointing at the
  README's upgrade section and exit 2. No aliases: the destination is chosen
  on the client now, so a silent alias would run a different topology.
- --listen with no host binds :: dual-stack, falling back to 0.0.0.0 where the
  OS will not allow that.
- PID files and --stop are gone; the process runs in the foreground and exits
  on SIGINT or SIGTERM.

fteproxy/conf.py
- Everything describing one run is gone from the global dictionary:
  runtime.mode, runtime.client/server/proxy.*, the shared key and its public
  default (D2), the two language keys, and the PID directory. What is left is
  what a library user might tune -- buffers, timeouts, the definitions release
  -- plus the client's default format and mode.

benchmark.py and PERFORMANCE.md move to the new command line: the server gets
a throwaway state directory and an --allow rule for the destination, and the
client runs one -L forward with the connection string the server wrote,
rewritten to point at the shaper when there is one. --upstream-format and
--record-layer-mode become --format and --mode.

Deviations from the plan, and why
- The plan gives ConnectionString a .format() method and a format hint. The
  hint is exposed as .format_name so the method keeps the plan's name.
- A connection string still carrying the <server-ip> placeholder is pointed at
  127.0.0.1 when the client reads it out of connection.txt. The plan asks for
  `fteproxy server` then `fteproxy client` with no arguments to work on one
  host, and a placeholder is the only thing a server that was never told its
  own address can write.
- The server's connection string and the format table go to stdout while
  progress goes to stderr. The plan says logs go to stderr and does not say
  where command output goes; splitting them is what makes `fteproxy keygen`
  and `fteproxy formats` usable in a pipe.
- MANIFEST.in now ships fteproxy/tests/vectors/*.json, which the .py-only
  recursive-include was dropping from the sdist.

Tests: test_cli.py rewritten (112 cases: URI round trips including IPv6 and
hints, the spec parsers, state-directory and file permissions, the URI
resolution order and the placeholder, every removed flag, keygen, formats, the
startup check, bind and format failures, log redaction); test_system.py
rewritten around the new command line (the transcript, a restart keeping the
same identity, SOCKS and -L transfers, allow rules, format mode, a non-default
format, FTEPROXY_URI, and the exit statuses). 485 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
