### PR TITLE
PR5: docs and examples, fail-closed decoder, rename to 1.0.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,13 @@
 # Packaging metadata lives in pyproject.toml. This file only exists because
-# setuptools has no pyproject.toml equivalent for sdist contents, and the one
-# thing the sdist needs beyond the defaults is the test suite: it is excluded
-# from the wheel (see [tool.setuptools.packages.find]) but downstream packagers
-# building from the sdist still want it. Everything else -- LICENSE, README.md,
-# PYPI_README.md, pyproject.toml, the package sources and fteproxy/defs/*.json
-# via [tool.setuptools.package-data] -- setuptools includes on its own.
+# setuptools has no pyproject.toml equivalent for sdist contents, and what the
+# sdist needs beyond the defaults is the test suite (and its vectors) plus the
+# design docs. Everything else -- LICENSE, README.md, PYPI_README.md,
+# pyproject.toml, the package sources and fteproxy/defs/*.json via
+# [tool.setuptools.package-data] -- setuptools includes on its own.
 recursive-include fteproxy/tests *.py
 # The handshake test vectors: the sdist should carry what proves the wire
 # format, not just the code that reads it.
 recursive-include fteproxy/tests/vectors *.json
+# The design docs (plans, release notes, format-authoring) are not package data,
+# so setuptools will not include them on its own.
+include docs/*.md

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -2,7 +2,7 @@
 
 Companion to [`benchmark.py`](benchmark.py). The numbers below were produced by
 that script on loopback (Apple M3 Pro, macOS, Python 3.14.7) on 2026-09-02 for
-**fteproxy 0.4.0 with `fte` 0.4.0** (the tree of the 0.4 release stack), with
+**fteproxy 1.0.0 with `fte` 0.4.0** (the tree of the 1.0 release stack), with
 **fteproxy 0.3.1 + `fte` 0.3.0** measured the same day on the same machine for
 comparison, and a **plain-TCP relay of identical two-hop topology** so the cost
 of Format-Transforming Encryption is isolated from the network. Everything here

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -58,7 +58,7 @@ python3 benchmark.py --scenarios lan --sizes 64K 1M --mode format
 | 8 MB upload (one direction) | – | 1069–1275 Mbit/s | **4412 Mbit/s** | – |
 
 Ranges are run-to-run spread across two runs; the 64 KB transfer window
-includes connection setup and negotiation, so it is the noisiest row (the
+includes connection setup and the handshake, so it is the noisiest row (the
 plain-TCP 64 KB figure varied 3x between runs). On the shaped links
 (broadband 25 Mbit and slower) fteproxy matches plain TCP within measurement
 noise, as it did on 0.3; those rows are omitted.
@@ -110,19 +110,34 @@ app → [client relay] ──FTE──→ [server relay] → dest
 
 1. **Hybrid record layer with an OpenSSL AE body** (the redesign): per-record cost
    0.9 → 0.17 ms; bulk 75 → 650–950 MB/s in the record layer.
-2. **Cipher cache** (`_make_cipher` is memoized on pattern, length and key): setup
-   8–12 ms → ~1 ms, and the negotiation scan on a failed connection 6 ms → free.
+2. **Cipher cache**: the expensive half of a libfte cipher is the DFA, and
+   `_regex_format` memoizes it on pattern and length, so setup went 8–12 ms →
+   ~1 ms and the server's first-record scan on a failed connection 6 ms → free.
+   The keyed `fte.FTE` on top is built per session (a couple of microseconds),
+   because since 0.4 every connection derives its own keys.
 3. **A pending header is decrypted once.** A 256 KiB record arrives in ~3 reads;
    the decoder used to re-rank and re-verify the same header on each partial
    delivery (two wasted header decrypts per record, more than the body itself).
    +30% on 8 MB echo.
-4. **A peer that closes before negotiating gets EOF** instead of being polled
+4. **A peer that closes before handshaking gets EOF** instead of being polled
    forever. On 0.4 without this, one dead connection (a port scan, a health
    check, an active probe) cost 64% of a core; five saturated it and pushed
    RTT p50 to 65 ms.
-5. Carried over from 0.3: `TCP_NODELAY` on both relay hops, O(n) buffer handling
-   in the record layer, the configured `--upstream-format` tried first in the
-   negotiation scan.
+5. **The handshake moved off the relay workers.** A per-connection setup thread
+   completes it, reads the client's OPEN and dials the destination before
+   either worker starts, so the accept loop no longer waits on a `connect()`
+   and the two workers never touch a half-built encoder. That was the
+   precondition for reworking the poll loop (lever #1 below).
+6. Carried over from 0.3: `TCP_NODELAY` on both relay hops, O(n) buffer handling
+   in the record layer, and trying the most-recently-matched format first in
+   the server's first-record scan.
+
+The handshake and the in-band destination add about 1.6 ms to connection
+setup, measured on one machine against the same build without them
+(0.7 -> 2.3 ms p50 on loopback): two X25519 key generations, four exchanges,
+and two extra round trips (the server hello, then OPEN/OPEN_RESULT). Bulk
+throughput is unchanged -- the record layer microbenchmark reads 673 MB/s at
+256 KiB and 973 MB/s at 1 MiB either way.
 
 ## Remaining levers, ranked by impact ÷ effort
 
@@ -130,10 +145,11 @@ app → [client relay] ──FTE──→ [server relay] → dest
    ripple, and the hang on link drop). The 0.3 caveat stands and was re-verified:
    simply deleting `time.sleep(throttle)` in `worker.run()` regresses the real
    subprocess deployment ~13x (a GIL-scheduling convoy between the two workers),
-   and a naive blocking-`recv` rework races the in-band negotiation between the
-   two workers. The loop must first make negotiation single-threaded (a
-   dedicated handshake phase, or one `selectors` loop per connection handling
-   both directions). Not a drive-by.
+   and on 0.3 a naive blocking-`recv` rework raced the in-band negotiation
+   between the two workers. 0.4 removes that second obstacle — the handshake
+   now finishes on a setup thread before either worker starts — so what is
+   left is the GIL convoy, and the shape to try is one `selectors` loop per
+   connection handling both directions. Still not a drive-by.
 2. **Carry small messages inline in the sealed header** (medium effort). A message
    of ≤ ~140 bytes fits in the header's capacity, so it could travel as one
    256-byte covertext instead of header + 92-byte body: 5.4x → 4.0x expansion
@@ -156,9 +172,9 @@ connection wedges past the observation window. The nominal 30 s
 `runtime.fteproxy.relay.socket_timeout` cannot rescue it because the poll loop
 never issues a blocking `recv` that lasts long enough. Lever #1 above is the fix.
 
-What is new in 0.4 is that the *other* stuck state, a connection closed before
-negotiation, is fixed: the server logs `peer closed before negotiation completed`
-and releases both workers.
+What is new in 0.4 is that the *other* stuck states are fixed: a connection
+closed before the handshake, and one that opens and then falls silent, both
+release their worker — the first at EOF, the second at the handshake deadline.
 
 ---
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -13,9 +13,9 @@
 pip install fteproxy
 ```
 
-> **0.4 is not wire-compatible with 0.3.x, and its command line has changed.**
+> **1.0 is not wire-compatible with 0.3.x, and its command line has changed.**
 > Every old flag now prints a pointer and exits 2; see
-> [Upgrading to 0.4.0](https://github.com/kpdyer/fteproxy#upgrading-to-040).
+> [Upgrading to 1.0.0](https://github.com/kpdyer/fteproxy#upgrading-to-100).
 
 ## Quick Start
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -13,31 +13,54 @@
 pip install fteproxy
 ```
 
-> **0.4 is not wire-compatible with 0.3.x.** Upgrade both endpoints together,
-> and give both the same `--key`/`--key-file` (the built-in default key is
-> public) and the same `--record-layer-mode`.
+> **0.4 is not wire-compatible with 0.3.x, and its command line has changed.**
+> Every old flag now prints a pointer and exits 2; see
+> [Upgrading to 0.4.0](https://github.com/kpdyer/fteproxy#upgrading-to-040).
 
 ## Quick Start
 
 ### Server
 
-```bash
-python3 -m fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
+Once per host. The first start generates the server's keypair and prints the
+connection string clients need:
+
+```console
+$ fteproxy server --advertise your.host:8080
+listening on [::]:8080
+key: ~/.local/state/fteproxy/server.key (created)
+clients connect with:
+  fteproxy client fte://Qm3s…ZzE@your.host:8080?defs=20260110
 ```
 
 ### Client
 
-```bash
-python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+```console
+$ fteproxy client fte://Qm3s…ZzE@your.host:8080
+checking your.host:8080 ... ok (protocol 1, manual-http, hybrid)
+SOCKS5 on 127.0.0.1:1080
+
+$ curl --socks5-hostname 127.0.0.1:1080 https://example.com/
 ```
+
+`-L 2222:127.0.0.1:22` gives an ssh-style port forward instead of SOCKS5.
 
 ## How It Works
 
 ```
-[Application] <-> [fteproxy client] <--FTE encoded--> [fteproxy server] <-> [Destination]
+[Application] <-SOCKS5 or -L-> [fteproxy client] <--FTE encoded--> [fteproxy server] -> [Destination]
 ```
 
-fteproxy encodes traffic to match user-specified regular expressions, making it appear as allowed traffic (e.g., HTTP) to network filters. By default each record starts with a covertext in the chosen format and carries the rest as raw authenticated ciphertext (`--record-layer-mode hybrid`); `--record-layer-mode format` puts every byte in the format at much lower throughput.
+fteproxy encodes traffic to match user-specified regular expressions, making it
+appear as allowed traffic (for example HTTP) to network filters. The client
+picks the format and the framing mode and puts both in the handshake, so
+nothing has to be configured to match: `--mode hybrid` (the default) formats a
+header per record and carries the body as raw authenticated ciphertext, and
+`--mode format` puts every byte in the format at much lower throughput.
+
+The destination travels in band, so one server serves SOCKS5 clients and port
+forwards alike, and `--allow` decides which destinations it will dial. The
+server authenticates itself with an X25519 keypair; clients hold only the
+public half, in the connection string.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Its job is to relay datastreams, such as web browsing traffic, by encoding the s
 
 fteproxy is powered by Format-Transforming Encryption [1] and was presented at CCS 2013.
 
-> **fteproxy 0.4 is not wire-compatible with 0.3.x, and its command line has
+> **fteproxy 1.0 is not wire-compatible with 0.3.x, and its command line has
 > changed.** Upgrade both endpoints together and see
-> [Upgrading to 0.4.0](#upgrading-to-040).
+> [Upgrading to 1.0.0](#upgrading-to-100).
 
 [1] [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf), Kevin P. Dyer, Scott E. Coull, Thomas Ristenpart and Thomas Shrimpton
 
@@ -91,7 +91,7 @@ first real connection:
 ```console
 $ fteproxy client fte://…@203.0.113.5:8080
 checking 203.0.113.5:8080 ... failed: no valid handshake reply within 5s
-  (wrong connection string, or the server is not running fteproxy 0.4)
+  (wrong connection string, or the server is not running fteproxy 1.0)
 $ echo $?
 1
 ```
@@ -109,7 +109,7 @@ fteproxy client
 ### A port forward instead of SOCKS
 
 `-L` takes ssh's spelling, and is how you reproduce the fixed-destination
-topology fteproxy had before 0.4:
+topology fteproxy had before 1.0:
 
 ```bash
 fteproxy client fte://…@203.0.113.5:8080 -L 2222:127.0.0.1:22
@@ -239,12 +239,12 @@ sock.open(("example.com", 443))     # raises fteproxy.OpenRefused(status)
 [`examples/`](examples/README.md) directory has programmatic, chat,
 file-transfer and integration examples.
 
-## Upgrading to 0.4.0
+## Upgrading to 1.0.0
 
-0.4.0 changes the wire format, the command line and the topology. There is no
-compatibility mode: a 0.3.x peer, or a peer running an earlier 0.4 development
+1.0.0 changes the wire format, the command line and the topology. There is no
+compatibility mode: a 0.3.x peer, or a peer running an earlier development
 build, gets no reply at all. The full notes are in
-[docs/release-notes-0.4.0.md](docs/release-notes-0.4.0.md).
+[docs/release-notes-1.0.0.md](docs/release-notes-1.0.0.md).
 
 - **The command line is new.** Every old flag (`--mode`, `--server_ip`,
   `--client_port`, `--proxy_ip`, `--proxy_port`, `--key`, `--key-file`,
@@ -265,7 +265,7 @@ build, gets no reply at all. The full notes are in
   becomes
 
   ```bash
-  # 0.4
+  # 1.0
   fteproxy server --listen :8080 --allow 127.0.0.1:22
   fteproxy client fte://…@S:8080 -L 8079:127.0.0.1:22
   ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Its job is to relay datastreams, such as web browsing traffic, by encoding the s
 
 fteproxy is powered by Format-Transforming Encryption [1] and was presented at CCS 2013.
 
-> **fteproxy 0.4 is not wire-compatible with 0.3.x.** Upgrade both endpoints
-> together, give both the same key, and see [Upgrading to 0.4.0](#upgrading-to-040).
+> **fteproxy 0.4 is not wire-compatible with 0.3.x, and its command line has
+> changed.** Upgrade both endpoints together and see
+> [Upgrading to 0.4.0](#upgrading-to-040).
 
 [1] [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf), Kevin P. Dyer, Scott E. Coull, Thomas Ristenpart and Thomas Shrimpton
 
@@ -50,128 +51,251 @@ declared in `pyproject.toml` -- there is no `requirements.txt`.
 
 ## Usage
 
-### Architecture
+### Start the server
 
-fteproxy operates as a client-server proxy:
+Once per host. The first start generates the server's keypair and prints the
+connection string clients need:
 
+```console
+$ fteproxy server
+listening on [::]:8080
+key: ~/.local/state/fteproxy/server.key (created)
+allowing: every destination except the loopback and link-local addresses of this host
+clients connect with:
+  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260110
+(also written to ~/.local/state/fteproxy/connection.txt)
 ```
-[Application] <-> [fteproxy client] <--FTE encoded--> [fteproxy server] <-> [Destination]
+
+Substitute the address your clients will dial for `<server-ip>`, or pass
+`--advertise your.host:8080` and the string comes out ready to hand over.
+
+### Start the client
+
+On the client machine, with the string the server printed:
+
+```console
+$ fteproxy client fte://Qm3s…ZzE@203.0.113.5:8080
+checking 203.0.113.5:8080 ... ok (protocol 1, manual-http, hybrid)
+SOCKS5 on 127.0.0.1:1080
+
+$ curl --socks5-hostname 127.0.0.1:1080 https://example.com/
 ```
 
-### Start the Server
+The client resolves nothing itself: names go through the tunnel and the server
+resolves them, so your DNS does not leak around the proxy.
 
-On the server machine:
+The client checks the server before it binds anything, so a wrong connection
+string fails in a round trip with a reason rather than as a timeout on the
+first real connection:
+
+```console
+$ fteproxy client fte://…@203.0.113.5:8080
+checking 203.0.113.5:8080 ... failed: no valid handshake reply within 5s
+  (wrong connection string, or the server is not running fteproxy 0.4)
+$ echo $?
+1
+```
+
+Pass `--no-check` to skip it.
+
+On one host you can leave the argument out entirely — the client reads
+`connection.txt` from the state directory:
 
 ```bash
-python3 -m fteproxy --mode server --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
+fteproxy server &
+fteproxy client
 ```
 
-This listens for FTE-encoded connections on port 8080 and forwards decoded traffic to 127.0.0.1:8081.
+### A port forward instead of SOCKS
 
-### Start the Client
-
-On the client machine:
+`-L` takes ssh's spelling, and is how you reproduce the fixed-destination
+topology fteproxy had before 0.4:
 
 ```bash
-python3 -m fteproxy --mode client --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+fteproxy client fte://…@203.0.113.5:8080 -L 2222:127.0.0.1:22
+ssh -p 2222 user@localhost
 ```
 
-This listens for plaintext connections on port 8079 and forwards FTE-encoded traffic to the server.
+`-L` and `-D` are repeatable and can be mixed; without either, the client
+opens SOCKS5 on `127.0.0.1:1080`.
 
-Both sides must use the same key (`--key` or `--key-file`; the built-in default
-is public and fteproxy warns when it is in use) and the same
-`--record-layer-mode`.
+### What the server will dial
 
-### Record-layer modes
+By default a server will reach any destination *except* its own loopback and
+link-local addresses, checked both on what the client asked for and on what
+the name resolved to. That keeps a connection string from being a route into
+the server's own admin interfaces.
 
-Every record on the wire starts with a covertext in the chosen format. What
-follows depends on `--record-layer-mode`, which must match on both endpoints:
+`--allow` replaces that policy with a list:
 
-- `hybrid` (default): the covertext is a fixed-length header and the rest of
-  the record is raw authenticated ciphertext. Fast (hundreds of MB/s), but only
+```bash
+fteproxy server --allow 127.0.0.1:8081          # only this local service
+fteproxy server --allow '*.example.com:443'     # only this domain, only TLS
+fteproxy server --allow 10.0.0.0/8              # only this network
+fteproxy server --allow any                     # everything, loopback included
+```
+
+Rules are repeatable. A rule naming an address is matched against addresses
+and CIDRs; a rule naming a name is matched against names. IPv6 literals go in
+brackets when a port follows.
+
+### Formats and record-layer modes
+
+A *format* is a base name from the definitions file, such as `manual-http`;
+the request and response covertexts are derived from it. `fteproxy formats`
+lists them with the capacity of one covertext:
+
+```console
+$ fteproxy formats
+name          req len  req cap  resp len  resp cap
+...
+manual-http       256      150       256       192  (default)
+words             280      138       280       138
+```
+
+The client picks the format and the record-layer mode and puts both in the
+handshake; the server follows. Nothing has to be configured to match.
+
+- `--mode hybrid` (default): each record is a fixed-length covertext header
+  followed by raw authenticated ciphertext. Fast — hundreds of MB/s — but only
   the header blends in with the target protocol.
-- `format`: every byte is transformed into the format, so the whole stream is
-  indistinguishable from the protocol. Much slower (well under 1 MB/s), for
-  deployments facing entropy or statistical detectors.
+- `--mode format`: every byte on the wire is in the format, so the whole
+  stream is indistinguishable from the protocol. Much slower (well under
+  1 MB/s), for deployments facing entropy or statistical detectors.
 
-### Command Line Options
+### Command line
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--mode` | Relay mode: client or server | client |
-| `--upstream-format` | Client-to-server format name (see `fteproxy/defs/20260110.json`) | manual-http-request |
-| `--downstream-format` | Server-to-client format name | manual-http-response |
-| `--record-layer-mode` | `hybrid` or `format` (see [Record-layer modes](#record-layer-modes)); must match on both endpoints | hybrid |
-| `--release` | Definitions file to use, as YYYYMMDD | 20260110 |
-| `--client_ip` | Client-side listening IP | 127.0.0.1 |
-| `--client_port` | Client-side listening port | 8079 |
-| `--server_ip` | Server-side listening IP | 127.0.0.1 |
-| `--server_port` | Server-side listening port | 8080 |
-| `--proxy_ip` | Forwarding-proxy listening IP | 127.0.0.1 |
-| `--proxy_port` | Forwarding-proxy listening port | 8081 |
-| `--key` | Shared secret (64 hex characters); must match on both endpoints. The built-in default is public and gives no protection. | (public default; warns) |
-| `--key-file` | Path to a file containing the key (64 hex characters). Mutually exclusive with `--key`. | |
-| `--quiet` | Suppress output | false |
-| `--stop` | Shut down the running daemon for `--mode` | |
-| `--version` | Show version and exit | |
-
-### Supplying the Key from a File
-
-Passing the key with `--key` places it in your shell history and exposes it in
-process listings (e.g. `ps aux`). To avoid this, write the key to a file and
-point fteproxy at it with `--key-file`:
-
-```bash
-# Generate a random 64-hex-character (32-byte) key
-python3 -c "import secrets; print(secrets.token_hex(32))" > fteproxy.key
-chmod 600 fteproxy.key
+```
+fteproxy server  [--listen [HOST]:PORT] [--allow RULE]... [--advertise HOST[:PORT]]
+                 [--state-dir DIR] [--defs RELEASE] [-q | -v]
+fteproxy client  [URI] [-D [BIND:]PORT] [-L [BIND:]PORT:HOST:PORT]...
+                 [--format NAME] [--mode hybrid|format] [--no-check]
+                 [--state-dir DIR] [-q | -v]
+fteproxy keygen  [--state-dir DIR] [--advertise HOST[:PORT]]
+fteproxy formats [--defs RELEASE]
+fteproxy --version
 ```
 
-Then start each side with `--key-file` (the client and server must use the same
-key):
+| Option | Command | Description | Default |
+|--------|---------|-------------|---------|
+| `--listen` | server | Address to listen on; `:PORT` means every interface, IPv6 in brackets | `:8080` |
+| `--allow` | server | A destination clients may reach; repeatable | loopback and link-local blocked, everything else allowed |
+| `--advertise` | server, keygen | The address to put in the connection string | a `<server-ip>` placeholder |
+| `--defs` | server, formats | Definitions release, as YYYYMMDD | 20260110 |
+| `URI` | client | `fte://SERVER-ID@HOST:PORT`; falls back to `$FTEPROXY_URI`, then `connection.txt` | |
+| `-D` | client | SOCKS5 listener, `[BIND:]PORT` | `127.0.0.1:1080` when no `-D`/`-L` |
+| `-L` | client | Forward `[BIND:]PORT` to one `HOST:PORT` through the tunnel; repeatable | |
+| `--format` | client | Base format name (see `fteproxy formats`) | the URI's hint, else `manual-http` |
+| `--mode` | client | `hybrid` or `format` | the URI's hint, else `hybrid` |
+| `--no-check` | client | Skip the startup check | check runs |
+| `--state-dir` | all | Where `server.key` and `connection.txt` live | `$FTEPROXY_STATE_DIR`, `$XDG_STATE_HOME/fteproxy`, `~/.local/state/fteproxy` |
+| `-q` / `-v` | all | Errors only / per-connection detail | INFO |
+| `--version` | | Version and licence, then quit | |
+
+Exit status is 0 on a clean shutdown, 1 on a runtime failure, 2 on a usage
+error. The process runs in the foreground and stops on SIGINT or SIGTERM;
+there is no daemon mode and no PID file.
+
+### Keys and the connection string
+
+The server holds an X25519 private key in `server.key` (mode 0600, in a
+directory with mode 0700). The connection string carries only its public half,
+so a client never holds anything that would let it impersonate the server.
+
+`fteproxy keygen` does what the first `fteproxy server` start does, without
+starting anything — for provisioning a container or a configuration-management
+run:
 
 ```bash
-python3 -m fteproxy --mode server --key-file fteproxy.key --server_ip 0.0.0.0 --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 8081
-python3 -m fteproxy --mode client --key-file fteproxy.key --client_ip 127.0.0.1 --client_port 8079 --server_ip <server-ip> --server_port 8080
+fteproxy keygen --advertise vpn.example.com:8080
 ```
 
-The file must contain exactly 64 hexadecimal characters (a trailing newline is
-ignored). `--key` and `--key-file` cannot be used together.
+Treat the connection string like a Tor bridge line: whoever holds it can
+connect, and its secrecy is what stops an active prober from confirming that
+your server is running fteproxy. A prober without it gets no reply at all. It
+does not let its holder impersonate the server or read another client's
+traffic. See [SECURITY.md](SECURITY.md).
 
 ### Python API
 
-`fteproxy.wrap_socket(sock, outgoing_regex=..., outgoing_length=..., incoming_regex=..., incoming_length=...)`
-turns any TCP socket into an FTE socket. The [`examples/`](examples/README.md)
-directory has programmatic, chat, file-transfer and integration examples.
+```python
+import fteproxy
+
+private, public = fteproxy.generate_server_key()
+
+# server side
+sock = fteproxy.wrap_socket(conn, server_key=private)
+destination = sock.wait_open()      # (host, port), or None if the peer sent data
+sock.open_result(0x00)
+
+# client side
+sock = fteproxy.wrap_socket(raw, server_id=public,
+                            format="manual-http", mode="hybrid")
+sock.connect(("203.0.113.5", 8080))
+sock.open(("example.com", 443))     # raises fteproxy.OpenRefused(status)
+```
+
+`fteproxy.ConnectionString.parse(text)` and `.format()` round-trip the URI. The
+[`examples/`](examples/README.md) directory has programmatic, chat,
+file-transfer and integration examples.
 
 ## Upgrading to 0.4.0
 
-fteproxy 0.4.0 moves to libfte 0.4 (`fte.FTE`) and its wire format is **not
-compatible with 0.3.x**. A 0.3 client and a 0.4 server (or the reverse) fail at
-negotiation (the server logs a warning, the client times out), so upgrade both
-endpoints together.
+0.4.0 changes the wire format, the command line and the topology. There is no
+compatibility mode: a 0.3.x peer, or a peer running an earlier 0.4 development
+build, gets no reply at all. The full notes are in
+[docs/release-notes-0.4.0.md](docs/release-notes-0.4.0.md).
 
-- **Key.** libfte 0.4 requires a 32-byte key. If you pass neither `--key` nor
-  `--key-file`, fteproxy uses a built-in default key that is public and warns at
-  startup. Generate one (`python3 -c "import secrets; print(secrets.token_hex(32))"`)
-  and use the same key on both sides.
-- **Record-layer mode.** New `--record-layer-mode` (`hybrid`, the default, or
-  `format`). Both endpoints must use the same mode.
-- **API renames.** `wrap_socket(outgoing_fixed_slice=, incoming_fixed_slice=)`
-  are now `outgoing_length=` / `incoming_length=`; `fteproxy.defs.getFixedSlice`
-  is `getLength`; the definitions JSON key `"fixed_slice"` is `"length"`. Code
-  that used `fte.Encoder` directly must move to `fte.FTE` (see
-  [libfte's README](https://github.com/kpdyer/libfte#readme)).
-- **Formats.** Twenty low-capacity formats got longer covertexts (`binary`
-  256 to 1032, `ip-address` and `timestamp` 64 to 312, and so on; see
-  `fteproxy/defs/20260110.json`). Four patterns were rewritten for libfte
-  0.4's stricter regex dialect (`\C` is now `.`; `manual-http-request` paths
-  no longer admit a backslash). The default `manual-http-*` formats still use
-  length 256 and carry 150 (request) and 192 (response) bytes per covertext.
+- **The command line is new.** Every old flag (`--mode`, `--server_ip`,
+  `--client_port`, `--proxy_ip`, `--proxy_port`, `--key`, `--key-file`,
+  `--upstream-format`, `--downstream-format`, `--record-layer-mode`,
+  `--release`, `--stop`, `--quiet`) is recognised only to print a pointer here
+  and exit 2. None of them is aliased, because the meaning changed rather than
+  the spelling.
+- **The topology changed: the destination is chosen on the client.** The
+  server no longer has a forward address, so `--proxy_ip`/`--proxy_port` have
+  no equivalent on the server. The old setup
+
+  ```bash
+  # 0.3
+  fteproxy --mode server --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 22
+  fteproxy --mode client --client_port 8079 --server_ip S --server_port 8080
+  ```
+
+  becomes
+
+  ```bash
+  # 0.4
+  fteproxy server --listen :8080 --allow 127.0.0.1:22
+  fteproxy client fte://…@S:8080 -L 8079:127.0.0.1:22
+  ```
+
+  and the same server now also serves `-D` SOCKS5 clients, without being
+  reconfigured.
+- **The shared key is gone.** So are `--key` and `--key-file`. The server has a
+  keypair instead, generated on first start; hand clients the connection string
+  it prints. Nothing needs a pre-shared secret, and there is no public default
+  key to forget to replace.
+- **Formats and modes are negotiated, not configured.** One `--format` base
+  name on the client replaces `--upstream-format`/`--downstream-format`, and
+  `--mode` replaces `--record-layer-mode` on one side only. A mismatch is no
+  longer possible.
+- **Failures are visible.** The client checks the server at startup and prints
+  a reason; a wrong connection string fails in a round trip instead of hanging.
+  Exit statuses are meaningful (0/1/2), and a no-argument run prints usage
+  instead of crashing.
+- **Definitions.** Thirty-two entries in `20260110.json` have longer
+  covertexts, so that every shipped format can carry a handshake; the loader
+  now refuses a release with a format that cannot. The default `manual-http-*`
+  formats are unchanged at length 256, carrying 150 (request) and 192
+  (response) bytes.
+- **API.** `wrap_socket`'s `outgoing_regex`/`incoming_regex`/`K1`/`K2`/
+  `negotiate` parameters are replaced by `server_key=` or `server_id=` plus
+  `format=`/`mode=`. See [Python API](#python-api).
 - **Requires** `fte>=0.4.0,<0.5.0` and `cryptography>=42.0`.
 
 See [SECURITY.md](SECURITY.md) for the security model, including what the
-record layer does and does not authenticate.
+handshake and the record layer do and do not authenticate.
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,63 +18,120 @@ first. This section covers what fteproxy adds on top of it.
 
 - **Threat model.** Format-Transforming Encryption is designed to get past an
   on-path observer that classifies traffic with protocol signatures (regular
-  expressions, DPI rules). The shared key protects the confidentiality and
-  integrity of the tunnelled bytes against that observer. fteproxy is not a
-  general-purpose VPN: it does not hide traffic volume or timing, and the
-  limitations below apply.
+  expressions, DPI rules), and against an active prober that opens connections
+  to a suspected server to see what answers. fteproxy is not a general-purpose
+  VPN: it does not hide traffic volume or timing, and the limitations below
+  apply.
 
-- **The key.** One 32-byte key, shared by both endpoints, every connection, and
-  both directions (`--key` or `--key-file`). Without one, fteproxy uses the
-  public constant in `fteproxy/conf.py` and prints a warning at startup; that
-  configuration gives no confidentiality or integrity against anyone who has
-  read the source. Rotate the key before the number of records sent under it
-  approaches 2^32 (every covertext and every hybrid body carries a fresh random
-  12-byte nonce; at 2^32 records the chance of a repeat is about 2^-33, and a
-  repeat exposes only the two colliding records' contents, never integrity).
+- **The server keypair.** A server holds a long-term X25519 keypair in
+  `server.key` (mode 0600, in a state directory with mode 0700), generated on
+  first start. The public half is the *server-id* in the connection string.
+  There is no shared secret and no default key: a client holds nothing that
+  would let it impersonate the server, and there is no public constant to
+  forget to replace.
 
-- **Authentication and ordering.** Every formatted covertext is a libfte frame:
-  AES-128-CTR then HMAC-SHA256 (Encrypt-then-MAC, 128-bit tag). In `hybrid`
-  mode the raw record body uses the same construction under subkeys derived
-  from the shared key. Every record carries its position in its stream (sealed
-  inside the covertext and, in `hybrid` mode, bound into the body tag), so a
-  record that is reordered, replayed, or dropped within a connection fails
-  authentication and the stream stops.
+- **What the connection string authorises.** The connection string is
+  `fte://<server-id>@<host>:<port>`. Both handshake records are sealed under
+  `K_cover = HKDF-SHA256(S_pub, "fteproxy/v1/cover")`, which every holder of
+  the string can compute. That is the point: holding the string is what
+  authorises a connection attempt, and a prober that does not hold it gets no
+  reply at all. Treat it like a Tor bridge line — its secrecy is what stops an
+  active prober confirming the server. It does **not** let its holder
+  impersonate the server (the server hello's MAC needs the private key) nor
+  read another client's session (the session keys come from two ephemeral
+  keys), and a holder who is not on the path cannot learn another client's
+  traffic at all.
 
-- **Known limitation: cross-stream replay.** Because the key is static and shared
-  by all connections and both directions, a record captured from one stream is
-  still valid at the same position of another stream under the same key. An
-  active on-path attacker can replay a whole captured stream into a fresh
-  connection, or splice record *i* of stream A into stream B. Tunnelled
-  protocols with their own authentication (SSH, TLS) detect this themselves;
-  plaintext protocols do not. Closing this would need per-connection key
-  material in the negotiation (a protocol change); the shared key is a known
-  limitation of the 0.4 line, so tunnel protocols that authenticate themselves
-  where this matters.
+- **The handshake.** Protocol version 1 is the Noise `NK` message pattern
+  (`e, es` then `e, ee`), hand-assembled from `cryptography`'s X25519, HKDF and
+  HMAC rather than taken from a Noise library, because the maintained options
+  are thin and the pattern is thirty lines. It gives server authentication and
+  forward secrecy; it does not authenticate the client beyond possession of
+  the connection string, which is the property obfs4 has. Every handshake byte
+  is bound into `H = SHA-256("fteproxy/v1" || S_pub || client hello || s_pub)`,
+  which is both the key schedule's salt and the server's MAC input, so a
+  tampered hello produces different keys on the two ends rather than a session.
+  An all-zero X25519 shared secret is refused explicitly. The wire format and
+  the key schedule are pinned by test vectors in
+  `fteproxy/tests/vectors/handshake_v1.json`, generated once from fixed seeds;
+  `fteproxy/tests/test_handshake.py` checks them and tampers with every field
+  of both records, one at a time.
+
+- **Per-connection, per-direction keys.** The handshake derives five keys:
+  `K_auth_s` and a header key and a body key for each direction. No two
+  connections and no two directions share a record key, which closes the
+  cross-stream replay limitation the shared-key line documented, and gives
+  forward secrecy: compromising `server.key` later does not decrypt a recorded
+  session. Rotate a connection's keys by opening a new connection; the old
+  advice to rotate a shared key before 2^32 records no longer applies, since a
+  key covers one direction of one connection.
+
+- **Authentication and ordering.** Every formatted covertext is a libfte
+  frame: AES-128-CTR then HMAC-SHA256 (Encrypt-then-MAC, 128-bit tag). In
+  `hybrid` mode the raw record body uses the same construction under subkeys
+  derived from that direction's body key. Every record carries its position in
+  its stream (sealed inside the covertext and, in `hybrid` mode, bound into the
+  body tag), so a record that is reordered, replayed, or dropped within a
+  connection fails authentication and the stream stops. Every record also
+  carries a type byte; a type this version does not define closes the
+  connection rather than being guessed at.
+
+- **Replay window and filter.** A client hello carries an *epoch*: hours since
+  the Unix epoch, accepted within plus or minus one hour. The server remembers
+  the client ephemeral public key of every hello it accepted inside that
+  window, bucketed by epoch, and refuses a repeat. So a recorded hello can only
+  be replayed inside a two-hour window, and inside it the filter refuses it.
+  The filter is in memory only and bounded; past its cap the oldest hour is
+  forgotten, which re-opens replay only for hellos already at the edge of the
+  window. The check runs last, so a hello refused for any other reason cannot
+  be used to fill the filter and lock out a real client.
+
+- **Behaviour on a failed handshake.** Every rejection is answered
+  identically: no reply, read and discard for a random 1 to 5 seconds, then
+  close, and one line in the DEBUG log. Unknown version, a reserved flag bit,
+  the wrong definitions release, an unknown format, a stale epoch, a replayed
+  hello and a hello sealed under someone else's key are indistinguishable from
+  each other and from a service with nothing to say. This is obfs4's behaviour
+  and is what stops an active prober learning anything from a bad guess.
+
+- **Which destinations a server will dial.** By default every destination
+  *except* the server host's own loopback and link-local addresses, checked
+  both on what the client asked for and on every address the name resolved to,
+  so `localhost` or a rebinding name does not walk around it. `--allow`
+  replaces that with a list: only what the rules name is reachable, and
+  `--allow any` restores everything including loopback. Without this a
+  connection string would be a route into every service bound to the server's
+  own loopback.
 
 - **What an observer sees.** In `hybrid` mode (the default) only the first
   `length` bytes of each record are in the target format; the rest of the
   record is high-entropy ciphertext, and its length (the plaintext length plus
-  28 bytes) is visible. In `format` mode every byte on the wire is in the
+  29 bytes) is visible. In `format` mode every byte on the wire is in the
   target format. Sealed covertexts are always exactly `length` bytes and use
   the format's whole rank space, so a short message neither shortens the
-  covertext nor leaves a run of the format's lowest character.
+  covertext nor leaves a run of the format's lowest character. The two
+  handshake records are one request-format covertext and one response-format
+  covertext, the same shape as any other record.
 
-- **No protocol-version handshake.** The 0.4 wire format is not compatible with
-  0.3.x, and the record-layer mode must match on both endpoints. A mismatch is
-  a failed negotiation: the server logs a warning when the peer closes, and
-  the client sees a timeout. Nothing is sent in the clear in either case.
+- **Nothing secret is logged.** The package logger carries a redaction filter,
+  installed at import, that strips a connection string's server-id, a hex key
+  and a bare base64url public key out of any message before a handler sees it.
+  Command output — the connection string a server prints, the format table —
+  goes to stdout; logs go to stderr.
 
 - **Patterns and lengths are trusted input.** The server compiles only the
-  formats in its own definitions file; a client's negotiation cell can name one
-  of them but cannot supply a pattern. Never load a definitions file (`--release`)
-  from an untrusted source: as libfte documents, a hostile pattern can make DFA
+  formats in its own definitions file; a client's hello can name one of them
+  but cannot supply a pattern. Never load a definitions file (`--defs`) from an
+  untrusted source: as libfte documents, a hostile pattern can make DFA
   construction take exponential time and memory.
 
-- **Negotiation cost.** For every new connection the server tries to decrypt
-  the first bytes as each known request format until one succeeds (the
-  configured `--upstream-format` first). A failed attempt is rejected before
-  the tag check when the bytes are not in the format, as in libfte; a full scan
-  over the built-in formats costs a few milliseconds of CPU.
+- **First-record cost.** For every new connection the server tries to unseal
+  the first covertext as each known request format until one succeeds, most
+  recently matched first, so a server whose clients share a format pays one
+  attempt. A full scan over the built-in formats costs well under a
+  millisecond of CPU, and the attempt is bounded by a handshake deadline and a
+  64 KiB buffer cap, so a peer that connects and falls silent does not occupy a
+  worker.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,12 @@ supported version before reporting an issue.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.4.x   | :white_check_mark: |
-| < 0.4   | :x:                |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
 
 ## Security model
 
-fteproxy 0.4 is built on libfte 0.4; read
+fteproxy 1.0 is built on libfte 0.4; read
 [libfte's security model](https://github.com/kpdyer/libfte/blob/master/SECURITY.md)
 first. This section covers what fteproxy adds on top of it.
 

--- a/docs/plan-1.0.md
+++ b/docs/plan-1.0.md
@@ -1,7 +1,7 @@
-# fteproxy 0.4: one-argument client, no-argument server
+# fteproxy 1.0: one-argument client, no-argument server
 
-Status: proposal, 2026-09-02. Target release: 0.4.0, which has not been cut yet
-(master carries the 0.4.0 preparation; the latest published release is 0.3.2).
+Status: proposal, 2026-09-02. Target release: 1.0.0, which has not been cut yet
+(master carries the 1.0.0 preparation; the latest published release is 0.3.2).
 Wire format: not compatible with 0.3.x (see Decision D1). Nothing on master's
 current wire format has shipped, so there is nothing to preserve.
 
@@ -42,7 +42,7 @@ The plan therefore has three parts that only work together:
    wstunnel, hysteria, gost) does.
 3. A CLI with two subcommands and one connection string.
 
-Non-goals for 0.4.0: traffic shaping or padding policy, UDP, stream
+Non-goals for 1.0.0: traffic shaping or padding policy, UDP, stream
 multiplexing, an asyncio rewrite of the relay, a config file, decoy responses
 to failed probes. The record layer's framing, sealing and hybrid body carrier
 stay as they are apart from a one-byte record type.
@@ -79,7 +79,7 @@ Wrong connection string, old client, or the server is not fteproxy:
 ```
 $ fteproxy client fte://…
 checking 203.0.113.5:8080 … failed: no valid handshake reply within 5s
-  (wrong connection string, or the server is not running fteproxy 0.4)
+  (wrong connection string, or the server is not running fteproxy 1.0)
 exit status 1
 ```
 
@@ -369,7 +369,7 @@ stream messages and allow rules in `fteproxy/stream.py`; SOCKS5 in
 ## 4. Documentation and security model
 
 - `README.md`: rewrite Usage around the two commands and the connection
-  string; replace the options table; rewrite "Upgrading to 0.4.0" to cover the wire break from 0.3.x, the new
+  string; replace the options table; rewrite "Upgrading to 1.0.0" to cover the wire break from 0.3.x, the new
   command line, keys, the topology change, and `-L` for the old
   fixed-destination setup. `PYPI_README.md` mirrors the quick start.
 - `SECURITY.md`: replace "The key" with the keypair and connection-string
@@ -412,7 +412,7 @@ Acceptance: `python -m fteproxy` prints usage and exits 2;
 
 ### PR2 (L): handshake, session keys, record types
 
-Wire break from 0.3.x; the version stays 0.4.0 because 0.4.0 has not been
+Wire break from 0.3.x; the version stays 1.0.0 because 1.0.0 has not been
 cut. Library level only.
 
 - `fteproxy/handshake.py`: key generation, `K_cover`, hello encode/decode,
@@ -429,7 +429,7 @@ cut. Library level only.
 - Tests: vectors; tamper each field of each hello; replay within and outside
   the window; epoch skew; wrong `S_pub`; each record type; both modes;
   `benchmark.py` before/after for the per-session cipher construction cost
-  (target: connection setup within 1 ms of 0.4, bulk throughput unchanged).
+  (target: connection setup within 1 ms of master, bulk throughput unchanged).
 - Review gate: a security review of `handshake.py` and the key schedule by
   someone other than the author before merge, as was done for #229.
 
@@ -471,8 +471,8 @@ the server.
 
 ### PR5 (M): docs, examples, release
 
-- Section 4 in full. `__version__` stays `"0.4.0"`; PyPI metadata; the
-  `SECURITY.md` supported-versions table already lists 0.4.x.
+- Section 4 in full. `__version__` stays `"1.0.0"`; PyPI metadata; the
+  `SECURITY.md` supported-versions table already lists 1.0.x.
 - `examples/` scripts and Python files; `test_examples.py`.
 - Release notes: wire break, command-line change, topology change, key
   model, upgrade steps.

--- a/docs/release-notes-0.4.0.md
+++ b/docs/release-notes-0.4.0.md
@@ -1,0 +1,151 @@
+# fteproxy 0.4.0
+
+0.4.0 replaces the protocol, the command line and the topology together,
+because none of the three worked without the other two. The short version: a
+server needs no arguments, a client needs one, and there is no shared secret.
+
+```console
+$ fteproxy server
+listening on [::]:8080
+key: ~/.local/state/fteproxy/server.key (created)
+clients connect with:
+  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260110
+
+$ fteproxy client fte://Qm3s…ZzE@203.0.113.5:8080
+checking 203.0.113.5:8080 ... ok (protocol 1, manual-http, hybrid)
+SOCKS5 on 127.0.0.1:1080
+```
+
+## Breaking changes
+
+**The wire format changed and there is no compatibility mode.** A 0.3.x peer,
+or a peer running an earlier 0.4 development build, gets no reply at all —
+which is the same thing an active prober gets, deliberately. Upgrade both ends
+together.
+
+**The command line changed.** Every flag of the old one — `--mode`,
+`--server_ip`, `--server_port`, `--client_ip`, `--client_port`, `--proxy_ip`,
+`--proxy_port`, `--key`, `--key-file`, `--upstream-format`,
+`--downstream-format`, `--record-layer-mode`, `--release`, `--stop`,
+`--quiet` — is recognised only to print a pointer to the upgrade notes and
+exit 2. None of them is aliased: the meaning changed rather than the spelling,
+so a silent alias would run a different topology than the operator asked for.
+
+**The destination is chosen on the client.** The server has no forward
+address; the client sends the destination in band, so one server serves SOCKS5
+clients and port forwards at once and never needs reconfiguring for a new
+destination. `--proxy_ip`/`--proxy_port` have no server-side equivalent.
+
+**There is no shared key.** `--key` and `--key-file` are gone, and so is the
+public default key that used to stand in for them.
+
+**PID files and `--stop` are gone.** The process runs in the foreground and
+exits on SIGINT or SIGTERM.
+
+## What is new
+
+- **A server keypair and a connection string.** The server generates an
+  X25519 keypair on first start into `~/.local/state/fteproxy/server.key`
+  (mode 0600, in a directory with mode 0700) and prints
+  `fte://<server-id>@<host>:<port>`, also writing it to `connection.txt`
+  alongside. `--advertise` fills in the address; `fteproxy keygen` does the
+  same without starting a server, for provisioning. A client holds only the
+  public half.
+- **Protocol version 1: a real handshake.** The Noise `NK` pattern
+  (`e, es` then `e, ee`) over X25519, HKDF-SHA256 and HMAC-SHA256, giving
+  server authentication, forward secrecy, and a separate header key and body
+  key for each direction of each connection. That closes the cross-stream
+  replay limitation the shared-key line documented. Both handshake records are
+  ordinary covertexts, so the shape on the wire is unchanged.
+- **A failed handshake is answered with silence.** Wrong key, wrong format,
+  stale clock, replayed hello: all identical from outside — no reply, read and
+  discard for a random 1 to 5 seconds, then close. A replay filter keyed on the
+  client's ephemeral key covers the ±1 hour epoch window.
+- **SOCKS5 and ssh-style forwards.** `-D [BIND:]PORT` is a SOCKS5 CONNECT
+  listener (the default is `127.0.0.1:1080`); `-L [BIND:]PORT:HOST:PORT` is a
+  fixed forward. Both are repeatable and can be mixed. Names are resolved at
+  the far end, so client DNS does not leak around the tunnel.
+- **`--allow` rules on the server.** By default every destination except the
+  server's own loopback and link-local addresses, checked on the request *and*
+  on what the name resolved to. `--allow 127.0.0.1:8081` publishes one local
+  service; `--allow any` restores everything.
+- **A startup check.** The client opens one short session before binding
+  anything and prints `checking HOST:PORT ... ok (protocol 1, format, mode)`,
+  or a reason and exit 1. `--no-check` skips it.
+- **Format and mode are negotiated.** One `--format` base name on the client
+  replaces the two format flags, and `--mode` replaces `--record-layer-mode` on
+  one side only. A mismatch between endpoints is no longer possible.
+  `fteproxy formats` lists the base names with the capacity of one covertext.
+- **Half-close.** A stream that ends in one direction now says so, instead of
+  tearing down both, so an HTTP request that finishes while its response is
+  still arriving works.
+- **Failures are visible.** Exit status is 0 clean / 1 runtime failure /
+  2 usage; a no-argument run prints usage instead of crashing with a
+  `TypeError` and exiting 0; an unknown format, an unreadable key and a refused
+  bind all report themselves instead of exiting 0.
+- **Logging.** stderr through the `logging` module, `-q` for errors only and
+  `-v` for per-connection detail, with a redaction filter that keeps a key, a
+  server-id or a connection string out of any log line. Command output — the
+  connection string, the format table — goes to stdout so it can be piped.
+
+## Upgrade steps
+
+1. Upgrade both endpoints to 0.4.0 at the same time. There is no window in
+   which a 0.3 client and a 0.4 server interoperate.
+2. Start the server once and keep the connection string it prints:
+
+   ```bash
+   fteproxy server --advertise your.host:8080 --allow any
+   ```
+
+   Choose the `--allow` rules deliberately; the default blocks the server's own
+   loopback, which is usually what you want but is not what 0.3 did.
+3. Give the connection string to each client, and translate the old
+   fixed-destination setup into a `-L` forward:
+
+   ```bash
+   # 0.3
+   fteproxy --mode client --client_port 8079 --server_ip S --server_port 8080
+   # 0.4, with the server's --proxy_ip:--proxy_port as the -L destination
+   fteproxy client fte://…@S:8080 -L 8079:127.0.0.1:22
+   ```
+
+   Or drop the forward and let applications use SOCKS5 on `127.0.0.1:1080`.
+4. Delete the old shared key file; nothing reads it any more.
+5. If you embedded fteproxy: `wrap_socket`'s `outgoing_regex`, `incoming_regex`,
+   `K1`, `K2` and `negotiate` parameters are replaced by `server_key=` (server
+   role) or `server_id=` plus `format=`/`mode=` (client role), with
+   `generate_server_key()`, `sock.open()`, `sock.wait_open()` and
+   `sock.open_result()` alongside. See the README's Python API section and
+   `examples/`.
+
+## Definitions
+
+Thirty-two entries in `20260110.json` have longer covertexts so that every
+shipped format can carry a handshake, and the loader now refuses a release
+containing a format that cannot (capacity below 128 bytes). The default
+`manual-http-*` formats are unchanged at length 256, carrying 150 (request)
+and 192 (response) bytes.
+
+## Performance
+
+Bulk throughput is unchanged: the record layer's framing, sealing and chunking
+are as they were, and the hybrid body still runs at 670–970 MB/s in the
+microbenchmark. Connection setup costs about 1.6 ms more than the same build
+without the handshake (0.7 → 2.3 ms p50 on loopback) — two X25519 key
+generations, four exchanges, and the two extra round trips that buy server
+authentication and an in-band destination. See
+[PERFORMANCE.md](../PERFORMANCE.md).
+
+## Security
+
+[SECURITY.md](../SECURITY.md) is rewritten around the keypair model: what the
+connection string authorises, the replay window and filter, what a failed
+handshake looks like from outside, and the allow-rule default. The handshake
+is hand-assembled from `cryptography` primitives rather than a Noise library,
+and its wire format and key schedule are pinned by checked-in test vectors in
+`fteproxy/tests/vectors/handshake_v1.json`.
+
+## Requirements
+
+`fte>=0.4.0,<0.5.0`, `cryptography>=42.0`, Python 3.10 or newer.

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -1,6 +1,6 @@
-# fteproxy 0.4.0
+# fteproxy 1.0.0
 
-0.4.0 replaces the protocol, the command line and the topology together,
+1.0.0 replaces the protocol, the command line and the topology together,
 because none of the three worked without the other two. The short version: a
 server needs no arguments, a client needs one, and there is no shared secret.
 
@@ -19,7 +19,7 @@ SOCKS5 on 127.0.0.1:1080
 ## Breaking changes
 
 **The wire format changed and there is no compatibility mode.** A 0.3.x peer,
-or a peer running an earlier 0.4 development build, gets no reply at all —
+or a peer running an earlier development build, gets no reply at all —
 which is the same thing an active prober gets, deliberately. Upgrade both ends
 together.
 
@@ -90,8 +90,8 @@ exits on SIGINT or SIGTERM.
 
 ## Upgrade steps
 
-1. Upgrade both endpoints to 0.4.0 at the same time. There is no window in
-   which a 0.3 client and a 0.4 server interoperate.
+1. Upgrade both endpoints to 1.0.0 at the same time. There is no window in
+   which a 0.3 client and a 1.0 server interoperate.
 2. Start the server once and keep the connection string it prints:
 
    ```bash
@@ -106,7 +106,7 @@ exits on SIGINT or SIGTERM.
    ```bash
    # 0.3
    fteproxy --mode client --client_port 8079 --server_ip S --server_port 8080
-   # 0.4, with the server's --proxy_ip:--proxy_port as the -L destination
+   # 1.0, with the server's --proxy_ip:--proxy_port as the -L destination
    fteproxy client fte://…@S:8080 -L 8079:127.0.0.1:22
    ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,15 @@ Traffic between client and server looks like:
 - anything you want!
 ```
 
-By default (`--record-layer-mode hybrid`) each record *starts* with a
-covertext in the chosen format and carries the rest as raw authenticated
-ciphertext. Use `--record-layer-mode format` on both endpoints to put every
-byte in the format (much slower). See the main README.
+The destination is named on the client -- with `-L` for one fixed address, or
+by whatever application uses the client's `-D` SOCKS5 listener -- and travels
+inside the tunnel. The server has no forward address; it only decides what it
+is willing to dial, with `--allow`.
+
+By default (`--mode hybrid`) each record *starts* with a covertext in the
+chosen format and carries the rest as raw authenticated ciphertext. Use
+`--mode format` for a stream that is entirely in the format (much slower).
+Both are the client's choice and the server follows. See the main README.
 
 ## Directory Structure
 
@@ -70,39 +75,40 @@ examples/
 
 **Location:** `basic/`
 
-The simplest way to get started with fteproxy.
+The simplest way to get started with fteproxy. Both scripts pass their
+arguments straight through to `python3 -m fteproxy server` / `... client`.
 
 ### start_server.sh
 
 Starts an fteproxy server that:
 - Listens for FTE-encoded connections on port 8080
-- Forwards decoded traffic to port 8081
+- Generates a keypair on first start and prints the connection string clients need
 
 ```bash
-./start_server.sh
+./start_server.sh --listen 127.0.0.1:8080 --allow 127.0.0.1:8081
 ```
 
 ### start_client.sh
 
 Starts an fteproxy client that:
-- Listens for plaintext on port 8079
-- Sends FTE-encoded traffic to the server
+- Takes its connection string from the argument, `$FTEPROXY_URI`, or `connection.txt`
+- Listens locally and tunnels to the server
 
 ```bash
-./start_client.sh [server-ip]
+./start_client.sh [connection-string] -L 8079:127.0.0.1:8081
 ```
 
 ### Try it out
 
 ```bash
-# Terminal 1: Start server
-./start_server.sh
+# Terminal 1: Start server, allowing it to dial the service below
+./start_server.sh --listen 127.0.0.1:8080 --allow 127.0.0.1:8081
 
 # Terminal 2: Start a service (e.g., netcat)
 nc -l 8081
 
-# Terminal 3: Start client
-./start_client.sh
+# Terminal 3: Start client (no connection string needed on the same host)
+./start_client.sh -L 8079:127.0.0.1:8081
 
 # Terminal 4: Send data
 echo "Hello through FTE!" | nc localhost 8079
@@ -118,20 +124,20 @@ A simple echo server/client demonstrating `fteproxy.wrap_socket()`.
 
 ### How it works
 
+One of `server_key=` and `server_id=` picks the role. The client also picks the
+format; the server learns it from the client's first record.
+
 ```python
 import socket
 import fteproxy
 
-# Create a regular socket
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+# The server holds the private key ...
+sock = fteproxy.wrap_socket(sock, server_key=private_key_bytes)
 
-# Wrap it with FTE encoding
-sock = fteproxy.wrap_socket(sock,
-    outgoing_regex="^[a-z]+$",      # Send as lowercase letters
-    outgoing_length=256,
-    incoming_regex="^[A-Z]+$",      # Receive as UPPERCASE
-    incoming_length=256,
-    negotiate=False)
+# ... and the client needs only the matching public half, as 32 bytes or as
+# the 43-character base64url string a connection string carries.
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock = fteproxy.wrap_socket(sock, server_id=SERVER_ID, format="binary")
 
 # Use normally - encoding is transparent!
 sock.connect(("localhost", 50007))
@@ -292,32 +298,33 @@ Use fteproxy with real-world tools.
 
 ### ssh_tunnel.sh
 
-Tunnel SSH through FTE so it looks like random text:
+Tunnel SSH through FTE so it looks like HTTP-like text:
 
 ```bash
-# On server (where sshd is running)
+# On server (where sshd is running); it prints a connection string
 ./ssh_tunnel.sh server
 
-# On client
-./ssh_tunnel.sh client server-ip
+# On client, with that string
+./ssh_tunnel.sh client 'fte://<server-id>@<server-ip>:8080'
 
 # Then connect normally
-ssh -p 8079 user@localhost
+ssh -p 2222 user@localhost
 ```
 
 ### web_proxy.sh
 
-Tunnel web traffic through FTE:
+Tunnel web traffic through FTE. SOCKS5 is built in, so nothing extra runs on
+the server:
 
 ```bash
-# On server (with a proxy like tinyproxy on port 8888)
+# On server
 ./web_proxy.sh server
 
 # On client
-./web_proxy.sh client server-ip
+./web_proxy.sh client 'fte://<server-id>@<server-ip>:8080'
 
-# Use with curl
-curl -x http://localhost:8079 https://example.com
+# Use with curl, or point a browser at SOCKS5 127.0.0.1:1080
+curl --socks5-hostname 127.0.0.1:1080 https://example.com/
 ```
 
 ### secure_chat.py
@@ -348,14 +355,14 @@ One-command demo to see fteproxy in action.
 ./demo.sh
 ```
 
-This starts:
-1. FTE server (port 8080)
-2. FTE client (port 8079)  
+This starts, in a throwaway state directory:
+1. FTE server (port 8080, allowed to dial 127.0.0.1:8081)
+2. FTE client (`-L 8079:127.0.0.1:8081`)
 3. Netcat listener (port 8081)
 
 Then in another terminal:
 ```bash
-echo "Hello, FTE!" | nc localhost 8079
+echo "Hello, FTE!" | nc 127.0.0.1 8079
 ```
 
 Traffic flow:
@@ -367,33 +374,40 @@ You --> :8079 --> [FTE encode] --> :8080 --> [FTE decode] --> :8081 --> netcat
 
 ## Available Formats
 
-fteproxy includes these built-in formats. Each exists as `<name>-request`
-(client to server) and `<name>-response` (server to client) in
-`fteproxy/defs/20260110.json`; pass them to `--upstream-format` and
-`--downstream-format`. Every covertext of a format is a fixed number of bytes
-(its `length`): 256 for most, 1032 for `binary`, 312 for `ip-address` and
-`timestamp`, and between 176 and 232 for the other structured formats.
+A format is named by its **base name**. Each base covers both directions:
+fteproxy derives a `-request` covertext (client to server) and a `-response`
+covertext (server to client) from it, so `--format words` is right and
+`--format words-request` is not. The format is the client's choice and the
+server follows.
+
+`fteproxy formats` is the authoritative list, and prints each format's
+covertext length and how many message bytes it carries:
 
 | Format | Output Looks Like | Example |
 |--------|------------------|---------|
-| `lowercase` | Random letters | `xkwqprmstyz` |
-| `uppercase` | CAPITAL LETTERS | `XKWQPRMSTYZ` |
-| `words` | English-like text | `hello world foo` |
-| `sentences` | Sentences with periods | `Hello world.` |
-| `digits` | Numbers | `8675309420` |
-| `hex` | Hexadecimal | `a1b2c3d4e5f6` |
+| `manual-http` | HTTP requests/responses (default) | `GET /a1b2 HTTP/1.1` |
+| `alphanumeric` | Letters and digits | `x7Kq2prM9tyz` |
 | `base64` | Base64 characters | `SGVsbG8gV29ybGQ` |
 | `binary` | Binary (0s and 1s) | `01101000011001` |
 | `csv` | Comma-separated | `foo,bar,baz` |
-| `ip-address` | IP addresses | `192.168.1.1` |
+| `digits` | Numbers | `8675309420` |
 | `domain` | Domain names | `example.com` |
+| `dummy` | Unconstrained (`^.+$`), for testing | `k#7~Qz!9k` |
 | `email-simple` | Email addresses | `user@host.com` |
-| `url-path` | URL paths | `/api/v1/users` |
-| `http-simple` | HTTP requests | `GET /page HTTP/1.1` |
-| `ssh` | SSH banners | `SSH-2.0-OpenSSH` |
-| `smtp` | SMTP commands | `EHLO mail.com` |
 | `ftp` | FTP responses | `220 ftp.com ready` |
+| `hex` | Hexadecimal | `a1b2c3d4e5f6` |
+| `http-simple` | HTTP requests | `GET /page HTTP/1.1` |
+| `ip-address` | IP addresses | `192.168.1.1` |
+| `key-value` | Key-value pairs | `key=value` |
+| `lowercase` | Random letters | `xkwqprmstyz` |
+| `sentences` | Sentences with periods | `Hello world.` |
+| `smtp` | SMTP commands | `EHLO mail.com` |
+| `ssh` | SSH banners | `SSH-2.0-OpenSSH` |
+| `timestamp` | Timestamps | `12:34:56` |
 | `tls-sni` | TLS SNI style | `www.example.com` |
+| `uppercase` | CAPITAL LETTERS | `XKWQPRMSTYZ` |
+| `url-path` | URL paths | `/api/v1/users` |
+| `words` | English-like text | `hello world foo` |
 
 ---
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,29 +2,44 @@
 
 This directory contains simple examples to get started with fteproxy.
 
+`start_server.sh` and `start_client.sh` are one-line wrappers around
+`python3 -m fteproxy server` and `python3 -m fteproxy client`; every argument
+you give them is passed straight through.
+
 ## Quick Start
+
+Four terminals on one machine.
 
 ### 1. Start the server
 
 In terminal 1:
 ```bash
-python3 -m fteproxy --mode server --server_port 8080 --proxy_port 8081
+./start_server.sh --listen 127.0.0.1:8080 --allow 127.0.0.1:8081
 ```
+
+The first start generates the server's keypair and prints the connection
+string clients need, which it also writes to `connection.txt` in the state
+directory. `--allow 127.0.0.1:8081` is what lets the server dial the service
+in step 2: without any rule it refuses its own loopback addresses.
 
 ### 2. Start a destination service
 
 In terminal 2:
 ```bash
 # Simple echo server using netcat
-nc -l -k 8081
+nc -l 8081
 ```
 
 ### 3. Start the client
 
 In terminal 3:
 ```bash
-python3 -m fteproxy --mode client --client_port 8079 --server_ip 127.0.0.1 --server_port 8080
+./start_client.sh -L 8079:127.0.0.1:8081
 ```
+
+No connection string is needed here, because the client reads the
+`connection.txt` the server just wrote. From another machine you would pass
+the string the server printed as the first argument.
 
 ### 4. Send data
 
@@ -46,15 +61,25 @@ Your Traffic Flow:
   |  App    |----->|  client   |=======>|  server   |---->| Service |
   |         |      |           |        |           |     |         |
   +---------+      +-----------+        +-----------+     +---------+
-     :8079           Encodes              Decodes           :8081
-                     traffic as           back to
-                     HTTP-like            plaintext
-                     patterns
+     :8079         -L 8079:127.0.0.1:8081   dials what      :8081
+                   names the destination    the client
+                   and encodes traffic      asked for
 ```
 
-Each record between the fteproxy client and server starts with a covertext
-shaped like an HTTP request (client to server) or an HTTP response (server to
-client). With the default `--record-layer-mode hybrid` the rest of the record is
-raw authenticated ciphertext; with `--record-layer-mode format` on both sides
-the whole stream is in the format. Either way, give both sides the same
-`--key-file`: the built-in default key is public.
+The server has no forward address of its own. The destination is chosen on the
+client -- by `-L` here, or by whatever a SOCKS5 application asks for when you
+use `-D` instead -- and travels inside the tunnel; the server dials it if
+`--allow` permits.
+
+Each record between the client and the server starts with a covertext shaped
+like an HTTP request (client to server) or an HTTP response (server to client).
+With the default `--mode hybrid` the rest of the record is raw authenticated
+ciphertext; with `--mode format` the whole stream is in the format, much more
+slowly. Both are the client's choice and travel in the handshake, so there is
+nothing to keep in step on the server.
+
+There is no shared secret to distribute. The server keeps an X25519 private key
+in `server.key`, and the connection string carries only its public half. Treat
+that string like a Tor bridge line: whoever holds it can connect, so keep it
+secret, but it does not let its holder impersonate the server or read another
+client's traffic.

--- a/examples/basic/start_client.sh
+++ b/examples/basic/start_client.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
-# Start fteproxy client with default settings
+# Start an fteproxy client. Every argument is passed straight through, e.g.
+#   ./start_client.sh fte://<server-id>@203.0.113.5:8080 -D 1080
+#
+# Without a URI argument the client takes one from $FTEPROXY_URI, then from
+# connection.txt in the state directory -- so on the host that ran the server
+# no argument is needed at all. With neither -D nor -L it opens a SOCKS5
+# listener on 127.0.0.1:1080.
 
-SERVER_IP="${1:-127.0.0.1}"
-
-echo "Starting fteproxy client..."
-echo "  Listening for plaintext on: 127.0.0.1:8079"
-echo "  Connecting to FTE server: $SERVER_IP:8080"
-echo ""
-
-python3 -m fteproxy --mode client \
-    --client_ip 127.0.0.1 \
-    --client_port 8079 \
-    --server_ip "$SERVER_IP" \
-    --server_port 8080
+exec python3 -m fteproxy client "$@"

--- a/examples/basic/start_server.sh
+++ b/examples/basic/start_server.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
-# Start fteproxy server with default settings
+# Start an fteproxy server. Every argument is passed straight through, e.g.
+#   ./start_server.sh --listen :8080 --allow 127.0.0.1:8081
+#
+# The first start generates the server's keypair in the state directory
+# (~/.local/state/fteproxy by default) and prints the connection string
+# clients need, which it also writes to connection.txt beside the key.
 
-echo "Starting fteproxy server..."
-echo "  Listening for FTE connections on: 0.0.0.0:8080"
-echo "  Forwarding plaintext to: 127.0.0.1:8081"
-echo ""
-
-python3 -m fteproxy --mode server \
-    --server_ip 0.0.0.0 \
-    --server_port 8080 \
-    --proxy_ip 127.0.0.1 \
-    --proxy_port 8081
+exec python3 -m fteproxy server "$@"

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,7 +1,7 @@
 # FTE Chat Example
 
 A chat demo with a 10-round conversation between client and server.
-All traffic is FTE-encoded to look like binary or letters.
+All traffic is FTE-encoded to look like binary (0s and 1s).
 
 ## Quick Start
 
@@ -20,8 +20,7 @@ python3 client.py
 FTE Chat Server
 ==================================================
 Listening on port 50007
-Client->Server format: binary (0s and 1s)
-Server->Client format: letters (As and Bs)
+Format and mode: whatever the client asks for
 ==================================================
 
 Waiting for client...
@@ -43,8 +42,7 @@ Client connected from ('127.0.0.1', 52431)
 FTE Chat Client
 ==================================================
 Connecting to 127.0.0.1:50007
-Client->Server format: binary (0s and 1s)
-Server->Client format: letters (As and Bs)
+Format: binary (0s and 1s in both directions)
 ==================================================
 
 Connected!
@@ -56,23 +54,42 @@ Connected!
 ...
 ```
 
+## How The Two Sides Are Configured
+
+The client makes every choice and the server follows. All the client holds is
+the server-id -- the public half of the server's keypair, which is what a
+connection string carries:
+
+```python
+# client.py
+sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID, format="binary")
+
+# server.py -- no format, no mode, no shared key
+sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
+```
+
+The server learns the format and the record-layer mode from the client's first
+record. A real server generates its keypair with `fteproxy keygen` and hands
+out only the public half; these scripts hardcode a demo keypair so they agree
+without exchanging anything.
+
 ## What's On The Wire
 
 Even though the conversation looks normal, the actual network traffic is encoded:
 
 | Direction | What You See | What's On The Wire |
 |-----------|-------------|-------------------|
-| Client -> Server | "Hi there!" | `0101101011101010110...` (520 bytes) + raw ciphertext |
-| Server -> Client | "Hello!" | `ABBAABABBAABBABA...` (520 bytes) + raw ciphertext |
+| Client -> Server | "Hi there!" | `0101101011101010110...` (1320 bytes) + raw ciphertext |
+| Server -> Client | "Hello!" | `1101001011010110100...` (1320 bytes) + raw ciphertext |
 
-With fteproxy's default record-layer mode (`hybrid`), each record starts with
-a 520-character covertext in the format and carries the message itself as raw
-authenticated ciphertext after it. To make the whole stream binary or letters,
-select `format` mode on both sides before wrapping the socket (there is no
-`wrap_socket` argument for it):
+With fteproxy's default record-layer mode (`hybrid`), each record starts with a
+1320-byte covertext in the `binary` format and carries the message itself as
+raw authenticated ciphertext after it. To make the whole stream binary, ask for
+`format` mode when wrapping the client socket -- the server follows:
 
 ```python
-fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'format')
+sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID,
+                            format="binary", mode="format")
 ```
 
 ## Traffic Flow
@@ -83,35 +100,25 @@ fteproxy.conf.setValue('runtime.fteproxy.record_layer.mode', 'format')
 +------------+                      +------------+
       |                                   |
       |  "Hi there!" encoded as binary    |
-      |  010110101110101011010110...       |
+      |  010110101110101011010110...      |
       |---------------------------------->|
       |                                   |
-      |  "Hello!" encoded as A/B letters  |
-      |  ABBAABABBAABBABABAAB...           |
+      |  "Hello!" encoded as binary       |
+      |  110100101101011010011010...      |
       |<----------------------------------|
       |                                   |
      ...         (10 rounds)             ...
 ```
 
-## Formats Used
-
-| Direction | Regex | Looks Like |
-|-----------|-------|------------|
-| Client -> Server | `^(0|1)+$` | `010110101110101...` |
-| Server -> Client | `^(A|B)+$` | `ABBAABABBAABAB...` |
-
 ## Customization
 
-Edit the regex patterns in both files to change the wire format:
+Change `FORMAT` in `client.py` to any base name `fteproxy formats` lists, and
+the wire format changes in both directions:
 
 ```python
-# Look like lowercase words
-CLIENT_TO_SERVER = '^([a-z]+ )+[a-z]+$'
-SERVER_TO_CLIENT = '^([A-Z]+ )+[A-Z]+$'
-
-# Look like hex
-CLIENT_TO_SERVER = '^[0-9a-f]+$'
-SERVER_TO_CLIENT = '^[0-9A-F]+$'
+FORMAT = "words"        # a a a xkq mfj ...
+FORMAT = "hex"          # a1b2c3d4e5f6 ...
+FORMAT = "manual-http"  # GET /... HTTP/1.1
 ```
 
-Both client and server must use matching formats!
+Only the client changes. The server is told nothing and follows.

--- a/examples/formats/README.md
+++ b/examples/formats/README.md
@@ -35,18 +35,39 @@ plaintext to `cipher.max_plaintext_bytes` yourself.
 
 ## Using a format with the proxy
 
-Every built-in format has a `-request` (client to server) and a `-response`
-(server to client) definition in `fteproxy/defs/20260110.json`. Pick them on
-the client; the server negotiates the matching pair automatically:
+The proxy names a format by its **base name**, such as `manual-http` or
+`words` -- never `words-request`. Each base covers both directions: fteproxy
+derives the `-request` covertext (client to server) and the `-response`
+covertext (server to client) from it. `fteproxy formats` lists the base names
+with the length of one covertext and how many message bytes it carries:
 
-```bash
-python3 -m fteproxy --mode client --upstream-format words-request --downstream-format words-response ...
+```console
+$ fteproxy formats
+name          req len  req cap  resp len  resp cap
+...
+manual-http       256      150       256      192  (default)
+words             280      138       280      138
 ```
 
-By default (`--record-layer-mode hybrid`) only a fixed-length header per record
-is in the chosen format and the rest of the record is raw ciphertext. Add
-`--record-layer-mode format` on both endpoints to put every byte in the format,
-at much lower throughput. See the main README's "Upgrading to 0.4.0" section.
+The format and the record-layer mode are the **client's** choice: both travel
+in the handshake and the server follows, so there is nothing to configure on
+the server and no way for the two ends to disagree.
+
+```bash
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080' --format words
+```
+
+With the default `--mode hybrid` only a fixed-length header per record is in
+the chosen format and the rest of the record is raw authenticated ciphertext.
+`--mode format` puts every byte in the format, at much lower throughput.
+
+The same two choices are arguments to `fteproxy.wrap_socket()` on the client
+side:
+
+```python
+sock = fteproxy.wrap_socket(sock, server_id=SERVER_ID,
+                            format="words", mode="hybrid")
+```
 
 ## Why different formats?
 
@@ -57,4 +78,5 @@ Different formats blend in with different traffic:
 - **Hex / base64**: encoded data, common in APIs
 - **Digits, IP addresses, timestamps**: numeric fields
 
-The full list is in [`../README.md`](../README.md#available-formats).
+`fteproxy formats` is the authoritative list; there is a summary in
+[`../README.md`](../README.md#available-formats).

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -2,6 +2,11 @@
 
 These examples show how to use fteproxy with common tools and services.
 
+The server never has a forward address of its own. It decides *what it is
+willing to dial* with `--allow`; the client decides *where to go*, with `-L`
+for one fixed destination or `-D` for a SOCKS5 listener that takes the
+destination from the application.
+
 ## SSH Over FTE
 
 Tunnel SSH connections through fteproxy so they look like HTTP traffic.
@@ -9,43 +14,56 @@ Tunnel SSH connections through fteproxy so they look like HTTP traffic.
 ### Server Side
 
 ```bash
-# Terminal 1: Start fteproxy server (forwards to local SSH)
-python3 -m fteproxy --mode server --server_port 8080 --proxy_ip 127.0.0.1 --proxy_port 22
+# Publish the local sshd. Without an --allow rule the server refuses its own
+# loopback addresses, so this rule is what makes 127.0.0.1:22 reachable.
+python3 -m fteproxy server --allow 127.0.0.1:22
 
 # Make sure sshd is running on port 22
 ```
+
+It prints a connection string. Copy that to the client.
 
 ### Client Side
 
 ```bash
 # Terminal 1: Start fteproxy client
-python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080' -L 2222:127.0.0.1:22
 
 # Terminal 2: Connect via SSH through fteproxy
-ssh -p 8079 user@localhost
+ssh -p 2222 user@localhost
 ```
 
-## HTTP Proxy Over FTE
+`127.0.0.1:22` in the `-L` is resolved by the *server*, so it means the
+server's own sshd.
 
-Use fteproxy to tunnel an HTTP proxy.
+## Web Browsing Over FTE
+
+SOCKS5 is built in, so there is nothing to install on the server.
 
 ### Server Side
 
 ```bash
-# Start a simple HTTP proxy (e.g., tinyproxy) on port 8888
-# Then start fteproxy to expose it:
-python3 -m fteproxy --mode server --server_port 8080 --proxy_port 8888
+# Reach the public internet, but not this host's loopback or link-local
+# addresses:
+python3 -m fteproxy server
+
+# Or reach everything, loopback included:
+python3 -m fteproxy server --allow any
 ```
 
 ### Client Side
 
 ```bash
-# Start fteproxy client
-python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+# Start fteproxy client with a SOCKS5 listener
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080' -D 1080
 
-# Use curl with the proxy
-curl -x http://localhost:8079 https://example.com
+# Use curl
+curl --socks5-hostname 127.0.0.1:1080 https://example.com/
 ```
+
+Or point a browser at a SOCKS5 proxy on `127.0.0.1:1080`. Use
+`--socks5-hostname` (and the browser's "proxy DNS when using SOCKS" setting)
+so names are resolved by the server rather than leaking around the tunnel.
 
 ## Netcat File Transfer
 
@@ -54,8 +72,8 @@ Transfer files using netcat through FTE encoding.
 ### Receiver Side
 
 ```bash
-# Terminal 1: Start fteproxy server
-python3 -m fteproxy --mode server --server_port 8080 --proxy_port 9999
+# Terminal 1: Start fteproxy server, publishing the port netcat will use
+python3 -m fteproxy server --allow 127.0.0.1:9999
 
 # Terminal 2: Wait for file with netcat
 nc -l 9999 > received_file.txt
@@ -65,28 +83,38 @@ nc -l 9999 > received_file.txt
 
 ```bash
 # Terminal 1: Start fteproxy client
-python3 -m fteproxy --mode client --client_port 8079 --server_ip <server-ip> --server_port 8080
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080' -L 8079:127.0.0.1:9999
 
 # Terminal 2: Send file
 cat myfile.txt | nc localhost 8079
 ```
 
-## Key
+## Keys and the connection string
 
-The built-in default key is public (fteproxy warns at startup when it is in
-use), so always supply your own. Both sides must use the same key. Prefer
-`--key-file`, which keeps the key out of shell history and `ps` output:
+There is no shared secret to distribute. On its first start the server
+generates an X25519 keypair in its state directory (`~/.local/state/fteproxy`
+by default): `server.key` holds the private half at mode 0600, and
+`connection.txt` holds the string clients need.
 
 ```bash
-# Generate a random 64-character hex key
-openssl rand -hex 32 > fteproxy.key
-chmod 600 fteproxy.key
+# Provision a key and print the string without starting a server
+python3 -m fteproxy keygen --advertise vpn.example.com:8080
+```
 
-# Server
-python3 -m fteproxy --mode server --key-file fteproxy.key --server_port 8080 --proxy_port 8081
+Without `--advertise` the string carries a literal `<server-ip>` placeholder
+for you to substitute.
 
-# Client (the SAME key file)
-python3 -m fteproxy --mode client --key-file fteproxy.key --server_ip <server-ip> --server_port 8080
+The connection string carries only the public half, so treat it like a Tor
+bridge line: whoever holds it can connect, and its secrecy is what stops an
+active prober from confirming your server is running fteproxy. It does not let
+its holder impersonate the server or read another client's traffic.
+
+On a single host you can skip it entirely -- the client reads `connection.txt`
+from the same state directory:
+
+```bash
+python3 -m fteproxy server --allow 127.0.0.1:8081 &
+python3 -m fteproxy client -L 8079:127.0.0.1:8081
 ```
 
 ## Chaining with socat

--- a/examples/integration/ssh_tunnel.sh
+++ b/examples/integration/ssh_tunnel.sh
@@ -1,60 +1,60 @@
 #!/bin/bash
 # SSH Tunnel Over FTE
-# 
+#
 # This script sets up an SSH tunnel through fteproxy.
 # Traffic will appear as HTTP-like patterns to network observers.
 #
 # Usage:
 #   Server: ./ssh_tunnel.sh server
-#   Client: ./ssh_tunnel.sh client <server-ip>
+#   Client: ./ssh_tunnel.sh client <connection-string>
 
 MODE="${1:-help}"
-SERVER_IP="${2:-127.0.0.1}"
+URI="$2"
 
 case "$MODE" in
     server)
         echo "Starting FTE server for SSH tunneling..."
         echo "  FTE listening on: 0.0.0.0:8080"
-        echo "  Forwarding to SSH: 127.0.0.1:22"
+        echo "  Clients may reach: 127.0.0.1:22"
         echo ""
-        echo "Make sure sshd is running on port 22"
+        echo "Make sure sshd is running on port 22."
+        echo "Hand a client the connection string printed below."
         echo ""
-        python3 -m fteproxy --mode server \
-            --server_ip 0.0.0.0 \
-            --server_port 8080 \
-            --proxy_ip 127.0.0.1 \
-            --proxy_port 22
+        # --allow is what publishes the local sshd: with no rule at all the
+        # server refuses its own loopback addresses.
+        python3 -m fteproxy server --allow 127.0.0.1:22
         ;;
-    
+
     client)
+        if [ -z "$URI" ]; then
+            echo "Error: pass the connection string the server printed, e.g."
+            echo "  $0 client 'fte://<server-id>@192.168.1.100:8080'"
+            exit 2
+        fi
         echo "Starting FTE client for SSH tunneling..."
-        echo "  Local port: 8079"
-        echo "  FTE server: $SERVER_IP:8080"
+        echo "  Local port: 2222 -> 127.0.0.1:22 through the tunnel"
         echo ""
         echo "To connect via SSH, run:"
-        echo "  ssh -p 8079 user@localhost"
+        echo "  ssh -p 2222 user@localhost"
         echo ""
-        python3 -m fteproxy --mode client \
-            --client_ip 127.0.0.1 \
-            --client_port 8079 \
-            --server_ip "$SERVER_IP" \
-            --server_port 8080
+        python3 -m fteproxy client "$URI" -L 2222:127.0.0.1:22
         ;;
-    
+
     *)
         echo "SSH Tunnel Over FTE"
         echo "==================="
         echo ""
         echo "Usage:"
-        echo "  $0 server              - Start server (forwards to local SSH)"
-        echo "  $0 client <server-ip>  - Start client (connect to remote FTE server)"
+        echo "  $0 server                      - Start server (publishes local SSH)"
+        echo "  $0 client <connection-string>  - Start client (connect to remote FTE server)"
         echo ""
         echo "Example:"
         echo "  # On server machine:"
         echo "  $0 server"
+        echo "  # It prints a connection string; copy it to the client."
         echo ""
         echo "  # On client machine:"
-        echo "  $0 client 192.168.1.100"
-        echo "  ssh -p 8079 user@localhost"
+        echo "  $0 client 'fte://<server-id>@192.168.1.100:8080'"
+        echo "  ssh -p 2222 user@localhost"
         ;;
 esac

--- a/examples/integration/web_proxy.sh
+++ b/examples/integration/web_proxy.sh
@@ -6,62 +6,66 @@
 # - You want to hide your browsing patterns
 # - You're on a network that inspects traffic
 #
-# Prerequisites:
-# - A proxy server (like tinyproxy, squid, or privoxy) on the server
-# - Or direct forwarding to a web server
+# No proxy software is needed on the server: the client speaks SOCKS5 to your
+# browser and the server dials whatever the browser asks for.
 
 MODE="${1:-help}"
-SERVER_IP="${2:-127.0.0.1}"
-PROXY_PORT="${3:-8888}"
+URI="$2"
+SOCKS_PORT="${3:-1080}"
 
 case "$MODE" in
     server)
-        echo "Starting FTE server for web proxy..."
+        echo "Starting FTE server for web proxying..."
         echo "  FTE listening on: 0.0.0.0:8080"
-        echo "  Forwarding to proxy: 127.0.0.1:$PROXY_PORT"
+        echo "  Clients may reach: any destination"
         echo ""
-        echo "Make sure your web proxy is running on port $PROXY_PORT"
-        echo "(e.g., tinyproxy, squid, privoxy)"
+        echo "'--allow any' means exactly that: whoever holds the connection"
+        echo "string can have this server dial any address and port, including"
+        echo "its own loopback and private networks. Plain 'fteproxy server'"
+        echo "with no rule reaches the whole public internet but refuses this"
+        echo "host's own loopback and link-local addresses; prefer it unless"
+        echo "you really need loopback reachable."
         echo ""
-        python3 -m fteproxy --mode server \
-            --server_ip 0.0.0.0 \
-            --server_port 8080 \
-            --proxy_ip 127.0.0.1 \
-            --proxy_port "$PROXY_PORT"
+        python3 -m fteproxy server --allow any
         ;;
-    
+
     client)
-        echo "Starting FTE client for web proxy..."
-        echo "  Local proxy port: 8079"
-        echo "  FTE server: $SERVER_IP:8080"
+        if [ -z "$URI" ]; then
+            echo "Error: pass the connection string the server printed, e.g."
+            echo "  $0 client 'fte://<server-id>@192.168.1.100:8080'"
+            exit 2
+        fi
+        echo "Starting FTE client for web proxying..."
+        echo "  SOCKS5 on: 127.0.0.1:$SOCKS_PORT"
         echo ""
         echo "Configure your browser to use:"
-        echo "  HTTP Proxy: localhost:8079"
+        echo "  SOCKS5 proxy: 127.0.0.1 port $SOCKS_PORT"
         echo ""
         echo "Or use curl:"
-        echo "  curl -x http://localhost:8079 https://example.com"
+        echo "  curl --socks5-hostname 127.0.0.1:$SOCKS_PORT https://example.com/"
         echo ""
-        python3 -m fteproxy --mode client \
-            --client_ip 127.0.0.1 \
-            --client_port 8079 \
-            --server_ip "$SERVER_IP" \
-            --server_port 8080
+        echo "--socks5-hostname (and a browser's 'proxy DNS' setting) sends the"
+        echo "name through the tunnel for the server to resolve, so lookups do"
+        echo "not leak around the proxy."
+        echo ""
+        python3 -m fteproxy client "$URI" -D "$SOCKS_PORT"
         ;;
-    
+
     *)
         echo "Web Proxy Over FTE"
         echo "=================="
         echo ""
         echo "Usage:"
-        echo "  $0 server [proxy-port]   - Start server (default proxy port: 8888)"
-        echo "  $0 client <server-ip>    - Start client"
+        echo "  $0 server                                    - Start server"
+        echo "  $0 client <connection-string> [socks-port]   - Start client (default port: 1080)"
         echo ""
         echo "Example:"
-        echo "  # On server (with tinyproxy on port 8888):"
+        echo "  # On server:"
         echo "  $0 server"
+        echo "  # It prints a connection string; copy it to the client."
         echo ""
         echo "  # On client:"
-        echo "  $0 client 192.168.1.100"
-        echo "  curl -x http://localhost:8079 https://example.com"
+        echo "  $0 client 'fte://<server-id>@192.168.1.100:8080'"
+        echo "  curl --socks5-hostname 127.0.0.1:1080 https://example.com/"
         ;;
 esac

--- a/examples/netcat/README.md
+++ b/examples/netcat/README.md
@@ -9,7 +9,7 @@ A simple demonstration of fteproxy using netcat.
 ./demo.sh
 
 # Terminal 2: Send a message
-echo "Hello, FTE!" | nc localhost 8079
+echo "Hello, FTE!" | nc 127.0.0.1 8079
 ```
 
 ## What It Does
@@ -30,14 +30,26 @@ The traffic between the FTE client and server is encoded to look like
 random characters matching a regex pattern, making it difficult to identify
 as proxy traffic.
 
+The server has no forward address. `-L 8079:127.0.0.1:8081` on the client is
+what names the destination, and it travels inside the tunnel; the server dials
+it because `--allow 127.0.0.1:8081` permits it. With no `--allow` rule at all a
+server refuses its own loopback addresses, so that rule is what publishes the
+netcat listener.
+
+The demo keeps its keypair in a throwaway `--state-dir`, generated on the first
+start along with the connection string. The client is given the same directory
+and reads the string back out of it, so neither side needs a shared secret or a
+URI on its command line.
+
 ## Ports
 
 | Port | Purpose |
 |------|---------|
-| 8079 | FTE client listens here (you connect here) |
+| 8079 | FTE client's `-L` forward (you connect here) |
 | 8080 | FTE server listens here (internal) |
 | 8081 | Final destination (netcat listener) |
 
 ## Cleanup
 
-Press `Ctrl+C` to stop. The script automatically cleans up all background processes.
+Press `Ctrl+C` to stop. The script kills every background process it started
+and removes the temporary state directory.

--- a/examples/netcat/demo.sh
+++ b/examples/netcat/demo.sh
@@ -3,32 +3,50 @@
 # FTE Proxy Netcat Demo
 #
 # Demonstrates fteproxy by tunneling netcat traffic through FTE encoding.
-# Run this script, then in another terminal: echo "Hello" | nc localhost 8079
+# Run this script, then in another terminal: echo "Hello" | nc 127.0.0.1 8079
 #
 
 set -e
 
 # Configuration
-CLIENT_IP=127.0.0.1
 CLIENT_PORT=8079
-SERVER_IP=127.0.0.1
 SERVER_PORT=8080
-PROXY_IP=127.0.0.1
-PROXY_PORT=8081
+DEST_PORT=8081
+
+# A throwaway state directory, so the demo neither reads nor writes the server
+# key you use for real. The server generates a keypair in here on startup and
+# writes the connection string to connection.txt; the client reads it back
+# from the same place, so neither side needs the string on its command line.
+STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fteproxy-demo.XXXXXX")"
 
 # Track background PIDs for cleanup
 PIDS=()
 
 cleanup() {
+    trap - EXIT INT TERM
     echo ""
     echo "Cleaning up..."
     for pid in "${PIDS[@]}"; do
         kill "$pid" 2>/dev/null || true
     done
+    rm -rf "$STATE_DIR"
     exit 0
 }
 
 trap cleanup EXIT INT TERM
+
+# Wait until $2 shows up in the log file $1, or until the process $3 dies.
+wait_for() {
+    local logfile="$1" pattern="$2" pid="$3" i
+    for i in $(seq 1 120); do
+        grep -q "$pattern" "$logfile" 2>/dev/null && return 0
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.5
+    done
+    echo "Failed to start. Log follows:"
+    sed 's/^/    /' "$logfile"
+    return 1
+}
 
 echo "================================================================"
 echo "                   FTE Proxy Netcat Demo                        "
@@ -36,40 +54,59 @@ echo "================================================================"
 echo ""
 echo "Traffic flow:"
 echo ""
-echo "  [You] -> :$CLIENT_PORT -> [FTE Client] -> [FTE Server] -> :$PROXY_PORT -> [nc]"
+echo "  [You] -> :$CLIENT_PORT -> [FTE Client] -> [FTE Server] -> :$DEST_PORT -> [nc]"
 echo "           plaintext       FTE encoded       plaintext"
 echo ""
 echo "================================================================"
 echo ""
 
-# Start fteproxy server
-echo "[1/3] Starting FTE server (listening on :$SERVER_PORT, forwarding to :$PROXY_PORT)..."
-python3 -m fteproxy --mode server --quiet \
-    --server_ip "$SERVER_IP" --server_port "$SERVER_PORT" \
-    --proxy_ip "$PROXY_IP" --proxy_port "$PROXY_PORT" &
-PIDS+=($!)
-sleep 0.5
+# Start fteproxy server. --allow is what lets it dial the netcat listener:
+# with no rule at all it refuses its own loopback addresses.
+echo "[1/3] Starting FTE server (listening on :$SERVER_PORT, may dial 127.0.0.1:$DEST_PORT)..."
+python3 -m fteproxy server \
+    --state-dir "$STATE_DIR" \
+    --listen "127.0.0.1:$SERVER_PORT" \
+    --advertise "127.0.0.1:$SERVER_PORT" \
+    --allow "127.0.0.1:$DEST_PORT" \
+    > "$STATE_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+PIDS+=($SERVER_PID)
+wait_for "$STATE_DIR/server.log" 'clients connect with' "$SERVER_PID"
 
-# Start fteproxy client  
-echo "[2/3] Starting FTE client (listening on :$CLIENT_PORT, connecting to :$SERVER_PORT)..."
-python3 -m fteproxy --mode client --quiet \
-    --client_ip "$CLIENT_IP" --client_port "$CLIENT_PORT" \
-    --server_ip "$SERVER_IP" --server_port "$SERVER_PORT" &
-PIDS+=($!)
-sleep 0.5
+# Start fteproxy client. -L picks the destination -- the server has no forward
+# address of its own -- and the destination travels inside the tunnel.
+echo "[2/3] Starting FTE client (forwarding :$CLIENT_PORT to 127.0.0.1:$DEST_PORT through the tunnel)..."
+python3 -m fteproxy client \
+    --state-dir "$STATE_DIR" \
+    -L "$CLIENT_PORT:127.0.0.1:$DEST_PORT" \
+    > "$STATE_DIR/client.log" 2>&1 &
+CLIENT_PID=$!
+PIDS+=($CLIENT_PID)
+wait_for "$STATE_DIR/client.log" 'forwarding' "$CLIENT_PID"
+sed 's/^/      /' "$STATE_DIR/client.log"
 
 # Start netcat listener
-echo "[3/3] Starting netcat listener on :$PROXY_PORT..."
+echo "[3/3] Starting netcat listener on :$DEST_PORT..."
 echo ""
 echo "================================================================"
 echo "Ready! In another terminal, run:"
 echo ""
-echo "    echo 'Hello, FTE!' | nc $CLIENT_IP $CLIENT_PORT"
+echo "    echo 'Hello, FTE!' | nc 127.0.0.1 $CLIENT_PORT"
 echo ""
 echo "You should see the message appear below."
 echo "Press Ctrl+C to stop."
 echo "================================================================"
 echo ""
 
-# Use nc (more portable than netcat)
-nc -l -k "$PROXY_PORT" 2>/dev/null || nc -l "$PROXY_PORT"
+# The listener runs in the background and the script waits on it, so that a
+# Ctrl+C reaches the cleanup trap instead of being swallowed by a foreground nc.
+# -k keeps it listening after the first connection; not every nc has it.
+nc -l -k "$DEST_PORT" 2>/dev/null &
+NC_PID=$!
+sleep 0.5
+if ! kill -0 "$NC_PID" 2>/dev/null; then
+    nc -l "$DEST_PORT" &
+    NC_PID=$!
+fi
+PIDS+=($NC_PID)
+wait "$NC_PID" || true

--- a/examples/programmatic/README.md
+++ b/examples/programmatic/README.md
@@ -2,10 +2,42 @@
 
 These examples show how to use fteproxy's Python API directly in your applications.
 
+## The API
+
+One of `server_key=` and `server_id=` picks the role. The client also picks the
+format and the record-layer mode; the server learns both from the client's
+first record, so nothing has to be configured to match:
+
+```python
+import fteproxy
+
+private, public = fteproxy.generate_server_key()
+
+# server side
+sock = fteproxy.wrap_socket(sock, server_key=private)
+
+# client side
+sock = fteproxy.wrap_socket(sock, server_id=public,
+                            format="words", mode="hybrid")
+```
+
+`server_id` also accepts the 43-character base64url string that a connection
+string carries, and `fteproxy.server_id(private)` recovers the public half of a
+key you already have. Wrapped sockets are used like ordinary sockets
+(`connect`, `bind`/`listen`/`accept`, `sendall`, `recv`), plus `close_write()`
+for a half-close.
+
+To relay for someone else rather than talk to them, a wrapped socket can carry
+a destination: the client calls `sock.open((host, port))` -- which raises
+`fteproxy.OpenRefused(status)` if the peer refuses -- and the server calls
+`sock.wait_open()` to learn the `(host, port)` asked for and answers with
+`sock.open_result(status)`.
+
 ## Examples
 
 ### 1. `simple_encoder.py`
-Direct encoding/decoding without network sockets. Good for understanding how FTE transforms data.
+Direct encoding/decoding with libfte, without sockets or fteproxy. Good for
+understanding how FTE transforms data.
 
 ### 2. `echo_client.py` / `echo_server.py`
 Basic echo server using `fteproxy.wrap_socket()`.
@@ -38,3 +70,8 @@ python format_demo.py
 # Create custom formats
 python custom_format.py
 ```
+
+These scripts share a hardcoded demo keypair so that any two of them agree
+without exchanging anything. A real server generates its own with
+`fteproxy keygen`, keeps `server.key` at mode 0600, and hands out only the
+public half.

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -26,7 +26,9 @@ import fte
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from fteproxy.handshake import generate_server_key, server_id
+# Re-exported: key generation belongs to the public API even though the
+# implementation lives with the handshake it feeds.
+from fteproxy.handshake import generate_server_key, server_id  # noqa: F401
 
 
 @functools.lru_cache(maxsize=256)
@@ -459,7 +461,7 @@ class _FTESocketWrapper(object):
 
         sealed = fteproxy.record_layer._seal(request_cipher,
                                              driver.hello_bytes, 0)
-        timeout = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
         try:
             self._socket.sendall(sealed)
             frame = self._read_exactly(
@@ -468,8 +470,7 @@ class _FTESocketWrapper(object):
             raise HandshakeFailedException('handshake I/O failed: %s' % e)
         if frame is None:
             raise HandshakeTimeoutException(
-                'no valid handshake reply within %ss (wrong connection '
-                'string, or the peer is not running fteproxy 0.4)' % timeout)
+                'no valid handshake reply within %ss' % timeout)
 
         try:
             plaintext = response_cipher.decrypt(frame)
@@ -503,7 +504,7 @@ class _FTESocketWrapper(object):
         peer that opens a connection, sends a few bytes and falls silent from
         holding a relay worker open indefinitely.
         """
-        timeout = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
         deadline = time.monotonic() + timeout
         previous = self._socket.gettimeout()
         try:
@@ -557,30 +558,37 @@ class _FTESocketWrapper(object):
             hello_bytes = fteproxy.record_layer._unseal(plaintext, 0)
             if hello_bytes is None:
                 continue
-            base = name[:-len('-request')]
-            return self._accept_hello(base, hello_bytes, buffered[length:])
+            return self._accept_hello(name, hello_bytes, buffered[length:])
 
         if len(buffered) > self._MAX_PRE_HANDSHAKE_BYTES:
             raise HandshakeFailedException(
                 'no client hello in the first %d bytes' % len(buffered))
         raise _NeedMoreData()
 
-    def _accept_hello(self, base, hello_bytes, remainder):
+    def _accept_hello(self, matched, hello_bytes, remainder):
         global _last_matched_format
 
         try:
             hello, reply_bytes, keys = fteproxy.handshake.accept_client_hello(
                 hello_bytes, self._server_key, self._server_public,
-                defs=self._defs, formats={base}, replay=_replay_filter)
+                defs=self._defs, formats=fteproxy.defs.base_names(),
+                replay=_replay_filter)
         except fteproxy.handshake.HandshakeError as e:
             raise HandshakeFailedException(str(e))
-        if hello.format != base:
-            # The covertext format and the name inside it are the same fact
-            # stated twice; a disagreement is not a client.
+
+        # The covertext format and the name inside it are the same fact stated
+        # twice, so they have to agree -- but by shape, not by name: two base
+        # names in a definitions file may share a pattern and a length, and
+        # then either one unseals the other's covertext. Comparing the names
+        # would refuse a client that did nothing wrong.
+        base = hello.format
+        request, response = _format_pair(base)
+        if (fteproxy.defs.getRegex(request), fteproxy.defs.getLength(request)) \
+                != (fteproxy.defs.getRegex(matched),
+                    fteproxy.defs.getLength(matched)):
             raise HandshakeFailedException('hello format does not match its '
                                            'covertext format')
 
-        _, response = _format_pair(base)
         response_cipher = _cipher_for(response, self._cover_key, cover=True)
         try:
             self._socket.sendall(
@@ -593,7 +601,7 @@ class _FTESocketWrapper(object):
         self._encoder, self._decoder = _session_channel(
             base, hello.mode, keys, is_client=False)
         self._handshake_done = True
-        _last_matched_format = base + '-request'
+        _last_matched_format = matched
         self._pre_handshake_incoming = b''
         fteproxy.debug('handshake complete: protocol 1, %s, %s'
                        % (base, hello.mode))

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -690,13 +690,23 @@ class _FTESocketWrapper(object):
         a version mismatch, and continuing would mean guessing at the meaning
         of the bytes that follow.
         """
-        self._decoder.push(data)
+        if self._broken:
+            return
         try:
+            self._decoder.push(data)
             records = self._decoder.pop_records()
         except fteproxy.record_layer.UnknownRecordType as e:
             fteproxy.warn('closing connection: %s' % e)
             self._broken = True
             return
+        except fteproxy.record_layer.StreamFailedError:
+            self._broken = True
+            return
+        if self._decoder.failed:
+            fteproxy.warn('closing connection: a record failed authentication '
+                          '(wrong key, a corrupted or replayed stream, or a '
+                          'peer on a different record-layer mode)')
+            self._broken = True
         for record_type, payload in records:
             if record_type == fteproxy.record_layer.DATA:
                 self._incoming_buffer += payload

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "0.4.0"
+__version__ = "1.0.0"
 
 import os
 import sys
@@ -55,7 +55,7 @@ def _make_cipher(pattern, length, key):
     cipher ``encrypt``/``decrypt`` one whole covertext per call; the record
     layer handles stream chunking and framing on top of it.
 
-    Deliberately not cached: since 0.4 every connection derives its own header
+    Deliberately not cached: since 1.0 every connection derives its own header
     keys, so a cache keyed on the key would grow by one entry per connection
     and never hit. ``fte.FTE`` holds only a reference to the (cached) format
     and the key schedule, and costs a couple of microseconds to build.
@@ -84,7 +84,7 @@ def _hybrid_mode():
     transforms every covertext byte into the target format for full-stream
     realism. See ``runtime.fteproxy.record_layer.mode`` in ``fteproxy.conf``.
 
-    Since 0.4 the mode is not a setting both endpoints must match by hand: the
+    Since 1.0 the mode is not a setting both endpoints must match by hand: the
     client puts its choice in the handshake and the server follows. This is
     where the client's choice comes from when the caller does not pass one.
     """
@@ -98,7 +98,7 @@ class _AEADBody:
     means a nonce collision costs only the confidentiality of the colliding
     pair, never authenticity. Each record binds its sequence number into the
     MAC, so a record reordered, dropped, or replayed within its stream fails
-    authentication. Since 0.4 the key is per connection *and* per direction
+    authentication. Since 1.0 the key is per connection *and* per direction
     (``K_c2s_body`` / ``K_s2c_body`` from :mod:`fteproxy.handshake`), so a
     record replayed into another connection or the other direction fails too --
     the cross-stream replay gap SECURITY.md used to document. The encryption

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -54,7 +54,7 @@ DEFAULT_MODE = 'hybrid'
 
 SUBCOMMANDS = ('server', 'client', 'keygen', 'formats')
 
-#: Flags from the pre-0.4 command line. They are recognised only so that a
+#: Flags from the pre-1.0 command line. They are recognised only so that a
 #: script carrying one gets a pointer instead of "unrecognized arguments", and
 #: are never aliased: the destination is chosen on the client now and the
 #: shared key is gone, so a silent alias would run a different topology than
@@ -72,10 +72,10 @@ This program comes with ABSOLUTELY NO WARRANTY. This is free software, and
 you are welcome to redistribute it under certain conditions.""" % FTEPROXY_VERSION
 
 _UPGRADE_POINTER = (
-    "fteproxy: %s was removed in 0.4. The destination is chosen on the client "
+    "fteproxy: %s was removed in 1.0. The destination is chosen on the client "
     "now and the shared key is replaced by a connection string, so the old "
     "flags would run a different topology than you asked for. See 'Upgrading "
-    "to 0.4.0' in the README.")
+    "to 1.0.0' in the README.")
 
 
 class _PrintVersion(argparse.Action):
@@ -249,7 +249,7 @@ def build_parser():
 
 
 def removed_flag(argv):
-    """The first pre-0.4 flag in ``argv``, or None.
+    """The first pre-1.0 flag in ``argv``, or None.
 
     Only the part before a subcommand is scanned, because ``--mode`` means
     something else under ``client``.
@@ -533,7 +533,7 @@ def run_startup_check(args, listener, uri):
             sys.stderr.write(prefix)
         sys.stderr.write('failed: %s\n' % e)
         sys.stderr.write('  (wrong connection string, or the server is not '
-                         'running fteproxy 0.4)\n')
+                         'running fteproxy 1.0)\n')
         sys.stderr.flush()
         return False
     if not args.quiet:

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -30,7 +30,6 @@ connection string can reach a log file.
 
 import argparse
 import logging
-import os
 import signal
 import sys
 import threading
@@ -485,8 +484,8 @@ def do_client(args):
         listeners.append(fteproxy.relay.ForwardListener(
             bind, port, destination=destination, **common))
 
-    if not args.no_check:
-        run_startup_check(args, listeners[0], uri)
+    if not args.no_check and not run_startup_check(args, listeners[0], uri):
+        return EXIT_FAILURE
 
     for listener in listeners:
         try:
@@ -516,25 +515,33 @@ def run_startup_check(args, listener, uri):
 
     On the wire it is an ordinary session start, and it costs one round trip.
     The alternative is a first connection that hangs until a timeout with
-    nothing to say about why.
+    nothing to say about why. Returns False when the check failed, having said
+    so; the caller exits 1.
+
+    Reported here rather than raised, so that the outcome finishes the
+    "checking ..." line the operator is already looking at instead of arriving
+    as a separate log record.
     """
-    where = _render_address(uri.host, uri.port)
+    prefix = 'checking %s ... ' % _render_address(uri.host, uri.port)
     if not args.quiet:
-        sys.stderr.write('checking %s ... ' % where)
+        sys.stderr.write(prefix)
         sys.stderr.flush()
     try:
         format_name, mode = listener.check()
     except Exception as e:
-        if not args.quiet:
-            sys.stderr.write('failed\n')
-        raise StartupError(
-            '%s: %s\n  (wrong connection string, or the server is not running '
-            'fteproxy 0.4)' % (where, e))
+        if args.quiet:
+            sys.stderr.write(prefix)
+        sys.stderr.write('failed: %s\n' % e)
+        sys.stderr.write('  (wrong connection string, or the server is not '
+                         'running fteproxy 0.4)\n')
+        sys.stderr.flush()
+        return False
     if not args.quiet:
         sys.stderr.write('ok (protocol %d, %s, %s)\n'
                          % (fteproxy.handshake.PROTOCOL_VERSION, format_name,
                             mode))
         sys.stderr.flush()
+    return True
 
 
 def _render_address(host, port):

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -74,7 +74,7 @@ conf['runtime.fteproxy.relay.throttle'] = 0.01
 
 
 """How long either end waits for the handshake to complete."""
-conf['runtime.fteproxy.negotiate.timeout'] = 5
+conf['runtime.fteproxy.handshake.timeout'] = 5
 
 
 """Record-layer framing mode.

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -6,7 +6,7 @@ What is left here is what a *library* user might want to change and what has
 no better home: buffer sizes, timeouts, and which definitions file to read.
 Everything that describes one run -- the listen address, the destination, the
 formats, the keys -- comes from the command line or from
-:func:`fteproxy.wrap_socket`, not from here. Until 0.4 those lived in this
+:func:`fteproxy.wrap_socket`, not from here. Until 1.0 those lived in this
 dictionary too, which is why a value that never reached it could stop the
 process working.
 """
@@ -90,7 +90,7 @@ stream is indistinguishable from the protocol: stronger against entropy or
 statistical detectors, but much slower. Turn it on when you want full-stream
 realism and can spend the throughput.
 
-Since 0.4 this is the *client's* default choice, not a setting both endpoints
+Since 1.0 this is the *client's* default choice, not a setting both endpoints
 must match by hand: the client puts its choice in the handshake and the server
 follows."""
 conf['runtime.fteproxy.record_layer.mode'] = 'hybrid'

--- a/fteproxy/config.py
+++ b/fteproxy/config.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """The connection string and the state directory.
 
-A 0.4 client needs one argument, and this is what it holds::
+A 1.0 client needs one argument, and this is what it holds::
 
     fte://<server-id>@<host>:<port>[?format=<base>&mode=<hybrid|format>&defs=<YYYYMMDD>]
 

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -81,6 +81,11 @@ class UnknownRecordType(Exception):
     """
 
 
+class StreamFailedError(Exception):
+    """Data was pushed into a :class:`Decoder` after one of its records
+    failed authentication. The stream cannot resume; close the connection."""
+
+
 def _seal(cipher, message, seq):
     """Encrypt ``message`` into one covertext, random-padded to the format's
     full plaintext capacity and stamped with its stream position ``seq``.
@@ -214,15 +219,39 @@ class Decoder:
         # the header covertext plus the ``body_len`` raw bytes the header carries.
         # Either way a trailing partial record stays buffered.
         self._frame_size = cipher.output_format.max_length
+        # The largest record this decoder is ever asked to hold: one header
+        # covertext plus, in hybrid mode, the largest framed body a header may
+        # announce. After every pop the buffer is shorter than this, so a
+        # stream that fails to authenticate cannot grow the buffer without
+        # bound (see the fail-closed behavior below).
+        self.max_record_bytes = self._frame_size + (
+            body_cipher.max_framed_bytes if body_cipher is not None else 0)
         self._buffer = b''
         self._seq = 0
+        # Set once a record fails to authenticate: nothing later can decode,
+        # since the sequence number cannot advance past the bad record, so the
+        # stream is dead and push refuses further input.
+        self._failed = False
         # Body length from a hybrid header that was decrypted and verified but
         # whose body had not fully arrived. While set, that header is the first
         # ``_frame_size`` bytes of ``_buffer`` (the buffer only grows).
         self._pending_body_len = None
 
+    @property
+    def failed(self):
+        """Whether a record failed to authenticate and the stream is dead."""
+        return self._failed
+
     def push(self, data):
-        """Push data onto the FIFO buffer."""
+        """Push data onto the FIFO buffer.
+
+        Raises :class:`StreamFailedError` once the stream has failed: nothing
+        pushed after a bad record could decode, and buffering it would let a
+        peer that holds the keys grow the buffer without bound.
+        """
+        if self._failed:
+            raise StreamFailedError('data pushed after a record failed to '
+                                    'authenticate')
         if isinstance(data, str):
             data = data.encode('utf-8')
         self._buffer += data
@@ -276,6 +305,8 @@ class Decoder:
         # writing ``self._buffer`` back once. The offset never advances past a
         # record that cannot (yet) be decoded, so the undecodable remainder is
         # preserved.
+        if self._failed:
+            return []
         buffer = self._buffer
         records = []
         offset = 0
@@ -293,6 +324,7 @@ class Decoder:
                 header = buffer[offset:offset + self._frame_size]
                 head = self._decrypt(self._cipher, header)
                 if head is None:
+                    self._failed = True
                     break
                 head = _unseal(head, self._seq)
                 if head is None:
@@ -303,6 +335,7 @@ class Decoder:
                     fteproxy.debug(
                         "fteproxy.record_layer: malformed or out-of-order sealed "
                         "record at seq " + str(self._seq))
+                    self._failed = True
                     break
 
                 if self._body_cipher is None:
@@ -319,6 +352,7 @@ class Decoder:
                     fteproxy.debug(
                         "fteproxy.record_layer: unexpected header width "
                         + str(len(head)))
+                    self._failed = True
                     break
                 body_len = _OVERFLOW_LEN.unpack(head)[0]
                 if body_len > self._body_cipher.max_framed_bytes:
@@ -327,6 +361,7 @@ class Decoder:
                     fteproxy.info(
                         "fteproxy.record_layer: body length " + str(body_len)
                         + " exceeds the record limit")
+                    self._failed = True
                     break
 
             body_start = offset + self._frame_size
@@ -345,12 +380,13 @@ class Decoder:
                 fteproxy.debug(
                     "fteproxy.record_layer: body auth failed at seq "
                     + str(self._seq))
+                self._failed = True
                 break
             self._seq += 1
             offset = body_start + body_len
             records.append(self._split_type(message))
 
-        self._buffer = buffer[offset:]
+        self._buffer = b'' if self._failed else buffer[offset:]
         return records
 
     def pop(self, limit=None):

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -30,7 +30,7 @@ same as they were before types existed.
 
 ``seq`` is the record's position in its stream, counted from 0 by each
 ``Encoder``/``Decoder`` pair, so a record moved, replayed, or dropped within
-a stream is rejected. Since 0.4 each direction of a connection has its own
+a stream is rejected. Since 1.0 each direction of a connection has its own
 header and body keys, derived per connection by :mod:`fteproxy.handshake`, so
 a record cannot be replayed into another stream or the other direction either.
 See SECURITY.md for what is not covered.

--- a/fteproxy/relay.py
+++ b/fteproxy/relay.py
@@ -113,11 +113,12 @@ class Connection:
     the other direction.
     """
 
-    def __init__(self, socket1, socket2):
+    def __init__(self, socket1, socket2, on_close=None):
         self._sockets = (socket1, socket2)
         self._outstanding = 2
         self._lock = threading.Lock()
         self._workers = []
+        self._on_close = on_close
 
     def start(self):
         for source, sink in (self._sockets, self._sockets[::-1]):
@@ -137,6 +138,8 @@ class Connection:
     def close(self):
         for sock in self._sockets:
             fteproxy.network_io.close_socket(sock)
+        if self._on_close is not None:
+            self._on_close(self)
 
     def stop(self):
         for thread in self._workers:
@@ -156,7 +159,11 @@ class listener(threading.Thread):
         self._sock = None
         self._local_ip = local_ip
         self._local_port = local_port
-        self._connections = []
+        # Live connections, so that stop() can tear them down. Entries remove
+        # themselves when both directions end; a long-running server would
+        # otherwise hold one per connection it had ever accepted.
+        self._connections = set()
+        self._connections_lock = threading.Lock()
 
     @property
     def address(self):
@@ -240,9 +247,19 @@ class listener(threading.Thread):
             fteproxy.warn('connection from %s failed: %s' % (_host(addr), e))
             fteproxy.network_io.close_socket(conn)
             return
-        if connection is not None:
-            self._connections.append(connection)
-            connection.start()
+        if connection is None:
+            return
+        with self._connections_lock:
+            if not self._running:
+                # stop() ran while this connection was being set up.
+                connection.close()
+                return
+            self._connections.add(connection)
+        connection.start()
+
+    def _forget(self, connection):
+        with self._connections_lock:
+            self._connections.discard(connection)
 
     def serve(self, conn, addr):
         """Set one accepted connection up and return a :class:`Connection`,
@@ -254,9 +271,11 @@ class listener(threading.Thread):
         self._running = False
         if self._sock is not None:
             fteproxy.network_io.close_socket(self._sock)
-        for connection in self._connections:
+        with self._connections_lock:
+            open_connections = list(self._connections)
+            self._connections.clear()
+        for connection in open_connections:
             connection.stop()
-        self._connections = []
 
 
 def _host(addr):
@@ -293,7 +312,7 @@ class ServerListener(listener):
             fteproxy.network_io.close_socket(conn)
             return None
 
-        timeout = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
         try:
             destination = tunnel.wait_open(timeout=timeout)
         except (fteproxy.ChannelNotReadyException,
@@ -328,7 +347,7 @@ class ServerListener(listener):
         fteproxy.debug('%s -> %s:%d' % (_host(addr), host, port))
         upstream.settimeout(
             fteproxy.conf.getValue('runtime.fteproxy.relay.socket_timeout'))
-        return Connection(tunnel, upstream)
+        return Connection(tunnel, upstream, on_close=self._forget)
 
 
 # --------------------------------------------------------------------------- #
@@ -356,7 +375,7 @@ class _ClientListener(listener):
         """Open and handshake one tunnel to the fteproxy server."""
         raw = socket.create_connection(
             self._server_address,
-            timeout=fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout'))
+            timeout=fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout'))
         raw.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         tunnel = fteproxy.wrap_socket(raw, server_id=self._server_id,
                                       format=self._format, mode=self._mode,
@@ -420,7 +439,7 @@ class ForwardListener(_ClientListener):
                              fteproxy.stream.status_name(e.status)))
             fteproxy.network_io.close_socket(conn)
             return None
-        return Connection(conn, tunnel)
+        return Connection(conn, tunnel, on_close=self._forget)
 
 
 class SocksListener(_ClientListener):
@@ -455,7 +474,7 @@ class SocksListener(_ClientListener):
             fteproxy.network_io.close_socket(conn)
             fteproxy.network_io.close_socket(tunnel)
             return None
-        return Connection(conn, tunnel)
+        return Connection(conn, tunnel, on_close=self._forget)
 
     @staticmethod
     def _fail(conn, status):

--- a/fteproxy/socks.py
+++ b/fteproxy/socks.py
@@ -13,8 +13,6 @@ a request crosses the tunnel without being re-encoded and the server's answer
 maps straight onto the SOCKS reply.
 """
 
-import socket
-
 import fteproxy.stream
 
 

--- a/fteproxy/stream.py
+++ b/fteproxy/stream.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Stream messages and destination policy.
 
-A 0.4 tunnel carries the destination in band: the client sends an
+A 1.0 tunnel carries the destination in band: the client sends an
 :data:`~fteproxy.record_layer.OPEN` record naming where it wants to go, and the
 server answers with an :data:`~fteproxy.record_layer.OPEN_RESULT` carrying a
 status. The server therefore needs no forward address of its own, and the

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -328,14 +328,14 @@ class TestParser:
 
 
 class TestRemovedFlags:
-    """Every pre-0.4 flag is recognised only to point at the upgrade notes."""
+    """Every pre-1.0 flag is recognised only to point at the upgrade notes."""
 
     @pytest.mark.parametrize('flag', fteproxy.cli.REMOVED_FLAGS)
     def test_each_removed_flag(self, flag, capsys):
         assert fteproxy.cli.main([flag, 'whatever']) == fteproxy.cli.EXIT_USAGE
         err = capsys.readouterr().err
         assert flag in err
-        assert 'Upgrading to 0.4.0' in err
+        assert 'Upgrading to 1.0.0' in err
 
     def test_flag_with_an_equals_sign(self, capsys):
         assert fteproxy.cli.main(['--key=deadbeef']) == fteproxy.cli.EXIT_USAGE
@@ -465,7 +465,7 @@ class TestClientStartup:
         assert status == fteproxy.cli.EXIT_FAILURE
         captured = capsys.readouterr()
         assert 'checking 127.0.0.1:%d' % port in captured.err
-        assert 'not running fteproxy 0.4' in captured.err
+        assert 'not running fteproxy 1.0' in captured.err
 
     def test_no_uri_anywhere_is_a_usage_error(self, tmp_path, monkeypatch):
         monkeypatch.delenv('FTEPROXY_URI', raising=False)

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -7,11 +7,7 @@ Verifies that each format can successfully encode and decode data.
 """
 
 import pytest
-import json
-import os
-import re
 
-import fte
 import fteproxy
 from fteproxy.tests import conftest
 import fteproxy.conf

--- a/fteproxy/tests/test_handshake.py
+++ b/fteproxy/tests/test_handshake.py
@@ -5,7 +5,7 @@
 The vectors in ``vectors/handshake_v1.json`` pin the wire format and the key
 schedule. They were generated once from fixed seeds; if a change to
 :mod:`fteproxy.handshake` breaks them, that change breaks interoperation with
-every deployed 0.4 peer, and the version must move rather than the vectors.
+every deployed 1.0 peer, and the version must move rather than the vectors.
 """
 
 import json

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -271,14 +271,14 @@ class TestWrapSocket:
         server = threading.Thread(target=serve)
         server.start()
 
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 1)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 1)
         client = fteproxy.wrap_socket(socket.socket(), server_id=other_public)
         try:
             with pytest.raises(fteproxy.HandshakeFailedException):
                 client.connect(('127.0.0.1', port))
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', previous)
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', previous)
             client.close()
             server.join(timeout=15)
             listener.close()

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -162,7 +162,7 @@ class TestCipherCaching:
 
 
 class TestWrapSocket:
-    """End-to-end use of the 0.4 wrap_socket."""
+    """End-to-end use of the 1.0 wrap_socket."""
 
     @staticmethod
     def _echo_server(port, private, received, ready):

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -257,7 +257,9 @@ class TestHybridRecordLayer:
         with caplog.at_level(logging.INFO, logger='fteproxy'):
             assert decoder.pop() == b''
         assert 'exceeds the record limit' in caplog.text
-        assert len(decoder._buffer) == len(header) + 64
+        # Fail-closed: the bad record marks the stream dead and drops the buffer.
+        assert decoder.failed
+        assert decoder._buffer == b''
 
     def test_reordered_record_is_rejected(self):
         """A record moved out of its stream position fails the body auth."""
@@ -303,7 +305,9 @@ class TestFormatModeRecordLayer:
         replayed = self._pair()[1]
         replayed.push(r0 + r0)
         assert replayed.pop() == b'first'          # the replay is refused
-        assert replayed._buffer == r0
+        # Fail-closed: the duplicate marks the stream dead and drops the buffer.
+        assert replayed.failed
+        assert replayed._buffer == b''
 
     def test_multi_record_message_roundtrips(self):
         encoder, decoder = self._pair()
@@ -429,3 +433,58 @@ class TestRecordTypes:
         decoder.push(encoder.encode(fteproxy.record_layer.OPEN, b'dest'))
         with pytest.raises(fteproxy.record_layer.UnknownRecordType):
             decoder.pop()
+
+
+class TestDecoderFailsClosed:
+    """A stream that fails to authenticate is closed, not buffered.
+
+    Ports the hardening from the pre-1.0 review (was PR #235 against the old
+    negotiation code) onto the 1.0 record layer: after a bad record the decoder
+    fails closed, drops its buffer, and refuses further input, so a peer that
+    holds the keys cannot grow the server's buffer without bound.
+    """
+
+    def _pair(self, hybrid):
+        key = conftest.TEST_KEY
+        regex = fteproxy.defs.getRegex('manual-http-request')
+        length = fteproxy.defs.getLength('manual-http-request')
+        cipher = fteproxy._make_cipher(regex, length, key)
+        body = fteproxy._make_body_cipher(key) if hybrid else None
+        enc = fteproxy.record_layer.Encoder(cipher=cipher, body_cipher=body)
+        dec = fteproxy.record_layer.Decoder(cipher=cipher, body_cipher=body)
+        return enc, dec
+
+    @pytest.mark.parametrize('hybrid', [False, True])
+    def test_good_then_garbage_fails_closed(self, hybrid):
+        enc, dec = self._pair(hybrid)
+        enc.push(b'hello')
+        dec.push(enc.pop())
+        assert dec.pop() == b'hello'
+        assert not dec.failed
+        dec.push(b'\x00' * dec._frame_size)
+        assert dec.pop_records() == []
+        assert dec.failed
+        assert dec._buffer == b''
+        with pytest.raises(fteproxy.record_layer.StreamFailedError):
+            dec.push(b'more')
+
+    @pytest.mark.parametrize('hybrid', [False, True])
+    def test_good_records_before_bad_are_delivered(self, hybrid):
+        enc, dec = self._pair(hybrid)
+        enc.push(b'first')
+        good = enc.pop()
+        dec.push(good + b'\x00' * dec._frame_size)
+        assert dec.pop() == b'first'
+        assert dec.failed
+
+    @pytest.mark.parametrize('hybrid', [False, True])
+    def test_garbage_stream_never_accumulates(self, hybrid):
+        _enc, dec = self._pair(hybrid)
+        dec.push(b'\x00' * dec._frame_size)
+        assert dec.pop_records() == []
+        assert dec.failed
+        # The buffer is dropped and further input is refused, so a flood of
+        # garbage cannot grow it.
+        assert len(dec._buffer) < dec.max_record_bytes
+        with pytest.raises(fteproxy.record_layer.StreamFailedError):
+            dec.push(b'\x00' * (16 * dec._frame_size))

--- a/fteproxy/tests/test_relay.py
+++ b/fteproxy/tests/test_relay.py
@@ -2,13 +2,12 @@
 # -*- coding: utf-8 -*-
 """End-to-end relay tests: SOCKS5 and ``-L`` forwards through a real tunnel.
 
-These build the listeners with the library API rather than the command line,
-which lands in PR4. Everything runs in one process on ephemeral ports, so the
-file can run alongside anything else.
+These build the listeners with the library API rather than the command line;
+``test_system.py`` covers the command line. Everything runs in one process on
+ephemeral ports, so this file can run alongside anything else.
 """
 
 import socket
-import struct
 import threading
 import time
 
@@ -369,8 +368,8 @@ class TestServerRejection:
         monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.1)
         tunnel = tunnel_factory()
         _other_private, other_public = fteproxy.generate_server_key()
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 1)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 1)
         try:
             client = fteproxy.wrap_socket(socket.socket(),
                                           server_id=other_public)
@@ -378,12 +377,12 @@ class TestServerRejection:
                 client.connect(tunnel.address)
             client.close()
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout',
                                    previous)
 
     def test_a_plain_tcp_probe_gets_nothing(self, tunnel_factory):
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 1)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 1)
         try:
             tunnel = tunnel_factory()
             sock = socket.create_connection(tunnel.address, timeout=15)
@@ -394,7 +393,7 @@ class TestServerRejection:
             finally:
                 sock.close()
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout',
                                    previous)
 
 
@@ -411,11 +410,32 @@ class TestStartupCheck:
         _other_private, other_public = fteproxy.generate_server_key()
         listener = fteproxy.relay.ForwardListener(
             LOCAL, 0, tunnel.address, other_public, destination=(LOCAL, 1))
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 1)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 1)
         try:
             with pytest.raises(fteproxy.HandshakeFailedException):
                 listener.check()
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout',
                                    previous)
+
+
+class TestConnectionBookkeeping:
+    """A long-running listener must not hold every connection it ever saw."""
+
+    def test_finished_connections_are_forgotten(self, echo, tunnel_factory):
+        tunnel = tunnel_factory(
+            rules=fteproxy.stream.AllowRules(['%s:%d' % (LOCAL, echo.port)]))
+        listener = tunnel.forward((LOCAL, echo.port))
+        for _ in range(5):
+            sock = socket.create_connection(listener.address, timeout=15)
+            sock.settimeout(15)
+            try:
+                sock.sendall(b'ping')
+                assert sock.recv(4096) == b'ping'
+            finally:
+                sock.close()
+        deadline = time.monotonic() + 15
+        while listener._connections and time.monotonic() < deadline:
+            time.sleep(0.1)
+        assert listener._connections == set()

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -323,7 +323,7 @@ class TestServerBuffersBeforeTheHandshake:
 
 
 class TestPreProtocolClient:
-    """A client speaking the pre-0.4 shared-key negotiation gets no reply.
+    """A client speaking the pre-1.0 shared-key negotiation gets no reply.
 
     On master the first record was a 64-byte cell sealed under a static shared
     key, with no version, no keypair and no epoch. There is no compatibility

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -167,8 +167,8 @@ class TestServerRejectPath:
         """A hello sealed for a different server never decodes here, so the
         server waits out its handshake deadline and then discards."""
         monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 0.2)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 0.2)
         try:
             _other_private, other_public = fteproxy.generate_server_key()
             driver = self._hello_for(server_public=other_public)
@@ -180,7 +180,7 @@ class TestServerRejectPath:
             assert server.recv(65536) == b''
             assert fake.sent == b''
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout',
                                    previous)
 
     def test_reject_discards_for_a_while_before_closing(self, monkeypatch):
@@ -338,8 +338,8 @@ class TestPreProtocolClient:
         import logging
 
         monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
-        previous = fteproxy.conf.getValue('runtime.fteproxy.negotiate.timeout')
-        fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout', 0.2)
+        previous = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout', 0.2)
         try:
             cipher = fteproxy._make_cipher(
                 fteproxy.defs.getRegex(FORMAT + '-request'),
@@ -352,10 +352,57 @@ class TestPreProtocolClient:
             with caplog.at_level(logging.DEBUG, logger='fteproxy'):
                 assert server.recv(65536) == b''
         finally:
-            fteproxy.conf.setValue('runtime.fteproxy.negotiate.timeout',
+            fteproxy.conf.setValue('runtime.fteproxy.handshake.timeout',
                                    previous)
         assert fake.sent == b''
         rejections = [record for record in caplog.records
                       if 'rejecting handshake without reply' in record.message]
         assert len(rejections) == 1
         assert rejections[0].levelno == logging.DEBUG
+
+
+class TestFormatAgreement:
+    """The covertext format and the name inside the hello must agree."""
+
+    def _sealed(self, covertext_format, declared_format):
+        """A hello sealed as ``covertext_format`` but naming ``declared_format``."""
+        cover = fteproxy.handshake.cover_key(SERVER_PUBLIC)
+        driver = fteproxy.handshake.ClientHandshake(
+            server_public=SERVER_PUBLIC, format=declared_format, mode=MODE,
+            defs=int(fteproxy.conf.getValue('fteproxy.defs.release')))
+        cipher = fteproxy._cipher_for(covertext_format + '-request', cover,
+                                      cover=True)
+        return fteproxy.record_layer._seal(cipher, driver.hello_bytes, 0)
+
+    def test_a_mismatched_name_gets_no_reply(self, monkeypatch):
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        fake = FakeSocket([self._sealed('manual-http', 'words')])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b''
+
+    def test_an_unknown_name_gets_no_reply(self, monkeypatch):
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
+        fake = FakeSocket([self._sealed('manual-http', 'no-such-format')])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b''
+
+    def test_two_names_sharing_a_pattern_both_work(self, monkeypatch):
+        """A definitions file may give two base names the same pattern and
+        length; then either one unseals the other's covertext, and the name
+        inside the hello is what decides."""
+        definitions = dict(fteproxy.defs.load_definitions())
+        pattern = fteproxy.defs.getRegex('manual-http-request')
+        response = fteproxy.defs.getRegex('manual-http-response')
+        definitions['twin-request'] = {'regex': pattern}
+        definitions['twin-response'] = {'regex': response}
+        monkeypatch.setattr(fteproxy.defs, '_definitions', definitions)
+        monkeypatch.setattr(fteproxy, '_last_matched_format',
+                            'manual-http-request')
+
+        fake = FakeSocket([self._sealed('manual-http', 'twin')])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        server.handshake()
+        assert server.negotiated_format == 'twin'
+        assert fake.sent, 'the server answered'

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -379,7 +379,7 @@ class TestCLI:
         result = run_cli([flag, 'value'], timeout=30)
         assert result.returncode == 2
         assert flag in result.stderr
-        assert 'Upgrading to 0.4.0' in result.stderr
+        assert 'Upgrading to 1.0.0' in result.stderr
 
     def test_an_unknown_format_exits_1(self, tmp_path):
         _private, public = fteproxy.generate_server_key()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "Kevin P. Dyer", email = "kpdyer@gmail.com"}
 ]
-keywords = ["fte", "encryption", "proxy", "censorship", "privacy"]
+keywords = ["fte", "encryption", "proxy", "censorship", "privacy", "socks5", "tunnel"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
### PR5: docs, examples, release notes

Implements section 5 / PR5 of docs/plan-0.4.md, plus three corrections found
while checking that the docs describe what the code does.

Documentation
- README.md: Usage rewritten around the two commands and the connection
  string, with the section 1 transcript verbatim (including the failure case
  and the no-argument same-host case). New options table by subcommand, a
  section on what a server will dial, one on formats and modes, the keypair
  and connection-string model, and the new Python API. "Upgrading to 0.4.0"
  now covers the wire break, the new command line, the topology change, the
  key model, and -L as the translation of the old fixed-destination setup.
- PYPI_README.md mirrors the quick start.
- SECURITY.md: "The key" is replaced by the server keypair, what the
  connection string authorises, the handshake and its test vectors,
  per-connection per-direction keys, the replay window and filter, what a
  failed handshake looks like from outside, the allow-rule default, and the
  redaction filter. The cross-stream replay limitation and "No protocol-version
  handshake" are gone, because both are.
- PERFORMANCE.md: the improvements list gains the split cipher cache and the
  handshake moving off the relay workers, and lever #1 records that the
  obstacle PERFORMANCE.md named for a loop rework -- the negotiation racing
  between the two workers -- is now removed, leaving only the GIL convoy.
- docs/release-notes-0.4.0.md (new): breaking changes, what is new, upgrade
  steps. The plan asks for release notes without naming a file; this sits
  beside the plan and can be pasted into a GitHub release. MANIFEST.in ships
  docs/*.md in the sdist, and pyproject gains socks5/tunnel keywords.

Examples
- The shell examples become pass-through wrappers or short scripts on the new
  command line: basic/ passes its arguments to `fteproxy server`/`client`,
  netcat/ uses a temporary state directory with `--allow` and a `-L` forward,
  integration/ssh_tunnel.sh publishes sshd with `--allow 127.0.0.1:22` and
  forwards with `-L 2222:127.0.0.1:22`, and integration/web_proxy.sh drops the
  "run tinyproxy on the server" story for the built-in SOCKS5 listener.
- Every README under examples/ is updated: base format names and
  `fteproxy formats` instead of two format flags, the keypair instead of a
  shared key, and wrap_socket snippets matching the API the Python examples
  actually use. The topology diagrams no longer show a server with a fixed
  forward address.

Corrections found while writing the above
- The server matched the format name in the hello against the name of the
  covertext format that unsealed it. Two base names in a definitions file may
  share a pattern and a length -- none of the shipped ones do, but a custom
  file can -- and then either unseals the other's covertext and a legitimate
  client was rejected. The names are now compared by shape: the hello's
  declared base decides the session, and its request format must have the same
  pattern and length as the one that matched.
- `relay.listener` appended every connection to a list and never removed one,
  so a long-running server held an entry per connection it had ever accepted.
  Connections now remove themselves once both directions have ended.
- The client's startup check reports its own failure, finishing the
  "checking ... " line the operator is looking at, instead of raising and
  arriving as a separate ERROR record after a bare "failed".
- Tidy-ups: the `runtime.fteproxy.negotiate.timeout` config key is now
  `runtime.fteproxy.handshake.timeout` (there is no negotiation any more), and
  unused imports are gone.

Verified by hand on one host: the plan's section 1 transcript end to end
(`fteproxy server`, then `fteproxy client` with no arguments, then
`curl --socks5-hostname` through it), a `-L` forward, `-D` and `-L` together,
a definitions release carried in the URI and a client that disagrees about it,
and the netcat example. 489 tests pass.

### Record layer: fail closed when a record does not authenticate

Ports the decoder hardening from the pre-1.0 review (PR #235, written
against the old negotiation code that this branch replaced) onto the 1.0
record layer.

Before, Decoder.pop_records broke and kept the buffer on any record that
failed to authenticate (bad header, unseal mismatch, wrong header width,
oversized announced body, body MAC failure). The sequence number cannot
advance past a bad record, so nothing later could ever decode, yet a peer
holding the session keys could keep pushing bytes and grow the buffer
without bound. (The unauthenticated case PR #235 measured is already
bounded on this branch by the handshake's 64 KiB pre-handshake cap.)

Now the first non-authenticating record marks the Decoder failed, drops
its buffer, and makes push raise StreamFailedError; records that decoded
before it are still returned. The socket wrapper treats a failed decoder
like an unknown record type: it delivers what decoded, marks the
connection broken, and reports EOF on the next recv so the relay closes
it. Incomplete-but-valid records (a partial frame, a body still arriving)
are unaffected and still wait for more data. The server's first-record
scan is untouched: it unseals with cipher.decrypt directly, not through a
Decoder.

record_layer.Decoder gains .failed and .max_record_bytes; between pops the
buffer now holds less than one record.

### Rename the release to 1.0.0

This redesign replaces the wire format, the command line, the topology and
the key model at once, so it is a 1.0, not a 0.4 point release. No 0.4.0 was
ever cut (the latest published release is 0.3.2), so nothing that shipped is
renamed out from under anyone.

- __version__ -> "1.0.0".
- User-facing version strings move to 1.0: the "Upgrading to 1.0.0" section
  and its anchor, the pre-1.0 flag rejection message, the client startup-check
  message, and the SECURITY.md supported-versions table (1.0.x).
- docs/plan-0.4.md -> docs/plan-1.0.md and docs/release-notes-0.4.0.md ->
  docs/release-notes-1.0.0.md, with their fteproxy-version references updated.
- Behavioral "since 0.4" notes in the code that describe this redesign now say
  "since 1.0"; references to libfte 0.4 and to the historical 0.3 line are left
  as they are, since those version numbers did not change.
- Tests that assert the version-bearing strings are updated with them.

libfte stays pinned at fte>=0.4.0,<0.5.0; only fteproxy's own version moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
