### PR TITLE
F6: assemble the release, default http, port-to-format mapping, docs

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -40,7 +40,19 @@ python3 benchmark.py --scenarios lan --sizes 64K 1M --mode format
    therefore caches ciphers itself (`_make_cipher`, one per pattern/length/key),
    which brings connection setup to ~1 ms. Without the cache it was 8–12 ms, and a
    connection closed before negotiating pinned the server at 64–100% CPU.
-6. **The relay's `select`+throttle poll loop is unchanged** and still carries the
+6. **Four of the five shipped formats run in `format` mode by design, so point 4
+   is their normal operating point.** Since the `20260903` definitions release the
+   default catalog is five cleartext protocols: `http` is `mode_hint: hybrid` (an
+   HTTP message with a raw body is what HTTP looks like), while the line protocols
+   `ftp`, `smtp`, `sip` and the binary `dns` format are `mode_hint: format`,
+   because a line protocol has no place to put a high-entropy tail. Expect about
+   1 MB/s and interactive-class latency on those four — fine for a shell, a chat,
+   or SOCKS-proxied browsing of text, and not a bulk-transfer channel. Pick `http`
+   (or pass `--mode hybrid`, accepting the tail) when throughput is what matters.
+   The measurements below predate the release and were taken on
+   `manual-http-request`/`-response` from the shape catalog; the `hybrid` column
+   is representative of `http`, and the `format` column of the other four.
+7. **The relay's `select`+throttle poll loop is unchanged** and still carries the
    caveats from 0.3: do not delete the throttle, and a dropped link can still wedge
    an application connection (see *Resilience*).
 
@@ -66,7 +78,10 @@ noise, as it did on 0.3; those rows are omitted.
 ### Record layer alone (no sockets), `manual-http-request`/`-response`
 
 Median encrypt+decrypt round trip through `fteproxy.record_layer`, from the
-release review (same machine):
+release review (same machine). `manual-http-*` is the shape catalog's HTTP
+entry (release `20260110`, length 256); the shipped `http` format is length 512
+with more capacity per record, which moves the small-message rows a little and
+leaves the bulk rows where they are:
 
 | message | 0.3.1 | 0.4 hybrid | 0.4 format | wire expansion 0.3.1 → 0.4 hybrid / format |
 |---|---:|---:|---:|---:|

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -29,14 +29,14 @@ $ fteproxy server --advertise your.host:8080
 listening on [::]:8080
 key: ~/.local/state/fteproxy/server.key (created)
 clients connect with:
-  fteproxy client fte://Qm3s…ZzE@your.host:8080?defs=20260110
+  fteproxy client fte://Qm3s…ZzE@your.host:8080?defs=20260903
 ```
 
 ### Client
 
 ```console
 $ fteproxy client fte://Qm3s…ZzE@your.host:8080
-checking your.host:8080 ... ok (protocol 1, manual-http, hybrid)
+checking your.host:8080 ... ok (protocol 1, http, hybrid)
 SOCKS5 on 127.0.0.1:1080
 
 $ curl --socks5-hostname 127.0.0.1:1080 https://example.com/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ listening on [::]:8080
 key: ~/.local/state/fteproxy/server.key (created)
 allowing: every destination except the loopback and link-local addresses of this host
 clients connect with:
-  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260110
+  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260903
 (also written to ~/.local/state/fteproxy/connection.txt)
 ```
 
@@ -75,7 +75,7 @@ On the client machine, with the string the server printed:
 
 ```console
 $ fteproxy client fte://Qm3s…ZzE@203.0.113.5:8080
-checking 203.0.113.5:8080 ... ok (protocol 1, manual-http, hybrid)
+checking 203.0.113.5:8080 ... ok (protocol 1, http, hybrid)
 SOCKS5 on 127.0.0.1:1080
 
 $ curl --socks5-hostname 127.0.0.1:1080 https://example.com/
@@ -141,17 +141,44 @@ brackets when a port follows.
 
 ### Formats and record-layer modes
 
-A *format* is a base name from the definitions file, such as `manual-http`;
-the request and response covertexts are derived from it. `fteproxy formats`
-lists them with the capacity of one covertext:
+A *format* is a base name from the definitions file, such as `http`; the
+request and response covertexts are derived from it. The shipped release,
+`20260903`, is five cleartext application protocols -- the case FTE is for,
+since a protocol that is normally encrypted is better tunnelled inside the
+real thing:
+
+| Format | Ports | Direction split | Mode | What a covertext looks like |
+|---|---|---|---|---|
+| `http` | 80, 8080, 8000 | request / response | hybrid | `GET /… HTTP/1.1` with browser headers **(default)** |
+| `ftp` | 21 | command / reply | format | `USER …`, `220 … ready` control lines |
+| `smtp` | 25, 587 | command / reply | format | `EHLO …`, `250-…` command and reply lines |
+| `sip` | 5060 | request / response | format | `INVITE sip:…@… SIP/2.0` with Via/From/To/Call-ID/CSeq |
+| `dns` | 53 | query / response | format | DNS over TCP: length prefix, header, question, A record |
+
+`http` is the default. A client given no `--format` and no `?format=` hint
+picks the format whose protocol runs on the server's port -- a server on 21
+gets `ftp`, one on 5060 gets `sip` -- and falls back to `http` for a port no
+protocol claims. `--format` and the connection string's `?format=` hint both
+win over that, and a `--format` that disagrees with the port is honoured with
+a warning.
+
+`fteproxy formats` lists the release with each format's role, ports, mode and
+the capacity of one covertext:
 
 ```console
 $ fteproxy formats
-name          req len  req cap  resp len  resp cap
-...
-manual-http       256      150       256       192  (default)
-words             280      138       280       138
+name  role      port          mode    req len  req cap  resp len  resp cap
+dns   req/resp  53            format      272      154       272       148
+ftp   req/resp  21            format      256      161       256       163
+http  req/resp  80,8080,8000  hybrid      512      303       512       316  (default)
+sip   req/resp  5060          format      512      258       512       259
+smtp  req/resp  25,587        format      320      181       256       166
 ```
+
+The comprehensive catalog of abstract *shapes* that earlier versions defaulted
+to -- 46 entries, 23 base names (`manual-http`, `words`, `base64`, …) -- still
+ships as release `20260110`: list it with `fteproxy formats --defs 20260110`,
+and serve it with `--defs 20260110` on the server.
 
 The client picks the format and the record-layer mode and puts both in the
 handshake; the server follows. Nothing has to be configured to match.
@@ -160,8 +187,15 @@ handshake; the server follows. Nothing has to be configured to match.
   followed by raw authenticated ciphertext. Fast — hundreds of MB/s — but only
   the header blends in with the target protocol.
 - `--mode format`: every byte on the wire is in the format, so the whole
-  stream is indistinguishable from the protocol. Much slower (well under
-  1 MB/s), for deployments facing entropy or statistical detectors.
+  stream is indistinguishable from the protocol. Much slower (about 1 MB/s),
+  for deployments facing entropy or statistical detectors.
+
+Each format records the mode it is designed for (the `mode` column above), and
+that is what the client uses unless `--mode` says otherwise. `http` is hybrid:
+an HTTP message with a body is exactly what HTTP looks like, so the raw body
+past the formatted header costs nothing. The line protocols and `dns` have no
+natural place for a high-entropy body, so they ship as `format` -- every byte
+in the protocol, at about 1 MB/s, which is fine for interactive use.
 
 ### Command line
 
@@ -181,11 +215,11 @@ fteproxy --version
 | `--listen` | server | Address to listen on; `:PORT` means every interface, IPv6 in brackets | `:8080` |
 | `--allow` | server | A destination clients may reach; repeatable | loopback and link-local blocked, everything else allowed |
 | `--advertise` | server, keygen | The address to put in the connection string | a `<server-ip>` placeholder |
-| `--defs` | server, formats | Definitions release, as YYYYMMDD | 20260110 |
+| `--defs` | server, formats | Definitions release, as YYYYMMDD | 20260903 |
 | `URI` | client | `fte://SERVER-ID@HOST:PORT`; falls back to `$FTEPROXY_URI`, then `connection.txt` | |
 | `-D` | client | SOCKS5 listener, `[BIND:]PORT` | `127.0.0.1:1080` when no `-D`/`-L` |
 | `-L` | client | Forward `[BIND:]PORT` to one `HOST:PORT` through the tunnel; repeatable | |
-| `--format` | client | Base format name (see `fteproxy formats`) | the URI's hint, else `manual-http` |
+| `--format` | client | Base format name (see `fteproxy formats`) | the URI's hint, else the format for the server's port, else `http` |
 | `--mode` | client | `hybrid` or `format` | the URI's hint, else `hybrid` |
 | `--no-check` | client | Skip the startup check | check runs |
 | `--state-dir` | all | Where `server.key` and `connection.txt` live | `$FTEPROXY_STATE_DIR`, `$XDG_STATE_HOME/fteproxy`, `~/.local/state/fteproxy` |
@@ -230,7 +264,7 @@ sock.open_result(0x00)
 
 # client side
 sock = fteproxy.wrap_socket(raw, server_id=public,
-                            format="manual-http", mode="hybrid")
+                            format="http", mode="hybrid")
 sock.connect(("203.0.113.5", 8080))
 sock.open(("example.com", 443))     # raises fteproxy.OpenRefused(status)
 ```
@@ -284,11 +318,12 @@ build, gets no reply at all. The full notes are in
   a reason; a wrong connection string fails in a round trip instead of hanging.
   Exit statuses are meaningful (0/1/2), and a no-argument run prints usage
   instead of crashing.
-- **Definitions.** Thirty-two entries in `20260110.json` have longer
-  covertexts, so that every shipped format can carry a handshake; the loader
-  now refuses a release with a format that cannot. The default `manual-http-*`
-  formats are unchanged at length 256, carrying 150 (request) and 192
-  (response) bytes.
+- **Definitions.** The default release is `20260903`: five real cleartext
+  protocols (`http`, `ftp`, `smtp`, `sip`, `dns`), with `http` the default
+  format instead of `manual-http`. The 46 abstract shape entries are still
+  shipped as release `20260110`, reachable with `--defs 20260110`; thirty-two of their
+  entries were given longer covertexts so that every shipped format can carry
+  a handshake, and the loader now refuses a release with a format that cannot.
 - **API.** `wrap_socket`'s `outgoing_regex`/`incoming_regex`/`K1`/`K2`/
   `negotiate` parameters are replaced by `server_key=` or `server_id=` plus
   `format=`/`mode=`. See [Python API](#python-api).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,6 +113,50 @@ first. This section covers what fteproxy adds on top of it.
   handshake records are one request-format covertext and one response-format
   covertext, the same shape as any other record.
 
+- **How realistic a covertext actually is.** The five shipped formats
+  (`http`, `ftp`, `smtp`, `sip`, `dns`) model real message *structure*: every
+  sealed covertext parses as a valid message of its protocol -- correct verb or
+  status line, mandatory headers, terminators -- and, because the record layer
+  pads each plaintext to the format's full capacity with random bytes before
+  encrypting, every variable field is filled with high-entropy characters from
+  its own class rather than a low-entropy run. That is enough to pass a regex
+  or keyword DPI rule, which is the threat model FTE is for. It is **not**
+  enough to pass a classifier that looks at content or behaviour, for two
+  reasons inherent to uniform rank sampling:
+
+  - **Field values are random.** A covertext's URL path, hostname, mail
+    address, SIP tag or DNS label is a random string from the field's
+    character class, not a plausible value: a 300-character random path, not
+    `/index.html`; a random Call-ID, not one a phone would mint. Field
+    *lengths* are fixed too -- every covertext of a format is exactly `length`
+    bytes -- so a length-distribution test separates a tunnel from real
+    traffic immediately.
+  - **One message type dominates.** Unranking a full-capacity plaintext lands
+    in the same branch of the alternation nearly every time, so in practice
+    every `http` request samples as `GET`, every `sip` request as `BYE`, every
+    `ftp` request as `CWD`, every `smtp` request as `VRFY`, and every `ftp`
+    reply as `150`. A stream that is all `BYE` with no `INVITE`, or all `CWD`
+    with no login, is not a conversation any real client would have.
+
+  Nothing in the protocol depends on this: confidentiality and integrity come
+  from the handshake and the record layer, not from how convincing a covertext
+  is. What a weak covertext costs you is *unobservability* against an
+  adversary better than a signature matcher.
+
+- **Mode choice leaks differently per format.** `hybrid` formats only each
+  record's fixed-length header and sends the body as raw authenticated
+  ciphertext, so the bytes past the header are high-entropy. For `http` that
+  reads as a message with a body, which is what HTTP looks like. For a line
+  protocol (`ftp`, `smtp`, `sip`) or for the binary `dns` format there is no
+  place a high-entropy tail belongs, so those ship as `mode_hint: format`
+  (every byte in the protocol, at about 1 MB/s) and running them under
+  `--mode hybrid` leaks an obvious high-entropy tail after each line. `dns`
+  carries one more tell: at a fixed 272-byte covertext the capacity lives in
+  the QNAME, so every query pads out to a ~254-octet name -- legal, under the
+  255-octet limit, and far longer than any name real traffic resolves.
+  Variable-length covertexts (planned, phase F7) are what would narrow both
+  the length fingerprint and this one.
+
 - **Nothing secret is logged.** The package logger carries a redaction filter,
   installed at import, that strips a connection string's server-id, a hex key
   and a bare base64url public key out of any message before a handler sees it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -137,6 +137,16 @@ first. This section covers what fteproxy adds on top of it.
     `ftp` request as `CWD`, every `smtp` request as `VRFY`, and every `ftp`
     reply as `150`. A stream that is all `BYE` with no `INVITE`, or all `CWD`
     with no login, is not a conversation any real client would have.
+  - **Replies do not answer their requests.** Every covertext is an
+    independent unranking of an independently randomised ciphertext, so
+    nothing in the record layer can make a reply depend on the request it
+    follows. For `dns` that is a concrete and cheap tell: a response's
+    16-bit ID and its question section never match the query's, a
+    stateless two-field check that resolvers, connection-tracking DNS
+    helpers and DNS-aware middleboxes already run. Over TCP it is largely
+    moot; over UDP port 53 it would be the first thing flagged. Making a
+    reply echo its request would be a protocol change, not a format
+    change (see `docs/udp-feasibility.md`).
 
   Nothing in the protocol depends on this: confidentiality and integrity come
   from the handshake and the record layer, not from how convincing a covertext

--- a/docs/format-authoring.md
+++ b/docs/format-authoring.md
@@ -145,9 +145,25 @@ files and touches no shared file:
    regex and passes the realism `check`, and `statistical_guard` over the batch.
 
 Because the five phases write disjoint entries and per-protocol files, they run
-in parallel without colliding. **F6** assembles the fragments in
-`fteproxy/defs/parts/*.json` into `fteproxy/defs/20260903.json` and makes it the
-default release.
+in parallel without colliding. **F6** assembled the fragments in
+`fteproxy/defs/parts/*.json` into `fteproxy/defs/20260903.json` and made it the
+default release (`fteproxy.conf`'s `fteproxy.defs.release`, with
+`fteproxy.default_format` and `fteproxy.cli.DEFAULT_FORMAT` now `http`).
+
+`parts/` stays the per-protocol source of truth: edit the fragment, then
+re-assemble the release from it. `fteproxy/tests/test_release_assembly.py`
+fails if the two drift, so an edit that never reaches the shipped file is
+caught rather than shipped.
+
+```python
+import json
+merged = {}
+for proto in ('http', 'ftp', 'smtp', 'sip', 'dns'):   # the shipped file's order
+    merged.update(json.load(open('fteproxy/defs/parts/%s.json' % proto)))
+with open('fteproxy/defs/20260903.json', 'w') as fh:
+    json.dump(merged, fh, indent=4)
+    fh.write('\n')
+```
 
 ## Running the checks
 

--- a/docs/plan-formats.md
+++ b/docs/plan-formats.md
@@ -220,6 +220,17 @@ Per-protocol notes:
 
 ### F6 — integration (after F1–F5)
 
+Status: **done**, 2026-09-03. `fteproxy/defs/20260903.json` is the assembly of
+the five `fteproxy/defs/parts/*.json` fragments (which stay the per-protocol
+source of truth, checked against the release by
+`fteproxy/tests/test_release_assembly.py`); `fteproxy.conf`'s
+`fteproxy.defs.release` and `fteproxy.default_format`, and `cli.DEFAULT_FORMAT`,
+now say `20260903` / `http`; the client picks its format from the server's port
+via `fteproxy.config.format_for_port`; README, SECURITY.md, PERFORMANCE.md and
+the examples are updated. The shape catalog stays shipped as release `20260110`
+(`--defs 20260110`) and is only retired from being the *default*; the tests that
+exercise it select it by name. Suite: 604 passing (was 566).
+
 - Make `20260903` the default release (the CLI default is "newest shipped").
 - Port-to-format defaulting: when the client URI carries no `format` hint and no
   `--format` is given, choose the default format for the server port from the

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -9,10 +9,10 @@ $ fteproxy server
 listening on [::]:8080
 key: ~/.local/state/fteproxy/server.key (created)
 clients connect with:
-  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260110
+  fteproxy client fte://Qm3s…ZzE@<server-ip>:8080?defs=20260903
 
 $ fteproxy client fte://Qm3s…ZzE@203.0.113.5:8080
-checking 203.0.113.5:8080 ... ok (protocol 1, manual-http, hybrid)
+checking 203.0.113.5:8080 ... ok (protocol 1, http, hybrid)
 SOCKS5 on 127.0.0.1:1080
 ```
 
@@ -121,11 +121,20 @@ exits on SIGINT or SIGTERM.
 
 ## Definitions
 
-Thirty-two entries in `20260110.json` have longer covertexts so that every
-shipped format can carry a handshake, and the loader now refuses a release
-containing a format that cannot (capacity below 128 bytes). The default
-`manual-http-*` formats are unchanged at length 256, carrying 150 (request)
-and 192 (response) bytes.
+The shipped release is `20260903`: five real cleartext protocols, a request and
+a response format each -- `http` (ports 80/8080/8000, hybrid), `ftp` (21),
+`smtp` (25/587), `sip` (5060) and `dns` over TCP (53), the last four in format
+mode. `http` is the default format, and a client given neither `--format` nor a
+`?format=` hint picks the format whose protocol runs on the server's port,
+falling back to `http`.
+
+The catalog of abstract shapes that earlier builds defaulted to (46 entries,
+`manual-http`, `words`, `base64`, …) is still shipped as release `20260110` and
+is reachable with `--defs 20260110`. Thirty-two of its entries have longer
+covertexts so that every shipped format can carry a handshake, and the loader
+now refuses a release containing a format that cannot (capacity below 128
+bytes); its `manual-http-*` formats are unchanged at length 256, carrying 150
+(request) and 192 (response) bytes.
 
 ## Performance
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,7 +137,7 @@ sock = fteproxy.wrap_socket(sock, server_key=private_key_bytes)
 # ... and the client needs only the matching public half, as 32 bytes or as
 # the 43-character base64url string a connection string carries.
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock = fteproxy.wrap_socket(sock, server_id=SERVER_ID, format="binary")
+sock = fteproxy.wrap_socket(sock, server_id=SERVER_ID, format="http")
 
 # Use normally - encoding is transparent!
 sock.connect(("localhost", 50007))
@@ -376,16 +376,33 @@ You --> :8079 --> [FTE encode] --> :8080 --> [FTE decode] --> :8081 --> netcat
 
 A format is named by its **base name**. Each base covers both directions:
 fteproxy derives a `-request` covertext (client to server) and a `-response`
-covertext (server to client) from it, so `--format words` is right and
-`--format words-request` is not. The format is the client's choice and the
+covertext (server to client) from it, so `--format http` is right and
+`--format http-request` is not. The format is the client's choice and the
 server follows.
 
 `fteproxy formats` is the authoritative list, and prints each format's
-covertext length and how many message bytes it carries:
+covertext length and how many message bytes it carries.
+
+The shipped release (`20260903`) is five real cleartext protocols. A client
+given no `--format` picks the one whose protocol runs on the server's port,
+falling back to `http`:
+
+| Format | Ports | Mode | Output Looks Like |
+|--------|-------|------|-------------------|
+| `http` | 80, 8080, 8000 | hybrid | `GET /a1b2… HTTP/1.1` with browser headers (default) |
+| `ftp` | 21 | format | `USER a1b2`, `220 … ready` |
+| `smtp` | 25, 587 | format | `EHLO mail.example`, `250-…` |
+| `sip` | 5060 | format | `INVITE sip:a1b2@example SIP/2.0` |
+| `dns` | 53 | format | DNS over TCP query / A-record response |
+
+The abstract *shapes* the earlier releases defaulted to are still shipped as
+release `20260110` (`fteproxy formats --defs 20260110`, `--defs 20260110` on
+the server). They are what the demo scripts in `formats/` and `programmatic/`
+illustrate:
 
 | Format | Output Looks Like | Example |
 |--------|------------------|---------|
-| `manual-http` | HTTP requests/responses (default) | `GET /a1b2 HTTP/1.1` |
+| `manual-http` | HTTP requests/responses | `GET /a1b2 HTTP/1.1` |
 | `alphanumeric` | Letters and digits | `x7Kq2prM9tyz` |
 | `base64` | Base64 characters | `SGVsbG8gV29ybGQ` |
 | `binary` | Binary (0s and 1s) | `01101000011001` |
@@ -394,14 +411,12 @@ covertext length and how many message bytes it carries:
 | `domain` | Domain names | `example.com` |
 | `dummy` | Unconstrained (`^.+$`), for testing | `k#7~Qz!9k` |
 | `email-simple` | Email addresses | `user@host.com` |
-| `ftp` | FTP responses | `220 ftp.com ready` |
 | `hex` | Hexadecimal | `a1b2c3d4e5f6` |
 | `http-simple` | HTTP requests | `GET /page HTTP/1.1` |
 | `ip-address` | IP addresses | `192.168.1.1` |
 | `key-value` | Key-value pairs | `key=value` |
 | `lowercase` | Random letters | `xkwqprmstyz` |
 | `sentences` | Sentences with periods | `Hello world.` |
-| `smtp` | SMTP commands | `EHLO mail.com` |
 | `ssh` | SSH banners | `SSH-2.0-OpenSSH` |
 | `timestamp` | Timestamps | `12:34:56` |
 | `tls-sni` | TLS SNI style | `www.example.com` |

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,7 +1,7 @@
 # FTE Chat Example
 
 A chat demo with a 10-round conversation between client and server.
-All traffic is FTE-encoded to look like binary (0s and 1s).
+All traffic is FTE-encoded to look like HTTP/1.1 requests and responses.
 
 ## Quick Start
 
@@ -42,7 +42,7 @@ Client connected from ('127.0.0.1', 52431)
 FTE Chat Client
 ==================================================
 Connecting to 127.0.0.1:50007
-Format: binary (0s and 1s in both directions)
+Format: http (HTTP requests out, HTTP responses back)
 ==================================================
 
 Connected!
@@ -62,7 +62,7 @@ connection string carries:
 
 ```python
 # client.py
-sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID, format="binary")
+sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID, format="http")
 
 # server.py -- no format, no mode, no shared key
 sock = fteproxy.wrap_socket(sock, server_key=DEMO_SERVER_KEY)
@@ -79,17 +79,18 @@ Even though the conversation looks normal, the actual network traffic is encoded
 
 | Direction | What You See | What's On The Wire |
 |-----------|-------------|-------------------|
-| Client -> Server | "Hi there!" | `0101101011101010110...` (1320 bytes) + raw ciphertext |
-| Server -> Client | "Hello!" | `1101001011010110100...` (1320 bytes) + raw ciphertext |
+| Client -> Server | "Hi there!" | `GET /Xq2p... HTTP/1.1` + headers (512 bytes) + raw ciphertext |
+| Server -> Client | "Hello!" | `HTTP/1.1 200 OK` + headers (512 bytes) + raw ciphertext |
 
 With fteproxy's default record-layer mode (`hybrid`), each record starts with a
-1320-byte covertext in the `binary` format and carries the message itself as
-raw authenticated ciphertext after it. To make the whole stream binary, ask for
-`format` mode when wrapping the client socket -- the server follows:
+512-byte covertext in the `http` format and carries the message itself as raw
+authenticated ciphertext after it -- which is what an HTTP message with a body
+looks like. To put every byte in the format, ask for `format` mode when
+wrapping the client socket -- the server follows:
 
 ```python
 sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID,
-                            format="binary", mode="format")
+                            format="http", mode="format")
 ```
 
 ## Traffic Flow
@@ -99,12 +100,12 @@ sock = fteproxy.wrap_socket(sock, server_id=DEMO_SERVER_ID,
 |   Client   |                      |   Server   |
 +------------+                      +------------+
       |                                   |
-      |  "Hi there!" encoded as binary    |
-      |  010110101110101011010110...      |
+      |  "Hi there!" as an HTTP request   |
+      |  GET /Xq2pm9... HTTP/1.1 ...      |
       |---------------------------------->|
       |                                   |
-      |  "Hello!" encoded as binary       |
-      |  110100101101011010011010...      |
+      |  "Hello!" as an HTTP response     |
+      |  HTTP/1.1 200 OK ...              |
       |<----------------------------------|
       |                                   |
      ...         (10 rounds)             ...
@@ -116,9 +117,20 @@ Change `FORMAT` in `client.py` to any base name `fteproxy formats` lists, and
 the wire format changes in both directions:
 
 ```python
-FORMAT = "words"        # a a a xkq mfj ...
-FORMAT = "hex"          # a1b2c3d4e5f6 ...
-FORMAT = "manual-http"  # GET /... HTTP/1.1
+FORMAT = "http"   # GET /... HTTP/1.1 with browser headers (the default)
+FORMAT = "smtp"   # EHLO mail.example / 250-... command and reply lines
+FORMAT = "sip"    # INVITE sip:...@... SIP/2.0 with Via/From/To/Call-ID
+FORMAT = "dns"    # DNS over TCP: length prefix, header, question, A record
+```
+
+Pick the one whose port the traffic will be seen on -- that is what the command
+line does for you when no `--format` is given. The abstract shape formats
+(`words`, `hex`, `manual-http`, ...) live in release `20260110`; to use one,
+select that release before wrapping the socket, on both ends:
+
+```python
+import fteproxy.conf
+fteproxy.conf.setValue('fteproxy.defs.release', '20260110')
 ```
 
 Only the client changes. The server is told nothing and follows.

--- a/examples/chat/client.py
+++ b/examples/chat/client.py
@@ -3,7 +3,7 @@
 FTE Chat Client
 
 A simple chat client that has a 10-round conversation with the server.
-All traffic is FTE-encoded to look like binary (0s and 1s).
+All traffic is FTE-encoded to look like HTTP/1.1 requests and responses.
 
 The client picks the format and the record-layer mode; the server follows.
 All it needs of the server is the server-id below.
@@ -18,8 +18,9 @@ import fteproxy
 DEMO_SERVER_ID = "g7RzVlLwycSzfHmHwo2LOdkvZ2rG_-J4lmsosmKPzQY"
 
 # A base name from the definitions file: the server derives the request and
-# response formats from it. `fteproxy formats` lists them all.
-FORMAT = "binary"
+# response formats from it. `fteproxy formats` lists them all. The demo runs
+# on a port no protocol claims, so it takes the shipped default, http.
+FORMAT = "http"
 
 HOST = '127.0.0.1'
 PORT = 50007
@@ -43,7 +44,7 @@ def main():
     print("FTE Chat Client")
     print("=" * 50)
     print(f"Connecting to {HOST}:{PORT}")
-    print(f"Format: {FORMAT} (0s and 1s in both directions)")
+    print(f"Format: {FORMAT} (HTTP requests out, HTTP responses back)")
     print("=" * 50)
     print()
 

--- a/examples/chat/server.py
+++ b/examples/chat/server.py
@@ -3,7 +3,7 @@
 FTE Chat Server
 
 A simple chat server that has a 10-round conversation with the client.
-All traffic is FTE-encoded to look like binary (0s and 1s).
+All traffic is FTE-encoded to look like HTTP/1.1 requests and responses.
 
 The server is told nothing about the format: it learns it, and the
 record-layer mode, from the client's first record, and proves its identity

--- a/examples/formats/README.md
+++ b/examples/formats/README.md
@@ -35,26 +35,41 @@ plaintext to `cipher.max_plaintext_bytes` yourself.
 
 ## Using a format with the proxy
 
-The proxy names a format by its **base name**, such as `manual-http` or
-`words` -- never `words-request`. Each base covers both directions: fteproxy
-derives the `-request` covertext (client to server) and the `-response`
-covertext (server to client) from it. `fteproxy formats` lists the base names
-with the length of one covertext and how many message bytes it carries:
+The proxy names a format by its **base name**, such as `http` or `ftp` --
+never `http-request`. Each base covers both directions: fteproxy derives the
+`-request` covertext (client to server) and the `-response` covertext (server
+to client) from it. `fteproxy formats` lists the base names with each one's
+role, ports, mode, the length of one covertext and how many message bytes it
+carries:
 
 ```console
 $ fteproxy formats
-name          req len  req cap  resp len  resp cap
-...
-manual-http       256      150       256      192  (default)
-words             280      138       280      138
+name  role      port          mode    req len  req cap  resp len  resp cap
+dns   req/resp  53            format      272      154       272       148
+ftp   req/resp  21            format      256      161       256       163
+http  req/resp  80,8080,8000  hybrid      512      303       512       316  (default)
+sip   req/resp  5060          format      512      258       512       259
+smtp  req/resp  25,587        format      320      181       256       166
 ```
+
+Given neither `--format` nor a `?format=` hint in the connection string, the
+client picks the format whose protocol runs on the server's port -- `ftp` for a
+server on 21, `sip` on 5060 -- and `http` for anything else. The demo scripts
+in this directory illustrate the abstract *shape* formats (`words`, `base64`,
+`manual-http`, ...), which are still shipped as release `20260110`:
+`fteproxy formats --defs 20260110`.
 
 The format and the record-layer mode are the **client's** choice: both travel
 in the handshake and the server follows, so there is nothing to configure on
 the server and no way for the two ends to disagree.
 
 ```bash
-python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080' --format words
+# Port 8080: http is what the port implies, so no --format is needed.
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:8080'
+
+# A server parked on 5060 gets sip without being told; naming a format that
+# does not match the port is honoured, with a warning.
+python3 -m fteproxy client 'fte://<server-id>@<server-ip>:5060'
 ```
 
 With the default `--mode hybrid` only a fixed-length header per record is in
@@ -66,14 +81,16 @@ side:
 
 ```python
 sock = fteproxy.wrap_socket(sock, server_id=SERVER_ID,
-                            format="words", mode="hybrid")
+                            format="http", mode="hybrid")
 ```
 
 ## Why different formats?
 
 Different formats blend in with different traffic:
 
-- **HTTP-like** (`http-simple`, `manual-http`): web traffic
+- **Real cleartext protocols** (`http`, `ftp`, `smtp`, `sip`, `dns`): the
+  shipped release, one per port a DPI rule would expect
+- **HTTP-like shapes** (`http-simple`, `manual-http`): web traffic
 - **Words / sentences**: natural text
 - **Hex / base64**: encoded data, common in APIs
 - **Digits, IP addresses, timestamps**: numeric fields

--- a/examples/integration/secure_chat.py
+++ b/examples/integration/secure_chat.py
@@ -19,8 +19,9 @@ DEMO_SERVER_KEY = bytes.fromhex(
     "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
 DEMO_SERVER_ID = fteproxy.server_id(DEMO_SERVER_KEY)
 
-# Chat traffic will look like space-separated words.
-FORMAT = "words"
+# Chat traffic will look like HTTP/1.1 requests and responses: this demo runs
+# on a port no protocol claims, so it takes the shipped default.
+FORMAT = "http"
 
 PORT = 50009
 

--- a/examples/programmatic/echo_client.py
+++ b/examples/programmatic/echo_client.py
@@ -18,7 +18,9 @@ import fteproxy
 DEMO_SERVER_ID = "g7RzVlLwycSzfHmHwo2LOdkvZ2rG_-J4lmsosmKPzQY"
 
 # A base name from the definitions file. `fteproxy formats` lists them all.
-FORMAT = "words"
+# The echo server runs on a port no protocol claims, so this is the shipped
+# default: traffic that looks like HTTP/1.1 requests and responses.
+FORMAT = "http"
 
 HOST = "127.0.0.1"
 PORT = 50007

--- a/examples/programmatic/file_transfer.py
+++ b/examples/programmatic/file_transfer.py
@@ -24,9 +24,12 @@ DEMO_SERVER_KEY = bytes.fromhex(
     "628e1b010509a623c31c54a443d996d10427f2e47ff11258d50e9f70c4b79651")
 DEMO_SERVER_ID = fteproxy.server_id(DEMO_SERVER_KEY)
 
-# A base name from the definitions file: the traffic looks like lowercase
-# words in both directions. `fteproxy formats` lists them all.
-FORMAT = "words"
+# A base name from the definitions file: the traffic looks like HTTP/1.1
+# requests and responses. `fteproxy formats` lists them all. Pick the format
+# your port would carry -- ftp on 21, smtp on 25, sip on 5060, dns on 53 --
+# so a DPI rule for that port matches; this demo is on a port no protocol
+# claims, so it takes the default.
+FORMAT = "http"
 
 PORT = 50008
 CHUNK_SIZE = 4096

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -50,7 +50,7 @@ EXIT_USAGE = 2
 
 DEFAULT_LISTEN = ':8080'
 DEFAULT_SOCKS = '127.0.0.1:1080'
-DEFAULT_FORMAT = 'manual-http'
+DEFAULT_FORMAT = 'http'
 DEFAULT_MODE = 'hybrid'
 
 SUBCOMMANDS = ('server', 'client', 'keygen', 'formats', 'defs-check')
@@ -214,8 +214,9 @@ def build_parser():
                              'the tunnel. Repeatable.')
     client.add_argument('--format', metavar='NAME', default=None,
                         help='Base format name; see "fteproxy formats" '
-                             '(default: the URI\'s hint, else %s).'
-                             % DEFAULT_FORMAT)
+                             '(default: the URI\'s hint, else the format '
+                             'whose protocol runs on the server\'s port, '
+                             'else %s).' % DEFAULT_FORMAT)
     client.add_argument('--mode', choices=['hybrid', 'format'], default=None,
                         help='Record framing. "hybrid" formats a header per '
                              'record and sends the body as raw authenticated '
@@ -522,6 +523,20 @@ def do_server(args):
     return serve_forever([listener])
 
 
+def mode_hint_for(base):
+    """The record-layer mode a base format was designed for, or None.
+
+    Read from the request side's ``mode_hint`` in the loaded definitions
+    release. None when the format is not in the release, so the caller falls
+    through to the built-in default; ``check_format`` has already refused an
+    unknown base by the time this runs.
+    """
+    try:
+        return fteproxy.defs.get_mode_hint(base + fteproxy.defs.REQUEST_SUFFIX)
+    except (fteproxy.defs.InvalidRegexName, KeyError):
+        return None
+
+
 def do_client(args):
     directory = resolve_state_dir(args, create=False)
     try:
@@ -541,10 +556,20 @@ def do_client(args):
     defs = uri.defs or fteproxy.conf.getValue('fteproxy.defs.release')
     select_defs(str(defs))
 
-    # Flags beat the URI's hints, which beat the built-in defaults.
-    base = args.format or uri.format_name or DEFAULT_FORMAT
-    mode = args.mode or uri.mode or DEFAULT_MODE
+    # Flags beat the URI's hints, which beat the port default, which beats the
+    # built-in one. The port default is what makes a server parked on 21 speak
+    # FTP-shaped covertexts without anyone saying so.
+    from_port = fteproxy.config.format_for_port(uri.port)
+    base = args.format or uri.format_name or from_port or DEFAULT_FORMAT
     check_format(base)
+    # --mode and the URI's hint beat the format's own mode_hint, which beats
+    # the built-in default. A line protocol or dns is designed for format
+    # mode, so a client that took the port default gets the mode the format
+    # was made for, not a high-entropy hybrid tail it never asked for.
+    mode = args.mode or uri.mode or mode_hint_for(base) or DEFAULT_MODE
+    if args.format and from_port and args.format != from_port:
+        fteproxy.warn('format %s does not match port %d, where %s is what an '
+                      'observer expects' % (args.format, uri.port, from_port))
 
     try:
         socks_specs = [fteproxy.config.split_socks_spec(spec)

--- a/fteproxy/conf.py
+++ b/fteproxy/conf.py
@@ -99,8 +99,11 @@ conf['runtime.fteproxy.record_layer.mode'] = 'hybrid'
 """The base format name a client uses when it is given none.
 
 A base name, not a direction: the request and response formats are derived
-from it, and only the base travels in the handshake."""
-conf['fteproxy.default_format'] = 'manual-http'
+from it, and only the base travels in the handshake. The command line goes
+further and picks the format matching the server's port (see
+:func:`fteproxy.config.format_for_port`); this is the last-resort default for
+a library caller that names none."""
+conf['fteproxy.default_format'] = 'http'
 
 
 """Covertext length for definitions that carry no "length" key (the manual-*
@@ -108,5 +111,10 @@ and dummy-* formats)."""
 conf['fteproxy.default_length'] = 2 ** 8
 
 
-"""The default definitions file to use."""
-conf['fteproxy.defs.release'] = '20260110'
+"""The default definitions file to use.
+
+Since the 20260903 release that is the five cleartext protocols (http, ftp,
+smtp, sip, dns), one entry per direction. The comprehensive shape catalog that
+used to be the default is still shipped as 20260110 and is reachable with
+``--defs 20260110``."""
+conf['fteproxy.defs.release'] = '20260903'

--- a/fteproxy/config.py
+++ b/fteproxy/config.py
@@ -203,6 +203,28 @@ class ConnectionString:
                    for name in self.__slots__)
 
 
+def format_for_port(port, definitions=None):
+    """The base format a server on ``port`` most likely wants, or ``None``.
+
+    Every shipped format names the ports its protocol is normally seen on
+    (schema v2's ``port`` list), so a client dialing a server parked on 21 can
+    speak FTP-shaped covertexts without being told to. The first entry in file
+    order that claims the port wins, and a release whose formats carry no port
+    lists (the shape catalog) matches nothing, leaving the caller's own default
+    in place.
+
+    This is only a default: ``--format`` and the connection string's
+    ``?format=`` hint both beat it.
+    """
+    import fteproxy.defs  # deferred: fteproxy.defs imports this module's package
+    if definitions is None:
+        definitions = fteproxy.defs.load_definitions()
+    for name, spec in definitions.items():
+        if port in fteproxy.defs.spec_port(spec):
+            return fteproxy.defs.base_name(name)
+    return None
+
+
 def _is_ipv6_literal(host):
     return ':' in host
 

--- a/fteproxy/defs/20260903.json
+++ b/fteproxy/defs/20260903.json
@@ -1,1 +1,118 @@
-{}
+{
+    "http-request": {
+        "regex": "^(GET|POST|HEAD) /[a-zA-Z0-9/._?=&%-]* HTTP/1\\.1\r\nHost: [a-z0-9.-]+\r\nUser-Agent: Mozilla/5\\.0 \\([a-zA-Z0-9;: .()/_-]+\\)\r\nAccept: [a-zA-Z0-9/*,;= .+-]+\r\nAccept-Language: [a-z,;=0-9. -]+\r\n\r\n$",
+        "length": 512,
+        "port": [
+            80,
+            8080,
+            8000
+        ],
+        "role": "request",
+        "mode_hint": "hybrid",
+        "default": true,
+        "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers"
+    },
+    "http-response": {
+        "regex": "^HTTP/1\\.1 (200 OK|302 Found|404 Not Found)\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: [0-9]+\r\nServer: [a-zA-Z0-9/. ()_-]+\r\n\r\n[a-zA-Z0-9/+= \r\n-]*$",
+        "length": 512,
+        "port": [
+            80,
+            8080,
+            8000
+        ],
+        "role": "response",
+        "mode_hint": "hybrid",
+        "default": true,
+        "description": "HTTP/1.1 200/302/404 response with headers and a body"
+    },
+    "ftp-request": {
+        "regex": "^((USER|PASS|CWD|RETR|STOR|LIST) [a-zA-Z0-9._@/-]+|TYPE [AI]|PASV|QUIT)\r\n$",
+        "length": 256,
+        "port": [
+            21
+        ],
+        "role": "request",
+        "mode_hint": "format",
+        "default": false,
+        "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated"
+    },
+    "ftp-response": {
+        "regex": "^(220|230|331|250|150|226|550) [a-zA-Z0-9 .,:()/-]+\r\n$",
+        "length": 256,
+        "port": [
+            21
+        ],
+        "role": "response",
+        "mode_hint": "format",
+        "default": false,
+        "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated"
+    },
+    "smtp-request": {
+        "regex": "^(EHLO [a-z0-9.-]+|HELO [a-z0-9.-]+|MAIL FROM:<[a-z0-9._%+-]+@[a-z0-9.-]+>|RCPT TO:<[a-z0-9._%+-]+@[a-z0-9.-]+>|VRFY [a-z0-9._%+-]+|DATA|RSET|NOOP|QUIT)\r\n$",
+        "length": 320,
+        "port": [
+            25,
+            587
+        ],
+        "role": "request",
+        "mode_hint": "format",
+        "default": false,
+        "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated"
+    },
+    "smtp-response": {
+        "regex": "^((220|250|354|421|550) |250-)[a-zA-Z0-9 .,;:()<>@_-]+\r\n$",
+        "length": 256,
+        "port": [
+            25,
+            587
+        ],
+        "role": "response",
+        "mode_hint": "format",
+        "default": false,
+        "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form"
+    },
+    "sip-request": {
+        "regex": "^(INVITE|REGISTER|ACK|BYE|OPTIONS) sip:[a-z0-9._-]+@[a-z0-9.-]+ SIP/2\\.0\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
+        "length": 512,
+        "port": [
+            5060
+        ],
+        "role": "request",
+        "mode_hint": "format",
+        "default": false,
+        "description": "SIP/2.0 request line (INVITE/REGISTER/ACK/BYE/OPTIONS) with the mandatory Via/From/To/Call-ID/CSeq headers"
+    },
+    "sip-response": {
+        "regex": "^SIP/2\\.0 (100 Trying|180 Ringing|200 OK|404 Not Found)\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
+        "length": 512,
+        "port": [
+            5060
+        ],
+        "role": "response",
+        "mode_hint": "format",
+        "default": false,
+        "description": "SIP/2.0 status line (100/180/200/404) with the mandatory Via/From/To/Call-ID/CSeq headers"
+    },
+    "dns-request": {
+        "regex": "^\u0001\u000e[\u0000-\u00ff][\u0000-\u00ff]\u0001\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000(\u0002[a-zA-Z0-9][a-zA-Z0-9]|\u0003[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]|\u0004[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0005[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0006[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0007[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\t[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\n[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\r[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000e[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9])+(\u0003[cC][oO][mM]|\u0003[nN][eE][tT]|\u0003[oO][rR][gG]|\u0003[eE][dD][uU]|\u0004[iI][nN][fF][oO]|\u0002[iI][oO]|\u0002[dD][eE]|\u0002[uU][kK])\u0000(\u0000\u0001|\u0000\u001c)\u0000\u0001$",
+        "length": 272,
+        "port": [
+            53
+        ],
+        "role": "request",
+        "mode_hint": "format",
+        "default": false,
+        "description": "DNS over TCP query (RFC 1035 4.2.2): 2-byte length prefix, 12-byte header, one A/AAAA question; the fixed 272-byte covertext pads QNAME to 254 octets -- inside the 255-octet limit but far longer than a real name (see F7)"
+    },
+    "dns-response": {
+        "regex": "^\u0001\u000e[\u0000-\u00ff][\u0000-\u00ff]\u0081\u0080\u0000\u0001\u0000\u0001\u0000\u0000\u0000\u0000(\u0002[a-zA-Z0-9][a-zA-Z0-9]|\u0003[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]|\u0004[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0005[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0006[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0007[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\t[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\n[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\r[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000e[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9])+(\u0003[cC][oO][mM]|\u0003[nN][eE][tT]|\u0003[oO][rR][gG]|\u0003[eE][dD][uU]|\u0004[iI][nN][fF][oO]|\u0002[iI][oO]|\u0002[dD][eE]|\u0002[uU][kK])\u0000\u0000\u0001\u0000\u0001\u00c0\f\u0000\u0001\u0000\u0001\u0000\u0000[\u0000-\u00ff][\u0000-\u00ff]\u0000\u0004[\u0001-~\u0080-\u00df][\u0000-\u00ff][\u0000-\u00ff][\u0000-\u00ff]$",
+        "length": 272,
+        "port": [
+            53
+        ],
+        "role": "response",
+        "mode_hint": "format",
+        "default": false,
+        "description": "DNS over TCP NOERROR response (RFC 1035 4.2.2): the question echoed plus one A record via a 0xc00c name pointer; the fixed 272-byte covertext pads QNAME to 238 octets -- valid but far longer than a real name (see F7)"
+    }
+}

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -18,6 +18,7 @@ import fteproxy.cli
 import fteproxy.conf
 import fteproxy.config
 import fteproxy.defs
+import fteproxy.relay
 
 
 PUBLIC = bytes(range(32))
@@ -414,14 +415,30 @@ class TestKeygen:
 class TestFormats:
 
     def test_lists_base_names_with_capacity(self, capsys):
-        assert fteproxy.cli.main(['formats']) == fteproxy.cli.EXIT_OK
+        """The shape catalog, which is where manual-http lives since the
+        20260903 release made the five cleartext protocols the default."""
+        assert fteproxy.cli.main(['formats', '--defs', '20260110']) == \
+            fteproxy.cli.EXIT_OK
         out = capsys.readouterr().out
         assert 'manual-http' in out
         # Base names only: the direction suffixes are columns, not rows.
         assert 'manual-http-request' not in out
-        assert '(default)' in out
         # manual-http-response carries 192 bytes per covertext at length 256.
         assert '192' in out
+
+    def test_the_default_release_is_the_five_protocols(self, capsys):
+        assert fteproxy.cli.main(['formats']) == fteproxy.cli.EXIT_OK
+        out = capsys.readouterr().out
+        assert '20260903' in out
+        for base in ('http', 'ftp', 'smtp', 'sip', 'dns'):
+            assert base in out
+        # Base names only: the direction suffixes are columns, not rows.
+        assert 'http-request' not in out
+        assert '(default)' in out
+        # The default base is http, and it is the only one marked.
+        assert out.count('(default)') == 1
+        assert 'http' in [line.split()[0] for line in out.splitlines()
+                          if '(default)' in line]
 
     def test_honours_the_release(self, capsys):
         assert fteproxy.cli.main(['formats', '--defs', '20131224']) == \
@@ -473,6 +490,106 @@ class TestClientStartup:
             fteproxy.cli.main(['client', '--no-check',
                                '--state-dir', str(tmp_path / 'empty')])
         assert excinfo.value.code == fteproxy.cli.EXIT_USAGE
+
+
+class TestPortSelectsTheFormat:
+    """A client told no format picks the one whose protocol runs on the port.
+
+    The whole point of an FTE format is that a DPI rule for the port it
+    arrives on matches it, so a server parked on 21 wants FTP-shaped
+    covertexts and one on 8080 wants HTTP-shaped ones. A ``--format`` flag and
+    the connection string's ``?format=`` hint both still win.
+    """
+
+    @pytest.fixture
+    def chosen(self, monkeypatch, tmp_path):
+        """Run ``fteproxy client`` and report the format it handed a listener.
+
+        The listener is replaced, so nothing is dialled and no port is bound:
+        the assertion is about the choice, which is made before either.
+        """
+        captured = {}
+
+        class _Listener:
+            def __init__(self, local_ip, local_port, *args, **kwargs):
+                captured.update(kwargs)
+                self.address = (local_ip, local_port)
+                self.daemon = False
+
+            def bind(self):
+                pass
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(fteproxy.relay, 'ForwardListener', _Listener)
+        monkeypatch.setattr(fteproxy.cli, 'serve_forever',
+                            lambda listeners: fteproxy.cli.EXIT_OK)
+
+        def run(port, *extra, query=''):
+            captured.clear()
+            status = fteproxy.cli.main([
+                'client', 'fte://%s@203.0.113.5:%d%s' % (SERVER_ID, port, query),
+                '-L', '19999:127.0.0.1:22', '--no-check',
+                '--state-dir', str(tmp_path)] + list(extra))
+            assert status == fteproxy.cli.EXIT_OK
+            return captured['format']
+
+        return run
+
+    @pytest.mark.parametrize('port,expected', [
+        (21, 'ftp'),
+        (25, 'smtp'),
+        (587, 'smtp'),
+        (53, 'dns'),
+        (5060, 'sip'),
+        (80, 'http'),
+        (8080, 'http'),
+    ])
+    def test_the_port_picks_the_format(self, chosen, port, expected):
+        assert chosen(port) == expected
+
+    @pytest.mark.parametrize('port', [1, 4433, 9001, 51820])
+    def test_an_unlisted_port_falls_back_to_http(self, chosen, port):
+        assert chosen(port) == fteproxy.cli.DEFAULT_FORMAT == 'http'
+
+    def test_the_uri_hint_beats_the_port(self, chosen):
+        assert chosen(21, query='?format=sip') == 'sip'
+
+    def test_the_flag_beats_everything(self, chosen):
+        assert chosen(21, '--format', 'smtp', query='?format=sip') == 'smtp'
+
+    def test_a_flag_that_disagrees_with_the_port_warns(self, chosen, capsys):
+        """The choice is honoured, but an FTP-shaped stream on port 53 is what
+        the format is meant to avoid, so it is said out loud."""
+        assert chosen(21, '--format', 'dns') == 'dns'
+        assert 'does not match port 21' in capsys.readouterr().err
+
+    def test_the_port_default_does_not_warn(self, chosen, capsys):
+        assert chosen(21) == 'ftp'
+        assert 'does not match port' not in capsys.readouterr().err
+
+
+class TestFormatForPort:
+    """The mapping itself, without the command line around it."""
+
+    @pytest.mark.parametrize('port,expected', [
+        (21, 'ftp'), (25, 'smtp'), (587, 'smtp'), (53, 'dns'),
+        (5060, 'sip'), (80, 'http'), (8000, 'http'), (8080, 'http'),
+    ])
+    def test_a_listed_port(self, port, expected):
+        assert fteproxy.config.format_for_port(port) == expected
+
+    @pytest.mark.parametrize('port', [1, 22, 443, 1080, 9001])
+    def test_an_unlisted_port_matches_nothing(self, port):
+        assert fteproxy.config.format_for_port(port) is None
+
+    def test_a_release_without_port_lists_matches_nothing(self):
+        """The shape catalog carries no ports, so the caller's own default
+        stands and nothing is silently renamed."""
+        shapes = {'manual-http-request': {'regex': '^[a-z]+$'},
+                  'manual-http-response': {'regex': '^[a-z]+$'}}
+        assert fteproxy.config.format_for_port(80, shapes) is None
 
 
 class TestServerStartup:
@@ -577,3 +694,70 @@ class TestLogRedaction:
         with caplog.at_level(logging.INFO, logger='fteproxy'):
             fteproxy.info('listening on 127.0.0.1:1080, format manual-http')
         assert 'listening on 127.0.0.1:1080, format manual-http' in caplog.text
+
+
+class TestModeFollowsTheFormat:
+    """A format's ``mode_hint`` is the client's default mode.
+
+    The line protocols and dns are designed for ``format`` mode -- a raw
+    hybrid body has no place inside them and leaks a high-entropy tail -- so a
+    client that took the port default must get the mode the format was made
+    for. ``--mode`` and the connection string's ``?mode=`` hint both still win.
+    """
+
+    @pytest.fixture
+    def chosen_mode(self, monkeypatch, tmp_path):
+        captured = {}
+
+        class _Listener:
+            def __init__(self, local_ip, local_port, *args, **kwargs):
+                captured.update(kwargs)
+                self.address = (local_ip, local_port)
+                self.daemon = False
+
+            def bind(self):
+                pass
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(fteproxy.relay, 'ForwardListener', _Listener)
+        monkeypatch.setattr(fteproxy.cli, 'serve_forever',
+                            lambda listeners: fteproxy.cli.EXIT_OK)
+
+        def run(port, *extra, query=''):
+            captured.clear()
+            status = fteproxy.cli.main([
+                'client', 'fte://%s@203.0.113.5:%d%s' % (SERVER_ID, port, query),
+                '-L', '19999:127.0.0.1:22', '--no-check',
+                '--state-dir', str(tmp_path)] + list(extra))
+            assert status == fteproxy.cli.EXIT_OK
+            return captured['format'], captured['mode']
+
+        return run
+
+    @pytest.mark.parametrize('port,expected', [
+        (21, ('ftp', 'format')),
+        (25, ('smtp', 'format')),
+        (53, ('dns', 'format')),
+        (5060, ('sip', 'format')),
+        (80, ('http', 'hybrid')),
+        (8080, ('http', 'hybrid')),
+    ])
+    def test_the_port_default_brings_its_mode(self, chosen_mode, port, expected):
+        assert chosen_mode(port) == expected
+
+    def test_an_unlisted_port_is_http_and_hybrid(self, chosen_mode):
+        assert chosen_mode(9001) == ('http', 'hybrid')
+
+    def test_the_flag_beats_the_format_hint(self, chosen_mode):
+        assert chosen_mode(21, '--mode', 'hybrid') == ('ftp', 'hybrid')
+        assert chosen_mode(8080, '--mode', 'format') == ('http', 'format')
+
+    def test_the_uri_hint_beats_the_format_hint(self, chosen_mode):
+        assert chosen_mode(21, query='?mode=hybrid') == ('ftp', 'hybrid')
+
+    def test_mode_hint_for_reads_the_release(self):
+        assert fteproxy.cli.mode_hint_for('ftp') == 'format'
+        assert fteproxy.cli.mode_hint_for('http') == 'hybrid'
+        assert fteproxy.cli.mode_hint_for('no-such-format') is None

--- a/fteproxy/tests/test_formats.py
+++ b/fteproxy/tests/test_formats.py
@@ -19,6 +19,23 @@ import fteproxy.record_layer
 _KEY = conftest.TEST_KEY
 
 
+@pytest.fixture(autouse=True)
+def _restore_release():
+    """Put the process-wide definitions release back after every test here.
+
+    This file exercises the comprehensive *shape* catalog, which stopped being
+    the default in the 20260903 release, so every test in it selects 20260110
+    (or 20131224) explicitly. Without this the selection would leak into every
+    later test in the session, which would then quietly run against a release
+    it never asked for.
+    """
+    previous = fteproxy.conf.getValue('fteproxy.defs.release')
+    saved = fteproxy.defs._definitions
+    yield
+    fteproxy.conf.setValue('fteproxy.defs.release', previous)
+    fteproxy.defs._definitions = saved
+
+
 def _cipher(pattern, length):
     """Build a libfte 0.4 cipher (successor to ``fte.Encoder(pattern, length)``)."""
     return fteproxy._make_cipher(pattern, length, _KEY)

--- a/fteproxy/tests/test_python3.py
+++ b/fteproxy/tests/test_python3.py
@@ -194,7 +194,7 @@ class TestWrapSocket:
             conn.close()
             sock.close()
 
-    def _run(self, payload, mode, format='manual-http'):
+    def _run(self, payload, mode, format='http'):
         private, public = fteproxy.generate_server_key()
         probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         probe.bind(('127.0.0.1', 0))
@@ -232,16 +232,16 @@ class TestWrapSocket:
         assert got == payload
         assert echo == payload
         assert client.negotiated_mode == mode
-        assert client.negotiated_format == 'manual-http'
+        assert client.negotiated_format == 'http'
 
     def test_server_learns_a_non_default_format(self):
         """The server is told nothing; it recovers the format from the first
         record."""
         got, echo, client = self._run(b'a non-default format', 'hybrid',
-                                      format='words')
+                                      format='ftp')
         assert got == b'a non-default format'
         assert echo == got
-        assert client.negotiated_format == 'words'
+        assert client.negotiated_format == 'ftp'
 
     def test_wrong_server_id_gets_no_reply(self):
         """A client with the wrong connection string times out rather than

--- a/fteproxy/tests/test_record_layer.py
+++ b/fteproxy/tests/test_record_layer.py
@@ -22,6 +22,27 @@ START = 0
 ITERATIONS = 2048
 STEP = 64
 
+#: The comprehensive *shape* catalog. These tests exercise the record layer
+#: against ``manual-http-*`` and against every entry in one release, which is
+#: what this catalog is: 46 formats of every shape, from a single-character
+#: alphabet to a full HTTP message. It stopped being the shipped default when
+#: the 20260903 cleartext-protocol release landed, so it is selected by name
+#: here rather than inherited.
+SHAPE_CATALOG = '20260110'
+SHAPE_FORMAT = 'manual-http-request'
+
+
+@pytest.fixture(autouse=True)
+def _shape_catalog():
+    """Point the loader at the shape catalog for this module, then restore."""
+    previous = fteproxy.conf.getValue('fteproxy.defs.release')
+    saved = fteproxy.defs._definitions
+    fteproxy.conf.setValue('fteproxy.defs.release', SHAPE_CATALOG)
+    fteproxy.defs._definitions = None
+    yield
+    fteproxy.conf.setValue('fteproxy.defs.release', previous)
+    fteproxy.defs._definitions = saved
+
 
 @pytest.fixture
 def record_layer_pairs():
@@ -170,7 +191,7 @@ class TestDecoderExceptionHandling:
 class TestHybridRecordLayer:
     """The hybrid framing: a formatted header covertext + a raw authenticated body."""
 
-    def _pair(self, language='manual-http-request'):
+    def _pair(self, language=SHAPE_FORMAT):
         key = conftest.TEST_KEY
         pattern = fteproxy.defs.getRegex(language)
         length = fteproxy.defs.getLength(language)
@@ -282,7 +303,7 @@ class TestHybridRecordLayer:
 class TestFormatModeRecordLayer:
     """'format' mode: one sealed covertext per record, stamped with its position."""
 
-    def _pair(self, language='manual-http-request'):
+    def _pair(self, language=SHAPE_FORMAT):
         key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
             fteproxy.defs.getRegex(language), fteproxy.defs.getLength(language), key)
@@ -345,7 +366,7 @@ def test_seal_fills_covertext_with_random_not_padding():
 class TestRecordTypes:
     """Every record carries a type byte; unknown types close the connection."""
 
-    def _pair(self, hybrid=True, language='manual-http-request'):
+    def _pair(self, hybrid=True, language=SHAPE_FORMAT):
         key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
             fteproxy.defs.getRegex(language),
@@ -410,8 +431,8 @@ class TestRecordTypes:
         record, not one plus a one-byte straggler."""
         key = conftest.TEST_KEY
         cipher = fteproxy._make_cipher(
-            fteproxy.defs.getRegex('manual-http-request'),
-            fteproxy.defs.getLength('manual-http-request'), key)
+            fteproxy.defs.getRegex(SHAPE_FORMAT),
+            fteproxy.defs.getLength(SHAPE_FORMAT), key)
         formatted = fteproxy.record_layer.Encoder(cipher=cipher)
         assert formatted.capacity == cipher.max_plaintext_bytes - 12 - 1
         body = fteproxy._make_body_cipher(key)
@@ -446,8 +467,8 @@ class TestDecoderFailsClosed:
 
     def _pair(self, hybrid):
         key = conftest.TEST_KEY
-        regex = fteproxy.defs.getRegex('manual-http-request')
-        length = fteproxy.defs.getLength('manual-http-request')
+        regex = fteproxy.defs.getRegex(SHAPE_FORMAT)
+        length = fteproxy.defs.getLength(SHAPE_FORMAT)
         cipher = fteproxy._make_cipher(regex, length, key)
         body = fteproxy._make_body_cipher(key) if hybrid else None
         enc = fteproxy.record_layer.Encoder(cipher=cipher, body_cipher=body)

--- a/fteproxy/tests/test_relay.py
+++ b/fteproxy/tests/test_relay.py
@@ -403,7 +403,7 @@ class TestStartupCheck:
     def test_check_reports_the_negotiated_session(self, tunnel_factory):
         tunnel = tunnel_factory()
         listener = tunnel.forward((LOCAL, 1))
-        assert listener.check() == ('manual-http', 'hybrid')
+        assert listener.check() == ('http', 'hybrid')
 
     def test_check_fails_on_a_wrong_server_id(self, tunnel_factory):
         tunnel = tunnel_factory()

--- a/fteproxy/tests/test_release_assembly.py
+++ b/fteproxy/tests/test_release_assembly.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The shipped 20260903 release is the assembly of the per-protocol parts.
+
+``fteproxy/defs/parts/<proto>.json`` is the source of truth for one protocol:
+phases F1-F5 each wrote one, and F6 merged them into the dated release the
+package ships. These tests keep the two from drifting -- an edit to a fragment
+that never reaches ``20260903.json`` fails here rather than shipping -- and
+pin what the release promises: the five cleartext protocols, both directions
+each, http the only default.
+"""
+
+import glob
+import json
+import os
+
+import pytest
+
+import fteproxy
+import fteproxy.conf
+import fteproxy.defs
+import fteproxy.defs.validate as validate
+
+
+RELEASE = '20260903'
+
+DEFS_DIR = os.path.dirname(os.path.abspath(fteproxy.defs.__file__))
+PARTS_DIR = os.path.join(DEFS_DIR, 'parts')
+RELEASE_PATH = os.path.join(DEFS_DIR, RELEASE + '.json')
+
+PROTOCOLS = {'http', 'ftp', 'smtp', 'sip', 'dns'}
+
+
+def _load(path):
+    with open(path) as handle:
+        return json.load(handle)
+
+
+def _parts():
+    """Every fragment, merged. Fails on a name two fragments both claim."""
+    merged = {}
+    paths = sorted(glob.glob(os.path.join(PARTS_DIR, '*.json')))
+    assert paths, 'no fragments under %s' % PARTS_DIR
+    for path in paths:
+        for name, spec in _load(path).items():
+            assert name not in merged, \
+                '%s is defined by two fragments' % name
+            merged[name] = spec
+    return merged
+
+
+class TestAssembly:
+    """The release file is exactly the union of the fragments."""
+
+    def test_the_release_is_the_merge_of_every_fragment(self):
+        assert _load(RELEASE_PATH) == _parts()
+
+    def test_every_protocol_ships_a_fragment(self):
+        names = {os.path.splitext(os.path.basename(path))[0]
+                 for path in glob.glob(os.path.join(PARTS_DIR, '*.json'))}
+        assert names == PROTOCOLS
+
+    def test_the_release_has_ten_entries(self):
+        """Five protocols, a request and a response each."""
+        assert len(_load(RELEASE_PATH)) == 2 * len(PROTOCOLS)
+
+
+class TestReleaseValidates:
+
+    def test_validate_release_passes(self):
+        """Every entry builds, clears the capacity floor, round-trips the
+        record layer, and matches its regex in format mode."""
+        summary = validate.validate_release(RELEASE, samples=8)
+        assert {name for name, _l, _c, _m in summary} == \
+            {'%s-%s' % (proto, direction)
+             for proto in PROTOCOLS for direction in ('request', 'response')}
+        for name, _length, capacity, _mode in summary:
+            assert capacity >= fteproxy.defs.MIN_CAPACITY, name
+
+
+class TestReleaseContents:
+
+    @pytest.fixture
+    def definitions(self):
+        return _load(RELEASE_PATH)
+
+    def test_base_names_are_the_five_protocols(self, definitions):
+        assert fteproxy.defs.base_names(definitions) == PROTOCOLS
+
+    def test_http_is_the_only_default(self, definitions):
+        marked = {name for name, spec in definitions.items()
+                  if fteproxy.defs.spec_is_default(spec)}
+        assert marked == {'http-request', 'http-response'}
+        for name, spec in definitions.items():
+            expected = name.startswith('http-')
+            assert fteproxy.defs.spec_is_default(spec) is expected, name
+        assert fteproxy.defs.default_base(definitions) == 'http'
+
+    def test_every_entry_names_the_ports_it_defaults_on(self, definitions):
+        for name, spec in definitions.items():
+            assert fteproxy.defs.spec_port(spec), name
+
+    def test_the_release_is_the_shipped_default(self):
+        """What ``fteproxy client`` uses when no ``--defs`` is given."""
+        assert fteproxy.conf.getValue('fteproxy.defs.release') == RELEASE

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -21,6 +21,14 @@ import fteproxy.handshake
 import fteproxy.record_layer
 
 
+#: These tests drive the wrapper against the comprehensive *shape* catalog:
+#: ``manual-http`` is its HTTP-shaped entry, the pre-1.0 negotiation cell below
+#: names that release, and one test synthesises a twin of a shape entry. The
+#: catalog stopped being the shipped default when the 20260903 cleartext-
+#: protocol release landed, so it is selected by name here rather than
+#: inherited.
+SHAPE_CATALOG = '20260110'
+
 FORMAT = 'manual-http'
 MODE = 'hybrid'
 
@@ -29,7 +37,15 @@ SERVER_PRIVATE, SERVER_PUBLIC = fteproxy.generate_server_key()
 
 @pytest.fixture(autouse=True)
 def _defs():
+    """Select the shape catalog for this module, and put it back afterwards."""
+    previous = fteproxy.conf.getValue('fteproxy.defs.release')
+    saved = fteproxy.defs._definitions
+    fteproxy.conf.setValue('fteproxy.defs.release', SHAPE_CATALOG)
+    fteproxy.defs._definitions = None
     fteproxy.defs.load_definitions()
+    yield
+    fteproxy.conf.setValue('fteproxy.defs.release', previous)
+    fteproxy.defs._definitions = saved
 
 
 def _session_keys():
@@ -144,7 +160,7 @@ class TestServerRejectPath:
 
     def _hello_for(self, **overrides):
         settings = dict(server_public=SERVER_PUBLIC, format=FORMAT,
-                        mode=MODE, defs=20260110)
+                        mode=MODE, defs=int(SHAPE_CATALOG))
         settings.update(overrides)
         return fteproxy.handshake.ClientHandshake(**settings)
 
@@ -332,7 +348,7 @@ class TestPreProtocolClient:
     """
 
     LEGACY_KEY = b'\xFF' * 16 + b'\x00' * 16
-    LEGACY_CELL = b'\x00' * 32 + b'20260110' + b'manual-http'
+    LEGACY_CELL = b'\x00' * 32 + SHAPE_CATALOG.encode() + b'manual-http'
 
     def test_no_reply_and_one_debug_line(self, monkeypatch, caplog):
         import logging

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -327,7 +327,7 @@ class TestEndToEnd:
     def test_a_non_default_format_end_to_end(self, server, state_dir,
                                              destination):
         """The server is told no format; it learns it from the first record."""
-        proc = start(['client', '--format', 'words',
+        proc = start(['client', '--format', 'ftp',
                       '-L', '%s:%d:%s:%d'
                       % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
                       '--state-dir', state_dir])
@@ -362,8 +362,12 @@ class TestCLI:
     def test_formats_goes_to_stdout(self):
         result = run_cli(['formats'], timeout=60)
         assert result.returncode == 0
-        assert 'manual-http' in result.stdout
+        # The shipped release is the five cleartext protocols, http default.
+        for base in ('http', 'ftp', 'smtp', 'sip', 'dns'):
+            assert base in result.stdout
         assert '(default)' in result.stdout
+        assert [line.split()[0] for line in result.stdout.splitlines()
+                if '(default)' in line] == ['http']
 
     def test_keygen_prints_the_connection_string(self, tmp_path):
         result = run_cli(['keygen', '--state-dir', str(tmp_path / 'state')],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ exclude = ["fteproxy.tests*"]
 fteproxy = ["tests/*"]
 
 [tool.setuptools.package-data]
-fteproxy = ["defs/*.json"]
+# The dated releases, and the per-protocol fragments they are assembled from:
+# fteproxy/defs/parts/<proto>.json is the source of truth for one format, and
+# the test suite checks the shipped release against it.
+fteproxy = ["defs/*.json", "defs/parts/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["fteproxy/tests"]


### PR DESCRIPTION
### F6: assemble the release, flip the default to http, port-to-format mapping, docs

Integration phase of docs/plan-formats.md, on the revised set http, smtp,
ftp, sip, dns.

Assembly. fteproxy/defs/20260903.json is the union of the five
fteproxy/defs/parts/*.json fragments (10 entries); parts/ stays the
per-protocol source of truth and ships as package data alongside the
release. test_release_assembly.py asserts the release equals the merge of
every fragment, validate_release passes with every capacity above the
128-byte floor, base_names() is exactly {http, ftp, smtp, sip, dns}, and
http is the only default.

Default flipped. fteproxy.defs.release -> 20260903 and default_format ->
http in conf.py; DEFAULT_FORMAT -> http in cli.py. The shape catalog
(20260110, 46 formats) stays in place and reachable via --defs; it is
retired only from being the default. Tests that exercise the shape catalog
now select it explicitly through autouse fixtures that restore the release
afterwards (test_formats, test_record_layer, test_socket_wrapper, and the
formats CLI listing test); no assertion was removed or loosened. Tests
that assert the default were updated to http.

Port -> format. New fteproxy.config.format_for_port picks the base whose
schema port list contains the server's port; do_client resolves --format,
then the URI ?format= hint, then the port default, then http. A --format
that disagrees with the port still warns.

Mode follows the format. The F6 verifier caught that the per-format
mode_hint never reached the client: do_client defaulted to hybrid, so a
client that took the port default for ftp/smtp/sip/dns ran them in hybrid
mode and leaked the high-entropy tail SECURITY.md warns about, while three
documents said it was in format mode. do_client now resolves --mode, then
the URI ?mode= hint, then the format's own mode_hint, then hybrid
(mode_hint_for in cli.py); TestModeFollowsTheFormat covers the port
defaults, both overrides, and the helper.

Docs. README gains the five-protocol table, the port-defaulting rule and a
real formats listing; SECURITY.md gains a realism-limits bullet (structure
and entropy are real, values are random, one message type dominates per
format under uniform rank sampling) and a per-format mode-leak bullet;
PERFORMANCE.md notes four of five formats run in format mode by design;
PYPI_README and the release notes no longer advertise the shape catalog;
examples pick a format matching their port.

Suite green at 614 (was 566).

### docs: covertext replies never answer their requests (the DNS echo gap)

Adds the third realism limit the UDP feasibility study surfaced to
SECURITY.md's realism bullet. Every covertext is an independent unranking,
so nothing in the record layer can make a reply depend on its request. For
dns that is a cheap stateless tell: a response's ID and question section
never match the query's, a check DNS-aware middleboxes already perform.
Largely moot over TCP, decisive over UDP/53; fixing it is a protocol
change, not a format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
