### PR TITLE
F1-F3: http, ftp and smtp formats

### DIFF
--- a/fteproxy/defs/parts/ftp.json
+++ b/fteproxy/defs/parts/ftp.json
@@ -1,0 +1,20 @@
+{
+  "ftp-request": {
+    "regex": "^((USER|PASS|CWD|RETR|STOR|LIST) [a-zA-Z0-9._@/-]+|TYPE [AI]|PASV|QUIT)\r\n$",
+    "length": 256,
+    "port": [21],
+    "role": "request",
+    "mode_hint": "format",
+    "default": false,
+    "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated"
+  },
+  "ftp-response": {
+    "regex": "^(220|230|331|250|150|226|550) [a-zA-Z0-9 .,:()/-]+\r\n$",
+    "length": 256,
+    "port": [21],
+    "role": "response",
+    "mode_hint": "format",
+    "default": false,
+    "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated"
+  }
+}

--- a/fteproxy/defs/parts/http.json
+++ b/fteproxy/defs/parts/http.json
@@ -1,0 +1,20 @@
+{
+  "http-request": {
+    "regex": "^(GET|POST|HEAD) /[a-zA-Z0-9/._?=&%-]* HTTP/1\\.1\r\nHost: [a-z0-9.-]+\r\nUser-Agent: Mozilla/5\\.0 \\([a-zA-Z0-9;: .()/_-]+\\)\r\nAccept: [a-zA-Z0-9/*,;= .+-]+\r\nAccept-Language: [a-z,;=0-9. -]+\r\n\r\n$",
+    "length": 512,
+    "port": [80, 8080, 8000],
+    "role": "request",
+    "mode_hint": "hybrid",
+    "default": true,
+    "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers"
+  },
+  "http-response": {
+    "regex": "^HTTP/1\\.1 (200 OK|302 Found|404 Not Found)\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: [0-9]+\r\nServer: [a-zA-Z0-9/. ()_-]+\r\n\r\n[a-zA-Z0-9/+= \r\n-]*$",
+    "length": 512,
+    "port": [80, 8080, 8000],
+    "role": "response",
+    "mode_hint": "hybrid",
+    "default": true,
+    "description": "HTTP/1.1 200/302/404 response with headers and a body"
+  }
+}

--- a/fteproxy/defs/parts/smtp.json
+++ b/fteproxy/defs/parts/smtp.json
@@ -1,0 +1,26 @@
+{
+  "smtp-request": {
+    "regex": "^(EHLO [a-z0-9.-]+|HELO [a-z0-9.-]+|MAIL FROM:<[a-z0-9._%+-]+@[a-z0-9.-]+>|RCPT TO:<[a-z0-9._%+-]+@[a-z0-9.-]+>|VRFY [a-z0-9._%+-]+|DATA|RSET|NOOP|QUIT)\r\n$",
+    "length": 320,
+    "port": [
+      25,
+      587
+    ],
+    "role": "request",
+    "mode_hint": "format",
+    "default": false,
+    "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated"
+  },
+  "smtp-response": {
+    "regex": "^((220|250|354|421|550) |250-)[a-zA-Z0-9 .,;:()<>@_-]+\r\n$",
+    "length": 256,
+    "port": [
+      25,
+      587
+    ],
+    "role": "response",
+    "mode_hint": "format",
+    "default": false,
+    "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form"
+  }
+}

--- a/fteproxy/tests/realism/ftp.py
+++ b/fteproxy/tests/realism/ftp.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Realism check for the ``ftp`` control-channel format (phase F-ftp).
+
+FTP's control channel (RFC 959) is a cleartext line protocol: the client sends
+a command -- an uppercase verb, optionally a space and an argument, terminated
+by CRLF -- and the server answers with a three-digit reply code, a space, some
+human-readable text, and CRLF. :func:`check` judges a single sealed covertext
+the way a DPI box scanning port 21 would: it insists on exactly one CRLF-ended
+line whose shape is a known FTP command *or* a known reply, rejecting anything
+else.
+
+This is a strict, self-contained grammar check. It shares no code with the
+other protocol realism modules and does not import the ``parts/ftp.json`` regex
+-- it re-derives the structure by hand so a covertext that only *happens* to
+match the sampling regex still has to stand on its own as a well-formed FTP
+message.
+"""
+
+
+class FTPRealismError(Exception):
+    """A covertext is not a structurally valid FTP control-channel message."""
+
+
+# Commands that take a (non-empty) argument on the control channel.
+_ARG_VERBS = frozenset((b'USER', b'PASS', b'CWD', b'RETR', b'STOR', b'LIST'))
+
+# Commands that stand alone with no argument.
+_BARE_VERBS = frozenset((b'PASV', b'QUIT'))
+
+# The reply codes this format models, as byte strings.
+_REPLY_CODES = frozenset((b'220', b'230', b'331', b'250',
+                          b'150', b'226', b'550'))
+
+# Characters allowed in a command argument (usernames, paths, filenames):
+# ASCII letters and digits plus a small set of path/name punctuation. No space
+# -- an FTP argument is a single token.
+_ARG_CHARS = frozenset(
+    b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._@/-')
+
+# Characters allowed in reply text: printable ASCII words with spacing and a
+# little punctuation. No control bytes.
+_TEXT_CHARS = frozenset(
+    b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,:()/-')
+
+
+def _fail(reason, covertext):
+    raise FTPRealismError('%s: %r' % (reason, covertext[:64]))
+
+
+def check(covertext):
+    """Raise :class:`FTPRealismError` unless ``covertext`` is a valid FTP line.
+
+    Accepts either a client command or a server reply; returns ``None`` on a
+    structurally valid message.
+    """
+    if not isinstance(covertext, (bytes, bytearray)):
+        _fail('covertext is not bytes', covertext)
+    covertext = bytes(covertext)
+
+    if not covertext.endswith(b'\r\n'):
+        _fail('does not end with CRLF', covertext)
+    line = covertext[:-2]
+
+    # Exactly one line: no embedded CR or LF anywhere in the payload.
+    if b'\r' in line or b'\n' in line:
+        _fail('contains an embedded CR or LF', covertext)
+    if not line:
+        _fail('empty line', covertext)
+
+    # A reply begins with three ASCII digits; a command begins with a letter.
+    first = line[0:1]
+    if first.isdigit():
+        _check_reply(line, covertext)
+    else:
+        _check_command(line, covertext)
+
+
+def _check_command(line, covertext):
+    """A client command: a bare verb, or a verb SP non-empty-token argument."""
+    if b' ' in line:
+        verb, _, arg = line.partition(b' ')
+        if verb == b'TYPE':
+            # TYPE takes exactly one representation code.
+            if arg not in (b'A', b'I'):
+                _fail('TYPE argument is not A or I', covertext)
+            return
+        if verb not in _ARG_VERBS:
+            _fail('unknown command verb %r' % verb, covertext)
+        if not arg:
+            _fail('%r command with empty argument' % verb, covertext)
+        if b' ' in arg:
+            _fail('%r argument contains a space' % verb, covertext)
+        if any(byte not in _ARG_CHARS for byte in arg):
+            _fail('%r argument has a disallowed byte' % verb, covertext)
+        return
+
+    # No space: only the argument-less verbs are valid on their own.
+    if line not in _BARE_VERBS:
+        _fail('bare command is not PASV or QUIT', covertext)
+
+
+def _check_reply(line, covertext):
+    """A server reply: a known 3-digit code, a space, non-empty text."""
+    if len(line) < 5:
+        _fail('reply too short for "code SP text"', covertext)
+    code = line[0:3]
+    if code not in _REPLY_CODES:
+        _fail('unknown reply code %r' % code, covertext)
+    if line[3:4] != b' ':
+        _fail('reply code not followed by a single space', covertext)
+    text = line[4:]
+    if not text:
+        _fail('reply has empty text', covertext)
+    if any(byte not in _TEXT_CHARS for byte in text):
+        _fail('reply text has a disallowed byte', covertext)

--- a/fteproxy/tests/realism/http.py
+++ b/fteproxy/tests/realism/http.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Realism check for the ``http`` format, judged by an independent parser.
+
+``check(covertext)`` raises if ``covertext`` is not a structurally valid HTTP/1.1
+message. To avoid grading fteproxy's own regex with a mirror of itself, the
+judgement is delegated to the standard library's HTTP machinery -- the same code
+a real client or DPI stack would lean on:
+
+* a **request** covertext has its request line parsed by
+  :class:`http.server.BaseHTTPRequestHandler` (the ``parse_request`` state
+  machine) and its header block parsed by :mod:`email.parser`;
+* a **response** covertext is parsed by :class:`http.client.HTTPResponse` driven
+  over a fake in-memory socket -- the exact class ``http.client`` uses to read a
+  real server's reply.
+
+A message that these parsers reject, or that parses into a shape outside the
+format's design (an unexpected method, version, status, or a missing mandatory
+header), fails the check.
+"""
+
+import email.parser
+import http.client
+import http.server
+import io
+
+
+_METHODS = ('GET', 'POST', 'HEAD')
+_STATUS = {200: 'OK', 302: 'Found', 404: 'Not Found'}
+_REQUEST_HEADERS = ('Host', 'User-Agent', 'Accept', 'Accept-Language')
+_RESPONSE_HEADERS = ('Content-Type', 'Content-Length', 'Server')
+
+
+class _RequestLineParser(http.server.BaseHTTPRequestHandler):
+    """Parse a single request line with the stdlib request state machine.
+
+    ``BaseHTTPRequestHandler.parse_request`` reads ``self.raw_requestline`` and
+    fills ``command`` / ``path`` / ``request_version``; on a malformed line it
+    calls ``send_error``, which we capture instead of writing to a socket.
+    """
+
+    def __init__(self, request_line):
+        self.rfile = io.BytesIO(b'')
+        self.wfile = io.BytesIO()
+        self.raw_requestline = request_line
+        self.error_code = None
+        self.error_message = None
+        self.request_version = ''
+        self.command = ''
+        self.path = ''
+        self.parsed_ok = self.parse_request()
+
+    def send_error(self, code, message=None, explain=None):
+        self.error_code = code
+        self.error_message = message
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+class _FakeSocket:
+    """A read-only socket whose ``makefile`` hands back the covertext bytes."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def makefile(self, *args, **kwargs):
+        return io.BytesIO(self._data)
+
+
+def _check_request(covertext):
+    request_line, separator, remainder = covertext.partition(b'\r\n')
+    if not separator:
+        raise ValueError('http request: no CRLF after the request line')
+
+    parser = _RequestLineParser(request_line + b'\r\n')
+    if not parser.parsed_ok or parser.error_code is not None:
+        raise ValueError('http request: unparsable request line %r (error %r)'
+                         % (request_line, parser.error_code))
+    if parser.command not in _METHODS:
+        raise ValueError('http request: unexpected method %r' % parser.command)
+    if parser.request_version != 'HTTP/1.1':
+        raise ValueError('http request: version %r is not HTTP/1.1'
+                         % parser.request_version)
+    if not parser.path.startswith('/'):
+        raise ValueError('http request: path %r is not absolute' % parser.path)
+
+    # The header block runs from just after the request line to the blank line;
+    # email.parser reads the headers and treats anything past the blank line as
+    # the (empty) body.
+    headers = email.parser.BytesParser().parsebytes(remainder)
+    if headers.defects:
+        raise ValueError('http request: malformed header block: %r'
+                         % headers.defects)
+    for name in _REQUEST_HEADERS:
+        if headers.get(name) is None:
+            raise ValueError('http request: missing %s header' % name)
+
+
+def _check_response(covertext):
+    response = http.client.HTTPResponse(_FakeSocket(covertext))
+    try:
+        response.begin()
+    except Exception as error:
+        raise ValueError('http response: unparsable: %s' % error)
+
+    if response.version != 11:
+        raise ValueError('http response: version %r is not HTTP/1.1'
+                         % response.version)
+    if response.status not in _STATUS:
+        raise ValueError('http response: unexpected status %r' % response.status)
+    if response.reason != _STATUS[response.status]:
+        raise ValueError('http response: status %d has reason %r, not %r'
+                         % (response.status, response.reason,
+                            _STATUS[response.status]))
+    for name in _RESPONSE_HEADERS:
+        if response.getheader(name) is None:
+            raise ValueError('http response: missing %s header' % name)
+    # Content-Length must be a well-formed decimal count.
+    length = response.getheader('Content-Length')
+    if not length.isdigit():
+        raise ValueError('http response: Content-Length %r is not numeric'
+                         % length)
+
+
+def check(covertext):
+    """Raise if ``covertext`` is not a structurally valid HTTP/1.1 message."""
+    if not isinstance(covertext, (bytes, bytearray)):
+        raise TypeError('covertext must be bytes, got %r' % type(covertext))
+    covertext = bytes(covertext)
+    if covertext.startswith(b'HTTP/'):
+        _check_response(covertext)
+    else:
+        _check_request(covertext)

--- a/fteproxy/tests/realism/smtp.py
+++ b/fteproxy/tests/realism/smtp.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Structural realism check for the ``smtp`` format (phase F5).
+
+SMTP is a cleartext, line-oriented protocol: a client sends command lines
+(``EHLO host``, ``MAIL FROM:<addr>``, ``RCPT TO:<addr>``, ``DATA``, ``QUIT``,
+...) and a server answers with reply lines (``250 OK``, ``220 host ESMTP``,
+``354 ...``, ``550 ...``), every line terminated by CRLF (RFC 5321). One sealed
+covertext of the ``smtp-request``/``smtp-response`` formats is exactly one such
+line.
+
+:func:`check` judges a covertext with a hand-written grammar, independent of the
+format's own regex (the format regex must not be imported here), and accepts a
+line that is a valid client command *or* a valid server reply, since the batch a
+test feeds it mixes both roles. It raises on anything that is not a
+structurally valid SMTP line.
+"""
+
+
+class SMTPRealismError(Exception):
+    """A covertext is not a structurally valid SMTP command or reply line."""
+
+
+# Character classes, spelled out as byte sets so the check owns its own grammar
+# rather than leaning on the format regex.
+_DIGITS = set(b'0123456789')
+_LOWER = set(b'abcdefghijklmnopqrstuvwxyz')
+_UPPER = set(b'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+_LETTERS = _LOWER | _UPPER
+# Host label bytes: lowercase letters, digits, dot and hyphen (RFC 1035 style).
+_HOST = _LOWER | _DIGITS | set(b'.-')
+# Local-part bytes of an address: letters, digits and the common local
+# specials SMTP addresses use in practice.
+_LOCAL = _LOWER | _DIGITS | set(b'._%+-')
+# Free-text reply bytes: printable ASCII an SMTP reply line uses, minus CR/LF.
+_TEXT = _LETTERS | _DIGITS | set(b' .,;:()<>@_-')
+
+# Reply codes the format models, by leading digit family.
+_REPLY_CODES = {b'220', b'250', b'354', b'421', b'550'}
+
+# Fixed client verbs that take no argument.
+_BARE_VERBS = {b'DATA', b'RSET', b'NOOP', b'QUIT'}
+
+
+def _all_in(chunk, allowed):
+    return len(chunk) > 0 and all(byte in allowed for byte in chunk)
+
+
+def _check_host(host):
+    if not _all_in(host, _HOST):
+        raise SMTPRealismError('invalid host %r' % (host,))
+    # A hostname is a non-empty run of the allowed bytes; reject a leading or
+    # trailing dot/hyphen so it is not a degenerate punctuation-only string.
+    if host[0:1] in (b'.', b'-') or host[-1:] in (b'.', b'-'):
+        raise SMTPRealismError('host %r starts or ends with a separator' % (host,))
+
+
+def _check_address(addr):
+    # ``local@domain`` with exactly one ``@`` splitting the two halves.
+    if addr.count(b'@') != 1:
+        raise SMTPRealismError('address %r is not local@domain' % (addr,))
+    local, domain = addr.split(b'@', 1)
+    if not _all_in(local, _LOCAL):
+        raise SMTPRealismError('invalid local-part %r' % (local,))
+    _check_host(domain)
+
+
+def _check_command(line):
+    """Raise unless ``line`` (no CRLF) is a valid client command."""
+    if line in _BARE_VERBS:
+        return
+    for verb in (b'EHLO ', b'HELO '):
+        if line.startswith(verb):
+            _check_host(line[len(verb):])
+            return
+    if line.startswith(b'VRFY '):
+        arg = line[len(b'VRFY '):]
+        if not _all_in(arg, _LOCAL):
+            raise SMTPRealismError('invalid VRFY argument %r' % (arg,))
+        return
+    for verb, path in ((b'MAIL FROM:', b'from'), (b'RCPT TO:', b'to')):
+        if line.startswith(verb):
+            rest = line[len(verb):]
+            if not (rest.startswith(b'<') and rest.endswith(b'>')):
+                raise SMTPRealismError('%s path not bracketed: %r' % (path, rest))
+            _check_address(rest[1:-1])
+            return
+    raise SMTPRealismError('unrecognized command line %r' % (line,))
+
+
+def _check_reply(line):
+    """Raise unless ``line`` (no CRLF) is a valid server reply line."""
+    if len(line) < 4:
+        raise SMTPRealismError('reply line too short: %r' % (line,))
+    code, sep, text = line[:3], line[3:4], line[4:]
+    if code not in _REPLY_CODES:
+        raise SMTPRealismError('unknown reply code %r' % (code,))
+    # A space separates a final reply line; a hyphen marks a continuation line.
+    if sep not in (b' ', b'-'):
+        raise SMTPRealismError('reply separator %r is not " " or "-"' % (sep,))
+    if not _all_in(text, _TEXT):
+        raise SMTPRealismError('reply text has non-text bytes: %r' % (text,))
+
+
+def check(covertext):
+    """Raise :class:`SMTPRealismError` unless ``covertext`` is a valid SMTP line.
+
+    A valid covertext is a single command or reply line terminated by exactly
+    one trailing CRLF, with no other CR or LF anywhere in the line.
+    """
+    if not isinstance(covertext, (bytes, bytearray)):
+        raise SMTPRealismError('covertext is not bytes: %r' % (type(covertext),))
+    covertext = bytes(covertext)
+    if not covertext.endswith(b'\r\n'):
+        raise SMTPRealismError('covertext does not end with CRLF')
+    line = covertext[:-2]
+    if b'\r' in line or b'\n' in line:
+        raise SMTPRealismError('bare CR/LF inside the line')
+    if not line:
+        raise SMTPRealismError('empty SMTP line')
+    # A reply line starts with a three-digit code; everything else is a command.
+    if len(line) >= 3 and _all_in(line[:3], _DIGITS):
+        _check_reply(line)
+    else:
+        _check_command(line)

--- a/fteproxy/tests/test_format_ftp.py
+++ b/fteproxy/tests/test_format_ftp.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the ``ftp`` control-channel format (phase F-ftp).
+
+Exercises the two ``parts/ftp.json`` entries end to end: the cipher builds and
+clears the capacity floor, random payloads round-trip through the record layer
+in both ``format`` and ``hybrid`` modes, and every sealed format-mode covertext
+is a real FTP line -- it fullmatches the sampling regex, passes the independent
+realism grammar check, and the batch survives the statistical guard.
+
+Note on message-type variety: FTP puts its discriminating token (the verb or
+reply code) first, so uniform rank sampling of a fixed-length format lands every
+covertext in a single lexicographic branch (``CWD`` commands, ``150`` replies).
+This is the seal-padding limitation documented in ``docs/format-authoring.md``
+(realistic value content and length distribution are not reachable by uniform
+rank sampling); the regex and the realism check still model every command and
+reply the format supports.
+"""
+
+import re
+
+import pytest
+
+import fteproxy
+import fteproxy.defs
+import fteproxy.record_layer as rl
+from fteproxy.tests.realism import (
+    format_covertexts,
+    statistical_guard,
+    load_part,
+)
+import fteproxy.tests.realism.ftp as ftp_realism
+
+
+_KEY = b'\x00' * 32
+
+_PART = load_part('ftp')
+_ENTRIES = ('ftp-request', 'ftp-response')
+
+
+def _spec(name):
+    return _PART[name]
+
+
+@pytest.mark.parametrize('name', _ENTRIES)
+def test_cipher_builds_and_clears_capacity_floor(name):
+    spec = _spec(name)
+    cipher = fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    assert cipher.max_plaintext_bytes >= fteproxy.defs.MIN_CAPACITY
+    assert cipher.max_plaintext_bytes >= 128
+
+
+@pytest.mark.parametrize('name', _ENTRIES)
+@pytest.mark.parametrize('hybrid', [False, True], ids=['format', 'hybrid'])
+def test_roundtrip_through_record_layer(name, hybrid):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+
+    def make_encoder():
+        return rl.Encoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    def make_decoder():
+        return rl.Decoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    encoder, decoder = make_encoder(), make_decoder()
+    import os
+    for i in range(16):
+        payload = os.urandom((i * 11) % (encoder.capacity + 1))
+        encoder.push(payload)
+        wire = encoder.pop()
+        decoder.push(wire)
+        assert decoder.pop() == payload
+
+
+@pytest.mark.parametrize('name', _ENTRIES)
+def test_sealed_covertexts_are_real_ftp(name):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+
+    covertexts = format_covertexts(regex, length, n=256)
+    assert len(covertexts) == 256
+
+    for covertext in covertexts:
+        assert pattern.fullmatch(covertext), covertext[:64]
+        ftp_realism.check(covertext)  # raises if not a valid FTP line
+
+    statistical_guard(covertexts)
+
+
+def test_realism_check_rejects_non_ftp():
+    # A few negatives to prove the grammar check is not vacuous.
+    for bad in (
+        b'CWD /var/log',                 # missing CRLF
+        b'CWD \r\n',                     # empty argument
+        b'CWD /a /b\r\n',                # argument with a space
+        b'HELO world\r\n',               # unknown verb
+        b'PASV now\r\n',                 # bare verb given an argument
+        b'TYPE Q\r\n',                   # bad TYPE code
+        b'999 nope\r\n',                 # unknown reply code
+        b'220\r\n',                      # reply with no text
+        b'220  \r\n'.replace(b' ', b'\x01'),  # control byte in text
+        b'CWD /a\r\nCWD /b\r\n',         # two lines
+    ):
+        with pytest.raises(ftp_realism.FTPRealismError):
+            ftp_realism.check(bad)
+
+
+def test_base_name_present():
+    assert 'ftp' in fteproxy.defs.base_names(load_part('ftp'))

--- a/fteproxy/tests/test_format_http.py
+++ b/fteproxy/tests/test_format_http.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Format tests for the ``http`` protocol (phase F1).
+
+For both ``http-request`` and ``http-response``:
+
+* the libfte cipher builds and holds at least :data:`fteproxy.defs.MIN_CAPACITY`
+  bytes of capacity;
+* random payloads round-trip through the record layer in both ``format`` and
+  ``hybrid`` modes (``http`` is a ``hybrid`` format, so either mode may be
+  selected at connection time);
+* a batch of sealed **format-mode** covertexts each fully match the regex, pass
+  the independent-parser realism :func:`~fteproxy.tests.realism.http.check`, and
+  clear :func:`~fteproxy.tests.realism.statistical_guard`;
+* the base name ``http`` is exposed by :func:`fteproxy.defs.base_names`.
+"""
+
+import os
+import re
+
+import pytest
+
+import fteproxy
+import fteproxy.defs
+import fteproxy.record_layer as rl
+import fteproxy.tests.realism as realism
+import fteproxy.tests.realism.http as http_realism
+
+
+_KEY = b'\x00' * 32
+_PART = realism.load_part('http')
+_NAMES = ('http-request', 'http-response')
+
+
+def _spec(name):
+    return _PART[name]
+
+
+def _cipher(name):
+    spec = _spec(name)
+    return fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+
+
+@pytest.mark.parametrize('name', _NAMES)
+def test_cipher_builds_with_capacity_floor(name):
+    capacity = _cipher(name).max_plaintext_bytes
+    assert capacity >= 128
+    assert capacity >= fteproxy.defs.MIN_CAPACITY
+
+
+@pytest.mark.parametrize('name', _NAMES)
+@pytest.mark.parametrize('hybrid', [False, True])
+def test_round_trip_through_record_layer(name, hybrid):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+
+    def make_encoder():
+        return rl.Encoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    def make_decoder():
+        return rl.Decoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    encoder = make_encoder()
+    decoder = make_decoder()
+    for i in range(16):
+        payload = os.urandom((i * 11) % (encoder.capacity + 1))
+        encoder.push(payload)
+        wire = encoder.pop()
+        decoder.push(wire)
+        assert decoder.pop() == payload
+
+
+@pytest.mark.parametrize('name', _NAMES)
+def test_sealed_covertexts_are_realistic(name):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+
+    covertexts = realism.format_covertexts(regex, length, n=256)
+    assert len(covertexts) == 256
+    for covertext in covertexts:
+        assert pattern.fullmatch(covertext), covertext[:80]
+        http_realism.check(covertext)
+    realism.statistical_guard(covertexts)
+
+
+def test_base_name_present():
+    assert 'http' in fteproxy.defs.base_names(_PART)

--- a/fteproxy/tests/test_format_smtp.py
+++ b/fteproxy/tests/test_format_smtp.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Format tests for the ``smtp`` covertext format (phase F5).
+
+Exercises both ``smtp-request`` and ``smtp-response`` end to end: the libfte
+cipher builds and clears the capacity floor, random payloads round-trip through
+the record layer in both ``format`` and ``hybrid`` modes, and a batch of sealed
+format-mode covertexts is drawn through the real record layer and judged for
+realism (regex fullmatch, the SMTP grammar :func:`~fteproxy.tests.realism.smtp.check`,
+and the statistical guard against degenerate single-byte runs).
+"""
+
+import os
+import re
+
+import pytest
+
+import fteproxy
+import fteproxy.defs
+import fteproxy.record_layer as rl
+from fteproxy.tests.realism import (
+    format_covertexts,
+    load_part,
+    statistical_guard,
+)
+from fteproxy.tests.realism import smtp as smtp_realism
+
+_KEY = b'\x00' * 32
+_PART = load_part('smtp')
+_ROLES = ('smtp-request', 'smtp-response')
+
+
+def _spec(name):
+    return _PART[name]
+
+
+@pytest.mark.parametrize('name', _ROLES)
+def test_cipher_builds_and_meets_capacity_floor(name):
+    spec = _spec(name)
+    cipher = fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    assert cipher.max_plaintext_bytes >= 128
+    assert cipher.max_plaintext_bytes >= fteproxy.defs.MIN_CAPACITY
+
+
+@pytest.mark.parametrize('name', _ROLES)
+@pytest.mark.parametrize('hybrid', [False, True], ids=['format', 'hybrid'])
+def test_round_trip_through_record_layer(name, hybrid):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+
+    def build_encoder():
+        return rl.Encoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    def build_decoder():
+        return rl.Decoder(
+            cipher=fteproxy._make_cipher(regex, length, _KEY),
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+
+    encoder = build_encoder()
+    decoder = build_decoder()
+    for i in range(16):
+        payload = os.urandom((i * 5) % (encoder.capacity + 1))
+        encoder.push(payload)
+        wire = encoder.pop()
+        decoder.push(wire)
+        assert decoder.pop() == payload
+
+
+@pytest.mark.parametrize('name', _ROLES)
+def test_format_covertexts_are_realistic(name):
+    spec = _spec(name)
+    regex, length = spec['regex'], spec['length']
+    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+
+    covertexts = format_covertexts(regex, length, n=256)
+    assert len(covertexts) == 256
+    for covertext in covertexts:
+        assert len(covertext) == length
+        assert pattern.fullmatch(covertext), repr(covertext[:64])
+        smtp_realism.check(covertext)
+    statistical_guard(covertexts)
+
+
+def test_realism_check_rejects_non_smtp():
+    # A structurally wrong line must be rejected, proving the grammar check is
+    # doing more than accepting anything with a CRLF.
+    with pytest.raises(smtp_realism.SMTPRealismError):
+        smtp_realism.check(b'GET / HTTP/1.1\r\n')
+    with pytest.raises(smtp_realism.SMTPRealismError):
+        smtp_realism.check(b'EHLO example.com')  # no CRLF
+    with pytest.raises(smtp_realism.SMTPRealismError):
+        smtp_realism.check(b'999 bogus code\r\n')
+
+
+def test_base_name_present():
+    assert 'smtp' in fteproxy.defs.base_names(load_part('smtp'))


### PR DESCRIPTION
### F1: http format

HTTP/1.1 GET/POST/HEAD requests and 200/302/404 responses with common browser headers. Ports 80/8080/8000, hybrid mode (body reads as an HTTP entity), the release default. Capacity 303/316 bytes. Realism judged by http.server + email.parser (request) and http.client.HTTPResponse (response), not by re-applying the regex.

Fragment fteproxy/defs/parts/http.json (request + response entries), an
independent realism validator fteproxy/tests/realism/http.py, and
fteproxy/tests/test_format_http.py. Validated by fteproxy/defs/validate.py;
F6 assembles the fragment into the shipped release.

### F2: ftp format

FTP control channel: USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT commands and 3-digit reply lines. Port 21, format mode. Capacity 161/163 bytes.

Fragment fteproxy/defs/parts/ftp.json (request + response entries), an
independent realism validator fteproxy/tests/realism/ftp.py, and
fteproxy/tests/test_format_ftp.py. Validated by fteproxy/defs/validate.py;
F6 assembles the fragment into the shipped release.

### F3: smtp format

SMTP: EHLO/HELO/MAIL FROM/RCPT TO/VRFY/DATA/RSET/NOOP/QUIT commands and 2xx-5xx replies with the 250- continuation form. Ports 25/587, format mode. Capacity 181/166 bytes.

Fragment fteproxy/defs/parts/smtp.json (request + response entries), an
independent realism validator fteproxy/tests/realism/smtp.py, and
fteproxy/tests/test_format_smtp.py. Validated by fteproxy/defs/validate.py;
F6 assembles the fragment into the shipped release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
