### PR TITLE
F7: variable-length covertexts for the text formats

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -35,11 +35,23 @@ python3 benchmark.py --scenarios lan --sizes 64K 1M --mode format
 4. **`format` mode (every byte in the target format) is interactive-only:** same RTT
    class as `hybrid` (0.7 vs 0.5 ms) but 4–7 Mbit/s bulk, because the DFA runs on
    every ~140 bytes instead of once per record. Its cost is inherent to the mode.
+   Since the variable-length formats landed, the payload per DFA run is whatever
+   the chosen covertext length holds rather than one number — for `http-request`,
+   50 bytes at length 200 and 435 at length 700 — but the rate barely moves,
+   because a longer covertext costs proportionally more to rank. Measured
+   encode-side across that format's whole range: **0.65 MB/s at the shortest
+   length, 0.91 at the middle, 0.71 at the longest** (0.08 to 0.62 ms per
+   record). So variable length costs `format` mode nothing worth quoting, and
+   the mode's cost is still inherent to the mode.
 5. **libfte 0.4 caches nothing.** 0.3 cached its DFA tables globally, so building an
    encoder was free; 0.4 compiles a DFA per `RegexFormat` (0.5–1.5 ms). fteproxy
    therefore caches ciphers itself (`_make_cipher`, one per pattern/length/key),
    which brings connection setup to ~1 ms. Without the cache it was 8–12 ms, and a
-   connection closed before negotiating pinned the server at 64–100% CPU.
+   connection closed before negotiating pinned the server at 64–100% CPU. A
+   variable-length format needs one DFA per length it can emit, which is why the
+   set of lengths is small (eight) and fixed: the whole shipped catalog is 66
+   DFAs (8 variable entries × 8 lengths, plus one each for the two `dns`
+   entries), compiled once per process and shared by every connection.
 6. **Four of the five shipped formats run in `format` mode by design, so point 4
    is their normal operating point.** Since the `20260903` definitions release the
    default catalog is five cleartext protocols: `http` is `mode_hint: hybrid` (an
@@ -117,7 +129,22 @@ app → [client relay] ──FTE──→ [server relay] → dest
 - Interactive traffic: one 64 B message costs one 256-byte header plus a
   92-byte body (348 B, 5.4x; 0.3 and `format` mode send 256 B).
 - In `format` mode every ~140 bytes of payload is one DFA rank/unrank
-  (~0.16 ms), which is the 4–7 Mbit/s.
+  (~0.16 ms), which is the 4–7 Mbit/s. That 140 was the capacity of the
+  fixed-length shape format these numbers were taken on. With the shipped
+  variable-length formats it is the capacity of the length the record picked
+  (50–435 bytes for `http-request`, 2–148 for `ftp-request`) — and the cost of
+  the rank scales with the length too, so the byte rate is nearly flat across a
+  format's range. Encode-side over `http-request`'s eight lengths:
+
+  | covertext length | 200 | 271 | 343 | 414 | 486 | 557 | 629 | 700 |
+  |---|---:|---:|---:|---:|---:|---:|---:|---:|
+  | payload per record (B) | 50 | 105 | 160 | 215 | 270 | 325 | 380 | 435 |
+  | ms per record | 0.08 | 0.12 | 0.18 | 0.24 | 0.32 | 0.41 | 0.51 | 0.62 |
+  | MB/s | 0.65 | 0.88 | 0.91 | 0.88 | 0.84 | 0.80 | 0.75 | 0.71 |
+
+  The shortest length is the worst rate (per-record fixed costs over the least
+  payload) and the middle is the best; the spread is well under 2x, so which
+  length a record picks is not a throughput decision.
 
 ---
 
@@ -129,7 +156,10 @@ app → [client relay] ──FTE──→ [server relay] → dest
    `_regex_format` memoizes it on pattern and length, so setup went 8–12 ms →
    ~1 ms and the server's first-record scan on a failed connection 6 ms → free.
    The keyed `fte.FTE` on top is built per session (a couple of microseconds),
-   because since 0.4 every connection derives its own keys.
+   because since 0.4 every connection derives its own keys. A variable-length
+   format wants one entry per length, so the cache holds 1024 and a connection
+   builds its eight keyed ciphers per direction up front, in
+   `record_layer.VariableLength`, rather than one per record.
 3. **A pending header is decrypted once.** A 256 KiB record arrives in ~3 reads;
    the decoder used to re-rank and re-verify the same header on each partial
    delivery (two wasted header decrypts per record, more than the body itself).

--- a/README.md
+++ b/README.md
@@ -147,13 +147,20 @@ request and response covertexts are derived from it. The shipped release,
 since a protocol that is normally encrypted is better tunnelled inside the
 real thing:
 
-| Format | Ports | Direction split | Mode | What a covertext looks like |
-|---|---|---|---|---|
-| `http` | 80, 8080, 8000 | request / response | hybrid | `GET /… HTTP/1.1` with browser headers **(default)** |
-| `ftp` | 21 | command / reply | format | `USER …`, `220 … ready` control lines |
-| `smtp` | 25, 587 | command / reply | format | `EHLO …`, `250-…` command and reply lines |
-| `sip` | 5060 | request / response | format | `INVITE sip:…@… SIP/2.0` with Via/From/To/Call-ID/CSeq |
-| `dns` | 53 | query / response | format | DNS over TCP: length prefix, header, question, A record |
+| Format | Ports | Direction split | Mode | Covertext length | What a covertext looks like |
+|---|---|---|---|---|---|
+| `http` | 80, 8080, 8000 | request / response | hybrid | 200–700 | `GET /… HTTP/1.1` with browser headers **(default)** |
+| `ftp` | 21 | command / reply | format | 64–256 | `USER …`, `220 … ready` control lines |
+| `smtp` | 25, 587 | command / reply | format | 80–320 | `EHLO …`, `250-…` command and reply lines |
+| `sip` | 5060 | request / response | format | 300–800 | `INVITE sip:…@… SIP/2.0` with Via/From/To/Call-ID/CSeq |
+| `dns` | 53 | query / response | format | 272 (fixed) | DNS over TCP: length prefix, header, question, A record |
+
+The four text formats vary their covertext length: in `format` mode each record
+picks a length from across its range, so a captured stream shows a spread of
+message sizes instead of one repeated size. `dns` is fixed at 272 bytes — its
+two-byte length prefix is a literal in the regex, so every covertext length
+would need its own regex. The two handshake records and a `hybrid` mode header
+are always at the top of the range.
 
 `http` is the default. A client given no `--format` and no `?format=` hint
 picks the format whose protocol runs on the server's port -- a server on 21
@@ -169,11 +176,14 @@ the capacity of one covertext:
 $ fteproxy formats
 name  role      port          mode    req len  req cap  resp len  resp cap
 dns   req/resp  53            format      272      154       272       148
-ftp   req/resp  21            format      256      161       256       163
-http  req/resp  80,8080,8000  hybrid      512      303       512       316  (default)
-sip   req/resp  5060          format      512      258       512       259
-smtp  req/resp  25,587        format      320      181       256       166
+ftp   req/resp  21            format   64-256   15-161    64-256    16-163
+http  req/resp  80,8080,8000  hybrid  200-700   63-448   200-700    52-434  (default)
+sip   req/resp  5060          format  300-800   99-472   300-800   101-474
+smtp  req/resp  25,587        format   80-320   20-181    80-320    29-215
 ```
+
+A range in the length column is a format that varies its covertext length; a
+single number is a fixed-length one.
 
 The comprehensive catalog of abstract *shapes* that earlier versions defaulted
 to -- 46 entries, 23 base names (`manual-http`, `words`, `base64`, …) -- still
@@ -187,8 +197,9 @@ handshake; the server follows. Nothing has to be configured to match.
   followed by raw authenticated ciphertext. Fast — hundreds of MB/s — but only
   the header blends in with the target protocol.
 - `--mode format`: every byte on the wire is in the format, so the whole
-  stream is indistinguishable from the protocol. Much slower (about 1 MB/s),
-  for deployments facing entropy or statistical detectors.
+  stream is indistinguishable from the protocol, and each covertext takes a
+  length from across the format's range. Much slower (about 1 MB/s), for
+  deployments facing entropy or statistical detectors.
 
 Each format records the mode it is designed for (the `mode` column above), and
 that is what the client uses unless `--mode` says otherwise. `http` is hybrid:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,15 +103,18 @@ first. This section covers what fteproxy adds on top of it.
   connection string would be a route into every service bound to the server's
   own loopback.
 
-- **What an observer sees.** In `hybrid` mode (the default) only the first
-  `length` bytes of each record are in the target format; the rest of the
+- **What an observer sees.** In `hybrid` mode (the default) only each record's
+  fixed-length covertext header is in the target format; the rest of the
   record is high-entropy ciphertext, and its length (the plaintext length plus
   29 bytes) is visible. In `format` mode every byte on the wire is in the
-  target format. Sealed covertexts are always exactly `length` bytes and use
-  the format's whole rank space, so a short message neither shortens the
-  covertext nor leaves a run of the format's lowest character. The two
-  handshake records are one request-format covertext and one response-format
-  covertext, the same shape as any other record.
+  target format, and each record's covertext takes one of the lengths its
+  format may emit (see the next point). A sealed covertext always uses the
+  format's whole rank space at whatever length it was sealed at, so a short
+  message neither shortens the covertext nor leaves a run of the format's
+  lowest character. The two handshake records are one request-format covertext
+  and one response-format covertext, both at the format's longest length: a
+  connection therefore opens with two records of a size fixed by the format,
+  whatever the data records after them do.
 
 - **How realistic a covertext actually is.** The five shipped formats
   (`http`, `ftp`, `smtp`, `sip`, `dns`) model real message *structure*: every
@@ -127,16 +130,31 @@ first. This section covers what fteproxy adds on top of it.
   - **Field values are random.** A covertext's URL path, hostname, mail
     address, SIP tag or DNS label is a random string from the field's
     character class, not a plausible value: a 300-character random path, not
-    `/index.html`; a random Call-ID, not one a phone would mint. Field
-    *lengths* are fixed too -- every covertext of a format is exactly `length`
-    bytes -- so a length-distribution test separates a tunnel from real
-    traffic immediately.
+    `/index.html`; a random Call-ID, not one a phone would mint.
+  - **Message lengths vary, but they are not a real length distribution.**
+    Every covertext of a format used to be exactly `length` bytes, so a
+    length-distribution test separated a tunnel from real traffic without
+    reading a byte. In `format` mode the four text formats (`http`, `ftp`,
+    `smtp`, `sip`) now choose a covertext length per record from eight lengths
+    spanning the format's range -- weighted towards short lengths for
+    interactive traffic and long ones for bulk -- so a capture shows a spread
+    of message sizes rather than one repeated size. What it does *not* show is
+    the protocol's own length distribution: eight discrete values, sized by
+    what the record layer is carrying, are not the continuous, content-driven
+    lengths of real HTTP or SIP, and an adversary who models message lengths
+    finely can still tell the difference. Three things stay fixed: `dns` (its
+    two-byte length prefix is a literal in the regex, so a second length would
+    need a second regex), a `hybrid` header, and the two handshake records,
+    which are always at the format's longest length.
   - **One message type dominates.** Unranking a full-capacity plaintext lands
     in the same branch of the alternation nearly every time, so in practice
-    every `http` request samples as `GET`, every `sip` request as `BYE`, every
+    every `http` request samples as `GET`, every `sip` request as `ACK`, every
     `ftp` request as `CWD`, every `smtp` request as `VRFY`, and every `ftp`
-    reply as `150`. A stream that is all `BYE` with no `INVITE`, or all `CWD`
-    with no login, is not a conversation any real client would have.
+    reply as `150`. Variable length does not fix this: which branch dominates
+    depends on the covertext length, so a stream now shows a *few* message
+    types instead of exactly one, and each length still shows one of them
+    almost exclusively. A stream that is all `ACK` with no `INVITE`, or all
+    `CWD` with no login, is not a conversation any real client would have.
   - **Replies do not answer their requests.** Every covertext is an
     independent unranking of an independently randomised ciphertext, so
     nothing in the record layer can make a reply depend on the request it
@@ -160,12 +178,15 @@ first. This section covers what fteproxy adds on top of it.
   protocol (`ftp`, `smtp`, `sip`) or for the binary `dns` format there is no
   place a high-entropy tail belongs, so those ship as `mode_hint: format`
   (every byte in the protocol, at about 1 MB/s) and running them under
-  `--mode hybrid` leaks an obvious high-entropy tail after each line. `dns`
-  carries one more tell: at a fixed 272-byte covertext the capacity lives in
-  the QNAME, so every query pads out to a ~254-octet name -- legal, under the
-  255-octet limit, and far longer than any name real traffic resolves.
-  Variable-length covertexts (planned, phase F7) are what would narrow both
-  the length fingerprint and this one.
+  `--mode hybrid` leaks an obvious high-entropy tail after each line -- and,
+  because a `hybrid` header is fixed length, gives back the length fingerprint
+  the format-mode records no longer have. `dns` carries one more tell: at a
+  fixed 272-byte covertext the capacity lives in the QNAME, so every query pads
+  out to a ~254-octet name -- legal, under the 255-octet limit, and far longer
+  than any name real traffic resolves. Varying its length is the fix, and it is
+  the one format that cannot have it: the two-byte length prefix at the head of
+  a DNS-over-TCP message is a literal in the regex, so each covertext length
+  would need its own regex.
 
 - **Nothing secret is logged.** The package logger carries a redaction filter,
   installed at import, that strips a connection string's server-id, a hex key
@@ -175,9 +196,11 @@ first. This section covers what fteproxy adds on top of it.
 
 - **Patterns and lengths are trusted input.** The server compiles only the
   formats in its own definitions file; a client's hello can name one of them
-  but cannot supply a pattern. Never load a definitions file (`--defs`) from an
-  untrusted source: as libfte documents, a hostile pattern can make DFA
-  construction take exponential time and memory.
+  but cannot supply a pattern, a length, or a length range. Never load a
+  definitions file (`--defs`) from an untrusted source: as libfte documents, a
+  hostile pattern can make DFA construction take exponential time and memory,
+  and a variable-length entry multiplies that by the number of lengths it
+  declares (a fixed eight per format, so the multiplier is bounded).
 
 - **First-record cost.** For every new connection the server tries to unseal
   the first covertext as each known request format until one succeeds, most

--- a/docs/format-authoring.md
+++ b/docs/format-authoring.md
@@ -51,16 +51,20 @@ high-entropy bytes from its class. Therefore:
 > `fte.FTE.encrypt(short_message)`.
 
 The realism harness does this for you: `fteproxy.tests.realism.format_covertexts`
-drives the format-mode `Encoder` and slices the wire into individual sealed
-covertexts. Use it, and `statistical_guard`, in every `test_format_<proto>.py`.
+drives the format-mode `Encoder` and cuts the wire back into individual sealed
+covertexts — by length for a fixed-length format, on the terminator for a
+variable-length one, exactly as the decoder frames it. Pass it the definitions
+entry (`format_covertexts(spec, n=256)`) so it picks the right framing; passing
+`regex, length` still works for a fixed-length format. Use it, and
+`statistical_guard`, in every `test_format_<proto>.py`.
 
 **What this can and cannot buy.** A sealed covertext is *structurally* a valid
 message — correct verbs, headers, terminators — but its field *values* are
 random within their character class (a 300-character random URL path, not
-`/index.html`), and every covertext of a fixed-length format is the same length.
-Realistic value *content* and a realistic *length distribution* are not reachable
-by uniform rank sampling; phase F7 (variable length) narrows the length gap.
-State these limits honestly; do not imply more.
+`/index.html`). Realistic value *content* is not reachable by uniform rank
+sampling. A realistic *length distribution* is not either, though a
+variable-length format (below) at least replaces one repeated size with a
+spread of eight. State these limits honestly; do not imply more.
 
 ## The capacity floor: `>= 128`
 
@@ -68,6 +72,92 @@ Every format must carry the protocol-v1 client hello (about 75 bytes plus the
 28-byte AE frame) in one covertext. Build the cipher and require
 `max_plaintext_bytes >= fteproxy.defs.MIN_CAPACITY` (128). Raise `length` until
 it does. `defs-check` and the load-time `check_capacities` both enforce this.
+
+For a variable-length format the floor applies at `max_length`, because that is
+the length the handshake seals at. The *shortest* length only has to carry one
+data record — a type byte, the 12-byte seal, and at least one payload byte — and
+`defs-check` enforces that separately, at every length in the set.
+
+## Variable-length formats
+
+A fixed-length format emits every covertext at exactly one length, which is a
+fingerprint of its own: a length-distribution test separates it from real
+traffic without reading a byte. A format avoids that by declaring a range and a
+terminator instead of a `length`:
+
+```json
+"ftp-request": {
+  "regex": "^((USER|PASS|CWD) [a-zA-Z0-9._@/-]+|PASV|QUIT)\r\n$",
+  "min_length": 64,
+  "max_length": 256,
+  "terminator": "\r\n",
+  ...
+}
+```
+
+Then, in `format` mode, each record picks one of
+`fteproxy.defs.spec_allowed_lengths(spec)` — eight lengths spread evenly across
+the range, including both ends — and is sealed with a fixed-length cipher at
+that length. Both ends derive the set from the same definitions entry, so
+nothing about it is negotiated. `hybrid` mode, the two handshake records and the
+server's first-record scan all stay at `max_length`.
+
+Two rules make this work, and both are easy to get wrong.
+
+### The length must be chosen per record, not left to libfte
+
+`fte.RegexFormat` accepts a `min_length`/`max_length` pair and will happily rank
+the whole range for you. **Do not use it for this.** The number of strings in a
+language grows exponentially with length, so a uniformly random rank lands in
+the longest length class almost every time: a 64–512 range emits ~512-byte
+covertexts and the fingerprint survives, with nothing in the tests to show for
+it. `fteproxy.record_layer.VariableLength.choose_length` therefore picks the
+length itself, from the discrete set, before sealing — biased towards short
+lengths when the payload fits in one record and long ones when more data is
+queued, so a length histogram reflects what the connection is carrying.
+
+The set is small (eight) because each length costs one compiled DFA. A
+continuous range would cost one per byte.
+
+### The terminator must be impossible anywhere but the end
+
+The decoder frames the wire by reading up to the next terminator, so if the
+format's *language* can produce that byte string anywhere else, a covertext gets
+cut in half and the connection fails closed on traffic that was perfectly valid.
+`fteproxy.defs.validate.check_terminator_uniqueness` proves it cannot, from the
+pattern, with two conservative rules:
+
+1. **No character class may admit a terminator byte.** For a CRLF terminator,
+   no field may contain a CR or an LF at all. This is deliberately stronger than
+   "no class admits both": it makes every terminator byte come from a literal,
+   which is what makes rule 2 exhaustive.
+2. **No *literal skeleton* may contain the terminator before its end.** A
+   skeleton is one covertext with each character-class run collapsed to a
+   single placeholder — the literals and their adjacencies, and nothing else.
+   The check expands one skeleton per alternation branch and per
+   present-or-absent optional atom, rather than concatenating the pattern's
+   literals once, because a single concatenation both invents adjacencies that
+   never occur and, worse, *misses* the adjacency between a branch's last
+   character and whatever follows the group. A repetition is expanded to one
+   and two copies, which exposes the junction where a repeated unit meets
+   itself. A pattern that expands to more than 4096 skeletons is refused rather
+   than passed: framing that cannot be proven is not framing.
+
+`validate_format` also re-checks the property on sampled covertexts, which is
+the net for the one gap the static check leaves — a terminator spanning three or
+more copies of a repeated group.
+
+This is why `http-response` ends at the header block's `\r\n\r\n` with
+`Content-Length: 0` and has no body field: the body-absorbing
+`[a-zA-Z0-9/+= \r\n-]*` it used to end with admitted CR and LF, so a covertext
+could carry `\r\n\r\n` inside it. A response with no body (`302`, `304`, or a
+`200` with `Content-Length: 0`) is valid HTTP, and the capacity the body carried
+moved into the `Server`, `Content-Type`, `ETag` and `Set-Cookie` values.
+
+`dns` stays fixed length. A DNS-over-TCP message opens with a two-byte
+big-endian length prefix, which the regex spells as a literal, so a second
+covertext length would need a second regex — out of scope, and noted in
+SECURITY.md as the one format that keeps the length fingerprint.
 
 ## Mode suitability
 
@@ -89,19 +179,29 @@ every new key defaults so old files are unchanged). The optional keys:
 
 | key | type | default | meaning |
 |---|---|---|---|
-| `min_length`, `max_length` | int / null | `null` | reserved for F7 (variable length) |
+| `min_length`, `max_length` | int / null | `null` | variable length: the ends of the covertext-length range |
+| `terminator` | str / null | `null` | variable length: what every covertext ends with, and only ends with |
 | `port` | list[int] | `[]` | ports this format defaults on |
 | `role` | `request` \| `response` \| `line` | inferred from the name suffix | direction |
 | `mode_hint` | `hybrid` \| `format` | `hybrid` | designed-for record-layer mode |
 | `default` | bool | `false` | exactly one base marks itself the release default |
 | `description` | str | `""` | one-line human description |
 
+A format is fixed length (`length`) or variable length (all three of
+`min_length`, `max_length`, `terminator`), never both and never half of one:
+a partial declaration would load as a fixed-length format and quietly emit one
+length again, so `check_capacities` refuses it. `fteproxy.defs.getLength()` and
+`spec_length()` return `max_length` for a variable format, which is what the
+fixed-frame paths use.
+
 Example (one line in the JSON; wrapped here):
 
 ```json
 "http-request": {
-  "regex": "^(GET|POST) /...$",
-  "length": 512,
+  "regex": "^(GET|POST) /...\r\n\r\n$",
+  "min_length": 200,
+  "max_length": 700,
+  "terminator": "\r\n\r\n",
   "port": [80, 8080, 8000],
   "role": "request",
   "mode_hint": "hybrid",
@@ -112,8 +212,9 @@ Example (one line in the JSON; wrapped here):
 
 ## The verified HTTP starting point
 
-This compiles, holds 303 bytes of capacity at length 512, and parses with
-Python's HTTP request parser (one line in the JSON; shown wrapped):
+This compiles, holds 448 bytes of capacity at length 700 (50 at length 200),
+parses with Python's HTTP request parser, and satisfies the terminator rules
+above (one line in the JSON; shown wrapped):
 
 ```
 ^(GET|POST) /[a-zA-Z0-9/._?=&%-]* HTTP/1\.1\r\n
@@ -124,8 +225,10 @@ Accept-Language: [a-z,;=0-9. -]+\r\n
 \r\n$
 ```
 
-The matching response (F1) adds `HTTP/1\.1 (200 OK|302 Found|404 Not Found)`
-with `Content-Type`, `Content-Length`, `Server`, then a body-absorbing field.
+The matching response is `HTTP/1\.1 (200 OK|302 Found|304 Not Modified|404 Not
+Found)` with `Server`, `Content-Type`, `Content-Length: 0`, `ETag` and
+`Set-Cookie`, ending at the header block. It carried a body-absorbing field
+until F7; see the terminator rules for why that field had to go.
 
 ## The fragment-file convention (F1–F5)
 

--- a/docs/plan-formats.md
+++ b/docs/plan-formats.md
@@ -61,9 +61,11 @@ design decision:
    a fixed-length format is the same length. So the honest quality ceiling for
    v1 is: parses as the real protocol, plausible per-field character classes,
    high-entropy fields. Realistic value *content* (a real User-Agent string) and
-   a realistic *length distribution* are not reachable by uniform rank sampling;
-   variable length (phase F7) narrows the length gap. State these limits in
-   SECURITY.md rather than implying more.
+   a realistic *length distribution* are not reachable by uniform rank sampling.
+   Variable length (phase F7, landed) narrows the length gap: a format-mode
+   covertext takes one of eight lengths across its range instead of one repeated
+   size, which is a spread rather than the protocol's own distribution. State
+   these limits in SECURITY.md rather than implying more.
 
 ## Hard constraints every format must meet
 
@@ -196,6 +198,8 @@ Per-protocol notes:
 - **http (F1):** start from the verified regex above; add a matching response
   (`HTTP/1\.1 (200 OK|302 Found|404 Not Found)` with `Content-Type`,
   `Content-Length`, `Server`, then a body-absorbing field). `mode_hint: hybrid`.
+  (F7 removed that body field: it admitted CR and LF, which terminator framing
+  cannot allow. The response now ends at the header block.)
 - **ftp (F2):** requests `USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT`; replies
   `220/230/331/250/150/226/550 <text>`. `mode_hint: format`.
 - **smtp (F3):** requests `EHLO/MAIL FROM:<...>/RCPT TO:<...>/DATA/QUIT`; replies
@@ -215,8 +219,10 @@ Per-protocol notes:
   capacity lives in the label bytes. realism/dns.py MUST use an independent DNS
   parser (validate the header counts, label lengths, the compression pointer and
   RDLENGTH consistency), not the format regex. A fixed length pads the QNAME into a
-  long name, structurally valid but unusual; note it, and it is the strongest case
-  for F7 variable length. `mode_hint: format`. length chosen so capacity >= 128.
+  long name, structurally valid but unusual; note it. `mode_hint: format`. length
+  chosen so capacity >= 128. (F7 could not fix that padding: the two-byte length
+  prefix is a literal in the regex, so each covertext length would need its own
+  regex. `dns` is the one format that stays fixed length.)
 
 ### F6 — integration (after F1–F5)
 
@@ -248,7 +254,10 @@ exercise it select it by name. Suite: 604 passing (was 566).
 Acceptance: `uv run python -m fteproxy defs-check` (default release) passes;
 a server on 8080 with a no-hint client selects http end to end; `pytest` green.
 
-### F7 — variable-length covertexts (optional, independent)
+### F7 — variable-length covertexts
+
+Status: **done**, 2026-09-03. The fixed-length fingerprint is gone from
+format-mode data records on the four text formats. Suite: 729 passing (was 614).
 
 The one change that removes the fixed-length fingerprint. Format mode only.
 
@@ -266,6 +275,37 @@ The one change that removes the fixed-length fingerprint. Format mode only.
 Acceptance: `pytest` green; a captured stream shows a spread of covertext lengths
 rather than one.
 
+**What was built, and the two things a naive version gets wrong.**
+
+- The record layer picks the covertext length itself, per record, from
+  `fteproxy.defs.spec_allowed_lengths` — eight lengths spread evenly across
+  `[min_length, max_length]` — and seals with a *fixed-length* cipher at that
+  length (`record_layer.VariableLength`). **Not** by handing libfte a
+  `min_length`/`max_length` format: string counts grow exponentially with
+  length, so a uniform rank lands in the longest class almost every time and a
+  64–512 range would still emit ~512-byte covertexts. The choice is weighted
+  towards short lengths when the payload fits in one record and long ones when
+  more is queued, so a histogram reflects interactive versus bulk traffic.
+- Terminator uniqueness is **enforced**, not assumed:
+  `defs.validate.check_terminator_uniqueness` proves from the pattern that no
+  character class admits a terminator byte and that the literal skeleton
+  contains the terminator only at the end, and the sampled covertexts are
+  re-checked. `http-response` failed that check — its body-absorbing trailing
+  field admitted CR and LF — so the response now ends at the header block
+  (`Content-Length: 0`, a 302/304-style message with no body) and its capacity
+  lives in `Server`, `Content-Type`, `ETag` and `Set-Cookie`.
+- Ranges: `http` 200–700, `sip` 300–800, `smtp` 80–320, `ftp` 64–256. The
+  128-byte capacity floor applies at `max_length` (where the handshake seals);
+  the shortest length only has to carry one data record.
+- **`dns` stays fixed at 272.** Its two-byte big-endian length prefix is a
+  literal in the regex, so each covertext length would need its own regex. Noted
+  in SECURITY.md as the one shipped format that keeps the length fingerprint.
+- Unchanged: both handshake records and every `hybrid` header are one
+  `max_length` covertext, so `getLength()` returns `max_length` and the
+  first-record scan, `check_capacities` and the hybrid path did not move. The
+  shape catalog (`20260110`) is fixed-length throughout and behaves exactly as
+  before.
+
 ## Decisions for the maintainer
 
 - **D-F1** The five protocols above (vs a swap for POP3/SIP/NNTP/DNS).
@@ -276,3 +316,4 @@ rather than one.
   `examples/defs/`. Recommended: yes.
 - **D-F4** Do F7 (variable length) in this cycle or defer. Recommended: land
   F0–F6 first; F7 as a fast follow, since it is the only record-layer change.
+  *Settled: F7 landed 2026-09-03, for the four text formats; `dns` stays fixed.*

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -128,6 +128,20 @@ mode. `http` is the default format, and a client given neither `--format` nor a
 `?format=` hint picks the format whose protocol runs on the server's port,
 falling back to `http`.
 
+The four text formats no longer emit every covertext at one length. In `format`
+mode each record picks a covertext length from across the format's range --
+`http` 200–700 bytes, `sip` 300–800, `smtp` 80–320, `ftp` 64–256 -- and the
+decoder frames the wire on the format's terminator (`\r\n\r\n`, or `\r\n` for
+the line protocols) rather than on a fixed slice, so a capture shows a spread of
+message sizes instead of one repeated size. The choice leans short for
+interactive traffic and long for bulk. Three things stay fixed length: `dns`
+(its two-byte length prefix is a literal in the regex, so each length would need
+its own regex), a `hybrid` mode header, and the two handshake records, which are
+always at the top of the format's range. `http-response` lost its body field to
+make this safe -- a field that could contain CRLF CRLF would break terminator
+framing -- and is now a header-block-only 200/302/304/404 response with
+`Content-Length: 0`.
+
 The catalog of abstract shapes that earlier builds defaulted to (46 entries,
 `manual-http`, `words`, `base64`, …) is still shipped as release `20260110` and
 is reachable with `--defs 20260110`. Thirty-two of its entries have longer

--- a/examples/README.md
+++ b/examples/README.md
@@ -381,7 +381,8 @@ covertext (server to client) from it, so `--format http` is right and
 server follows.
 
 `fteproxy formats` is the authoritative list, and prints each format's
-covertext length and how many message bytes it carries.
+covertext length — a range for the four text formats, which vary it per record
+in `--mode format` — and how many message bytes it carries.
 
 The shipped release (`20260903`) is five real cleartext protocols. A client
 given no `--format` picks the one whose protocol runs on the server's port,

--- a/examples/formats/README.md
+++ b/examples/formats/README.md
@@ -46,11 +46,16 @@ carries:
 $ fteproxy formats
 name  role      port          mode    req len  req cap  resp len  resp cap
 dns   req/resp  53            format      272      154       272       148
-ftp   req/resp  21            format      256      161       256       163
-http  req/resp  80,8080,8000  hybrid      512      303       512       316  (default)
-sip   req/resp  5060          format      512      258       512       259
-smtp  req/resp  25,587        format      320      181       256       166
+ftp   req/resp  21            format   64-256   15-161    64-256    16-163
+http  req/resp  80,8080,8000  hybrid  200-700   63-448   200-700    52-434  (default)
+sip   req/resp  5060          format  300-800   99-472   300-800   101-474
+smtp  req/resp  25,587        format   80-320   20-181    80-320    29-215
 ```
+
+A range means the format varies its covertext length: in `--mode format` each
+record picks a length from across it, so a capture shows a spread of message
+sizes rather than one repeated size. `dns` is the exception and stays fixed at
+272 bytes.
 
 Given neither `--format` nor a `?format=` hint in the connection string, the
 client picks the format whose protocol runs on the server's port -- `ftp` for a
@@ -74,7 +79,8 @@ python3 -m fteproxy client 'fte://<server-id>@<server-ip>:5060'
 
 With the default `--mode hybrid` only a fixed-length header per record is in
 the chosen format and the rest of the record is raw authenticated ciphertext.
-`--mode format` puts every byte in the format, at much lower throughput.
+`--mode format` puts every byte in the format, at much lower throughput, and is
+also the only mode in which a format varies its covertext length.
 
 The same two choices are arguments to `fteproxy.wrap_socket()` on the client
 side:

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -31,7 +31,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from fteproxy.handshake import generate_server_key, server_id  # noqa: F401
 
 
-@functools.lru_cache(maxsize=256)
+@functools.lru_cache(maxsize=1024)
 def _regex_format(pattern, length):
     """The cached half of a libfte cipher: the compiled DFA.
 
@@ -43,6 +43,12 @@ def _regex_format(pattern, length):
 
     The tables are read-only, so one instance serves every connection and
     thread.
+
+    The cache holds one entry per ``(pattern, length)``, and a variable-length
+    format uses :data:`fteproxy.defs.LENGTH_STEPS` lengths rather than one, so
+    it is sized for every shipped format at every length it can emit, several
+    releases over, with room to spare. A definitions file large enough to
+    overflow it would only re-compile, not misbehave.
     """
     return fte.RegexFormat(pattern, length=length)
 
@@ -63,7 +69,7 @@ def _make_cipher(pattern, length, key):
     return fte.FTE(output_format=_regex_format(pattern, length), key=key)
 
 
-@functools.lru_cache(maxsize=256)
+@functools.lru_cache(maxsize=1024)
 def _cover_cipher(pattern, length, key):
     """The cipher for handshake records, cached.
 
@@ -313,11 +319,42 @@ def _cipher_for(format_name, key, cover=False):
                  fteproxy.defs.getLength(format_name), key)
 
 
+def _variable_lengths_for_spec(spec, key):
+    """The :class:`~fteproxy.record_layer.VariableLength` a definitions spec
+    describes, keyed with ``key``.
+
+    Builds the cipher for every length the format may emit. The costly half of
+    each is the DFA, which :func:`_regex_format` hands back from the
+    process-wide cache, so a connection pays a few microseconds per length
+    rather than a compile.
+    """
+    regex = spec['regex']
+    ciphers = {length: _make_cipher(regex, length, key)
+               for length in fteproxy.defs.spec_allowed_lengths(spec)}
+    return fteproxy.record_layer.VariableLength(
+        ciphers, fteproxy.defs.spec_terminator(spec))
+
+
+def _variable_for(format_name, key):
+    """The :class:`~fteproxy.record_layer.VariableLength` for a loaded format
+    name, or ``None`` if that format is fixed length (which leaves its framing
+    exactly as it was)."""
+    spec = fteproxy.defs._spec(format_name)
+    if not fteproxy.defs.spec_is_variable(spec):
+        return None
+    return _variable_lengths_for_spec(spec, key)
+
+
 def _session_channel(base, mode, keys, is_client):
     """Build the ``(Encoder, Decoder)`` pair for one end of a session.
 
     Each direction gets its own header key and body key, so the two directions
     are cryptographically independent streams that happen to share a socket.
+
+    In ``format`` mode a variable-length format also gets the ciphers for every
+    length it may emit; in ``hybrid`` mode it does not, because a hybrid record
+    is a fixed-length header plus a raw body and only the header is in the
+    format at all.
     """
     request, response = _format_pair(base)
     outgoing, incoming = ((request, response) if is_client
@@ -327,10 +364,12 @@ def _session_channel(base, mode, keys, is_client):
     hybrid = (mode == fteproxy.handshake.MODE_HYBRID)
     encoder = fteproxy.record_layer.Encoder(
         cipher=_cipher_for(outgoing, out_header),
-        body_cipher=_make_body_cipher(out_body) if hybrid else None)
+        body_cipher=_make_body_cipher(out_body) if hybrid else None,
+        variable=None if hybrid else _variable_for(outgoing, out_header))
     decoder = fteproxy.record_layer.Decoder(
         cipher=_cipher_for(incoming, in_header),
-        body_cipher=_make_body_cipher(in_body) if hybrid else None)
+        body_cipher=_make_body_cipher(in_body) if hybrid else None,
+        variable=None if hybrid else _variable_for(incoming, in_header))
     return encoder, decoder
 
 

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -301,7 +301,14 @@ def select_defs(release):
 
 
 def check_format(base):
-    """Build both directions of ``base`` so an unusable format fails now."""
+    """Build both directions of ``base`` so an unusable format fails now.
+
+    Every length each direction may emit, not just the one the handshake uses:
+    a variable-length format that cannot compile at one of its shorter lengths
+    would otherwise fail mid-connection instead of here. The DFAs land in
+    :func:`fteproxy._regex_format`'s cache, so the first connection does not pay
+    for them either.
+    """
     try:
         request, response = fteproxy.defs.getRegex(base + '-request'), \
             fteproxy.defs.getRegex(base + '-response')
@@ -310,10 +317,12 @@ def check_format(base):
             'unknown format %r; "fteproxy formats" lists the base names' % base)
     for name, pattern in ((base + '-request', request),
                           (base + '-response', response)):
-        try:
-            fteproxy._regex_format(pattern, fteproxy.defs.getLength(name))
-        except Exception as e:
-            raise StartupError('format %s is unusable: %s' % (name, e))
+        for length in fteproxy.defs.get_allowed_lengths(name):
+            try:
+                fteproxy._regex_format(pattern, length)
+            except Exception as e:
+                raise StartupError('format %s is unusable at length %d: %s'
+                                   % (name, length, e))
 
 
 def resolve_state_dir(args, create=True):
@@ -357,6 +366,11 @@ def do_keygen(args):
     return EXIT_OK
 
 
+def _span(low, high):
+    """``512`` for one value, ``200-700`` for a range."""
+    return str(low) if low == high else '%d-%d' % (low, high)
+
+
 def do_formats(args):
     """Print each base format name with its schema-v2 metadata and capacity.
 
@@ -366,6 +380,10 @@ def do_formats(args):
     carries, which is what bounds a record) each row shows the schema-v2
     ``role``, ``port``, ``mode_hint`` and ``description``, and the release
     default base is marked.
+
+    A variable-length format shows both as a range -- ``200-700`` -- because in
+    ``format`` mode it picks a length per record from across that range. The top
+    of the range is the length a handshake record and a ``hybrid`` header use.
     """
     try:
         definitions = select_defs(args.defs)
@@ -413,15 +431,18 @@ def do_formats(args):
             if name is None:
                 row += ['-', '-']
                 continue
-            length = fteproxy.defs.getLength(name)
+            spec = definitions[name]
+            lengths = fteproxy.defs.spec_allowed_lengths(spec)
+            shortest, longest = lengths[0], lengths[-1]
             try:
-                capacity = fteproxy._make_cipher(
-                    fteproxy.defs.getRegex(name), length,
-                    key).max_plaintext_bytes
+                capacities = [fteproxy._make_cipher(
+                    spec['regex'], length, key).max_plaintext_bytes
+                    for length in (shortest, longest)]
             except Exception:
-                row += [str(length), 'unusable']
+                row += [_span(shortest, longest), 'unusable']
                 continue
-            row += [str(length), str(capacity)]
+            row += [_span(shortest, longest),
+                    _span(min(capacities), max(capacities))]
         rows.append(row)
         descriptions[base] = fteproxy.defs.spec_description(primary_spec)
         defaults[base] = (base == default)
@@ -433,6 +454,8 @@ def do_formats(args):
     print('definitions release %s' % args.defs)
     print('role, port, mode, and covertext length / message capacity (bytes) '
           'per direction')
+    print('a length range means the format varies its covertext length per '
+          'record in format mode')
     print()
 
     def _emit(row, trailer):
@@ -474,10 +497,28 @@ def do_defs_check(args):
     print('OK: definitions release %s (%d format%s)'
           % (args.defs, len(summary), '' if len(summary) == 1 else 's'))
     if summary:
+        # The summary reports the length the handshake seals at; a
+        # variable-length format also emits shorter covertexts, so show the
+        # whole span it may emit and mark that the capacity is the largest one.
+        # Read the file directly, as validate_release does, rather than pointing
+        # the process-wide loader at a release the caller only asked to check.
+        import json
+        with open(fteproxy.defs._release_path(args.defs)) as handle:
+            definitions = json.load(handle)
         name_w = max(len(name) for name, _l, _c, _m in summary)
-        for name, length, capacity, mode_hint in summary:
-            print('  %s  length %5d  capacity %5d  %s'
-                  % (name.ljust(name_w), length, capacity, mode_hint))
+        spans = {}
+        for name, length, _capacity, _mode in summary:
+            lengths = fteproxy.defs.spec_allowed_lengths(
+                definitions.get(name, {'length': length}))
+            spans[name] = _span(lengths[0], lengths[-1])
+        span_w = max(len(span) for span in spans.values())
+        for name, _length, capacity, mode_hint in summary:
+            print('  %s  length %s  capacity %5d  %s'
+                  % (name.ljust(name_w), spans[name].rjust(span_w),
+                     capacity, mode_hint))
+        if any('-' in span for span in spans.values()):
+            print('a length range varies per record in format mode; the '
+                  'capacity shown is the one at the top of the range')
     return EXIT_OK
 
 

--- a/fteproxy/defs/20260903.json
+++ b/fteproxy/defs/20260903.json
@@ -1,7 +1,9 @@
 {
     "http-request": {
         "regex": "^(GET|POST|HEAD) /[a-zA-Z0-9/._?=&%-]* HTTP/1\\.1\r\nHost: [a-z0-9.-]+\r\nUser-Agent: Mozilla/5\\.0 \\([a-zA-Z0-9;: .()/_-]+\\)\r\nAccept: [a-zA-Z0-9/*,;= .+-]+\r\nAccept-Language: [a-z,;=0-9. -]+\r\n\r\n$",
-        "length": 512,
+        "min_length": 200,
+        "max_length": 700,
+        "terminator": "\r\n\r\n",
         "port": [
             80,
             8080,
@@ -10,11 +12,13 @@
         "role": "request",
         "mode_hint": "hybrid",
         "default": true,
-        "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers"
+        "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers; 200-700 bytes per message in format mode"
     },
     "http-response": {
-        "regex": "^HTTP/1\\.1 (200 OK|302 Found|404 Not Found)\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: [0-9]+\r\nServer: [a-zA-Z0-9/. ()_-]+\r\n\r\n[a-zA-Z0-9/+= \r\n-]*$",
-        "length": 512,
+        "regex": "^HTTP/1\\.1 (200 OK|302 Found|304 Not Modified|404 Not Found)\r\nServer: [a-zA-Z0-9/. ()_-]+\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: 0\r\nETag: \"[a-zA-Z0-9]+\"\r\nSet-Cookie: [a-zA-Z0-9]+=[a-zA-Z0-9%_-]+; Path=/\r\n\r\n$",
+        "min_length": 200,
+        "max_length": 700,
+        "terminator": "\r\n\r\n",
         "port": [
             80,
             8080,
@@ -23,33 +27,39 @@
         "role": "response",
         "mode_hint": "hybrid",
         "default": true,
-        "description": "HTTP/1.1 200/302/404 response with headers and a body"
+        "description": "HTTP/1.1 200/302/304/404 response, header block only (Content-Length: 0), so the CRLF CRLF that ends it cannot occur inside it; 200-700 bytes per message in format mode"
     },
     "ftp-request": {
         "regex": "^((USER|PASS|CWD|RETR|STOR|LIST) [a-zA-Z0-9._@/-]+|TYPE [AI]|PASV|QUIT)\r\n$",
-        "length": 256,
+        "min_length": 64,
+        "max_length": 256,
+        "terminator": "\r\n",
         "port": [
             21
         ],
         "role": "request",
         "mode_hint": "format",
         "default": false,
-        "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated"
+        "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated; 64-256 bytes per line"
     },
     "ftp-response": {
         "regex": "^(220|230|331|250|150|226|550) [a-zA-Z0-9 .,:()/-]+\r\n$",
-        "length": 256,
+        "min_length": 64,
+        "max_length": 256,
+        "terminator": "\r\n",
         "port": [
             21
         ],
         "role": "response",
         "mode_hint": "format",
         "default": false,
-        "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated"
+        "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated; 64-256 bytes per line"
     },
     "smtp-request": {
         "regex": "^(EHLO [a-z0-9.-]+|HELO [a-z0-9.-]+|MAIL FROM:<[a-z0-9._%+-]+@[a-z0-9.-]+>|RCPT TO:<[a-z0-9._%+-]+@[a-z0-9.-]+>|VRFY [a-z0-9._%+-]+|DATA|RSET|NOOP|QUIT)\r\n$",
-        "length": 320,
+        "min_length": 80,
+        "max_length": 320,
+        "terminator": "\r\n",
         "port": [
             25,
             587
@@ -57,11 +67,13 @@
         "role": "request",
         "mode_hint": "format",
         "default": false,
-        "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated"
+        "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated; 80-320 bytes per line"
     },
     "smtp-response": {
         "regex": "^((220|250|354|421|550) |250-)[a-zA-Z0-9 .,;:()<>@_-]+\r\n$",
-        "length": 256,
+        "min_length": 80,
+        "max_length": 320,
+        "terminator": "\r\n",
         "port": [
             25,
             587
@@ -69,29 +81,33 @@
         "role": "response",
         "mode_hint": "format",
         "default": false,
-        "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form"
+        "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form; 80-320 bytes per line"
     },
     "sip-request": {
         "regex": "^(INVITE|REGISTER|ACK|BYE|OPTIONS) sip:[a-z0-9._-]+@[a-z0-9.-]+ SIP/2\\.0\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
-        "length": 512,
+        "min_length": 300,
+        "max_length": 800,
+        "terminator": "\r\n\r\n",
         "port": [
             5060
         ],
         "role": "request",
         "mode_hint": "format",
         "default": false,
-        "description": "SIP/2.0 request line (INVITE/REGISTER/ACK/BYE/OPTIONS) with the mandatory Via/From/To/Call-ID/CSeq headers"
+        "description": "SIP/2.0 request line (INVITE/REGISTER/ACK/BYE/OPTIONS) with the mandatory Via/From/To/Call-ID/CSeq headers; 300-800 bytes per message"
     },
     "sip-response": {
         "regex": "^SIP/2\\.0 (100 Trying|180 Ringing|200 OK|404 Not Found)\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
-        "length": 512,
+        "min_length": 300,
+        "max_length": 800,
+        "terminator": "\r\n\r\n",
         "port": [
             5060
         ],
         "role": "response",
         "mode_hint": "format",
         "default": false,
-        "description": "SIP/2.0 status line (100/180/200/404) with the mandatory Via/From/To/Call-ID/CSeq headers"
+        "description": "SIP/2.0 status line (100/180/200/404) with the mandatory Via/From/To/Call-ID/CSeq headers; 300-800 bytes per message"
     },
     "dns-request": {
         "regex": "^\u0001\u000e[\u0000-\u00ff][\u0000-\u00ff]\u0001\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000(\u0002[a-zA-Z0-9][a-zA-Z0-9]|\u0003[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]|\u0004[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0005[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0006[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0007[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\t[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\n[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\r[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000e[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9])+(\u0003[cC][oO][mM]|\u0003[nN][eE][tT]|\u0003[oO][rR][gG]|\u0003[eE][dD][uU]|\u0004[iI][nN][fF][oO]|\u0002[iI][oO]|\u0002[dD][eE]|\u0002[uU][kK])\u0000(\u0000\u0001|\u0000\u001c)\u0000\u0001$",
@@ -102,7 +118,7 @@
         "role": "request",
         "mode_hint": "format",
         "default": false,
-        "description": "DNS over TCP query (RFC 1035 4.2.2): 2-byte length prefix, 12-byte header, one A/AAAA question; the fixed 272-byte covertext pads QNAME to 254 octets -- inside the 255-octet limit but far longer than a real name (see F7)"
+        "description": "DNS over TCP query (RFC 1035 4.2.2): 2-byte length prefix, 12-byte header, one A/AAAA question; the fixed 272-byte covertext pads QNAME to 254 octets -- inside the 255-octet limit but far longer than a real name (dns stays fixed length: its 2-byte length prefix is a literal in the regex, so every covertext length would need its own regex)"
     },
     "dns-response": {
         "regex": "^\u0001\u000e[\u0000-\u00ff][\u0000-\u00ff]\u0081\u0080\u0000\u0001\u0000\u0001\u0000\u0000\u0000\u0000(\u0002[a-zA-Z0-9][a-zA-Z0-9]|\u0003[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]|\u0004[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0005[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0006[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0007[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\t[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\n[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\r[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000e[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9])+(\u0003[cC][oO][mM]|\u0003[nN][eE][tT]|\u0003[oO][rR][gG]|\u0003[eE][dD][uU]|\u0004[iI][nN][fF][oO]|\u0002[iI][oO]|\u0002[dD][eE]|\u0002[uU][kK])\u0000\u0000\u0001\u0000\u0001\u00c0\f\u0000\u0001\u0000\u0001\u0000\u0000[\u0000-\u00ff][\u0000-\u00ff]\u0000\u0004[\u0001-~\u0080-\u00df][\u0000-\u00ff][\u0000-\u00ff][\u0000-\u00ff]$",
@@ -113,6 +129,6 @@
         "role": "response",
         "mode_hint": "format",
         "default": false,
-        "description": "DNS over TCP NOERROR response (RFC 1035 4.2.2): the question echoed plus one A record via a 0xc00c name pointer; the fixed 272-byte covertext pads QNAME to 238 octets -- valid but far longer than a real name (see F7)"
+        "description": "DNS over TCP NOERROR response (RFC 1035 4.2.2): the question echoed plus one A record via a 0xc00c name pointer; the fixed 272-byte covertext pads QNAME to 238 octets -- valid but far longer than a real name (dns stays fixed length: its 2-byte length prefix is a literal in the regex, so every covertext length would need its own regex)"
     }
 }

--- a/fteproxy/defs/__init__.py
+++ b/fteproxy/defs/__init__.py
@@ -3,11 +3,18 @@
 """Loading and validating the format definitions.
 
 A definitions file maps a format name to the regex its covertexts are drawn
-from and the fixed byte length of one covertext. Names come in pairs: a
+from and the byte length of one covertext. Names come in pairs: a
 ``-request`` for client-to-server and a ``-response`` for server-to-client,
 sharing a base name such as ``manual-http``. The base name is what a
 connection string and a client hello carry; the two directions are derived
 from it.
+
+A format is either **fixed length** (``length``: every covertext is exactly
+that many bytes) or **variable length** (``min_length``/``max_length`` plus a
+``terminator``: each record picks one of a small set of allowed lengths and the
+decoder frames the wire on the terminator). :func:`spec_allowed_lengths` is the
+single definition of that set, so the two ends of a connection agree on it
+without negotiating it. See ``docs/format-authoring.md``.
 """
 
 
@@ -59,6 +66,19 @@ MODE_HYBRID = 'hybrid'
 MODE_FORMAT = 'format'
 MODE_HINTS = (MODE_HYBRID, MODE_FORMAT)
 
+#: How many covertext lengths a variable-length format may emit.
+#:
+#: The set is small and evenly spaced on purpose. A format-mode record picks one
+#: of these lengths and seals at it with a *fixed-length* cipher, so each allowed
+#: length costs one compiled DFA in :func:`fteproxy._regex_format`: a continuous
+#: range would cost one per byte. Small also keeps the decoder's "is this a
+#: length we emit?" test tight, which is what fails a wrong-length frame closed.
+#: Eight points span a protocol's plausible message sizes finely enough that a
+#: length histogram is a spread rather than a spike, which is the whole point of
+#: the exercise. It is *not* a security parameter: nothing secret is carried by
+#: the choice, and the record's contents are sealed either way.
+LENGTH_STEPS = 8
+
 
 def _release_path(release):
     """The path of a definitions release, searched in the package's ``defs``
@@ -105,13 +125,19 @@ def check_capacities(definitions, minimum=MIN_CAPACITY):
     drive it at the configured length, so this doubles as a load-time syntax
     check. It costs one DFA compile per format, which the cache in
     :func:`fteproxy._regex_format` then hands back to every connection.
+
+    The floor applies at :func:`spec_length` -- ``max_length`` for a
+    variable-length format -- because that is the length the handshake seals at.
+    A shorter allowed length only has to carry one data record, which
+    ``fteproxy.defs.validate`` checks; the cheap load-time pass does not compile
+    every allowed length.
     """
     import fteproxy  # deferred: fteproxy imports this module at import time
 
     too_small = []
     for name, spec in definitions.items():
-        length = spec.get('length', fteproxy.conf.getValue(
-            'fteproxy.default_length'))
+        _check_variable_keys(name, spec)
+        length = spec_length(spec)
         try:
             capacity = fteproxy._make_cipher(
                 spec['regex'], length, b'\x00' * 32).max_plaintext_bytes
@@ -126,6 +152,35 @@ def check_capacities(definitions, minimum=MIN_CAPACITY):
             'these formats cannot carry a handshake (need %d bytes of '
             'capacity): %s' % (minimum, ', '.join(
                 '%s at length %d holds %d' % row for row in too_small)))
+
+
+def _check_variable_keys(name, spec):
+    """Raise :class:`DefinitionsError` on an incoherent length declaration.
+
+    A half-written variable-length entry is the dangerous case: a range with no
+    terminator has nothing to frame on, and a terminator with no range would be
+    ignored, so either would load as a fixed-length format and quietly emit one
+    length again. Caught here, at load, rather than as a fingerprint nobody
+    notices.
+    """
+    low, high = spec_min_length(spec), spec_max_length(spec)
+    terminator = spec_terminator(spec)
+    declared = [key for key, value in
+                (('min_length', low), ('max_length', high),
+                 ('terminator', terminator)) if value is not None]
+    if not declared:
+        return
+    if len(declared) != 3:
+        raise DefinitionsError(
+            'format %s declares %s: a variable-length format needs all of '
+            'min_length, max_length and terminator' % (name, ', '.join(declared)))
+    if 'length' in spec:
+        raise DefinitionsError(
+            'format %s carries both length and min_length/max_length; a format '
+            'is either fixed or variable' % name)
+    if low > high:
+        raise DefinitionsError(
+            'format %s has min_length %d above max_length %d' % (name, low, high))
 
 
 def base_names(definitions=None):
@@ -157,13 +212,19 @@ def getRegex(format_name):
 
 
 def getLength(format_name):
+    """The fixed-frame covertext length of a format.
+
+    For a variable-length format this is its ``max_length``: see
+    :func:`spec_length` for why the fixed-frame paths (the handshake, the
+    first-record scan, a hybrid header) all use the longest covertext.
+    """
     definitions = load_definitions()
     try:
-        length = definitions[format_name]['length']
+        spec = definitions[format_name]
     except KeyError:
-        length = fteproxy.conf.getValue('fteproxy.default_length')
+        return fteproxy.conf.getValue('fteproxy.default_length')
 
-    return length
+    return spec_length(spec)
 
 
 # ------------------------------------------------------------------------- #
@@ -185,18 +246,81 @@ def _infer_role(format_name):
 
 
 def spec_length(spec):
-    """The covertext length of a spec, defaulting to ``fteproxy.default_length``."""
+    """The covertext length a *single* fixed-length cipher is built at.
+
+    For a fixed-length format that is its ``length`` (or the configured
+    default). For a variable-length one it is ``max_length``: the handshake, the
+    server's first-record scan and a hybrid-mode header are all fixed-length
+    frames, and they use the longest covertext the format emits so that one
+    frame size serves every format. Only post-handshake *format*-mode data
+    records vary (see :func:`spec_allowed_lengths`).
+    """
+    maximum = spec_max_length(spec)
+    if maximum is not None:
+        return maximum
     return spec.get('length', fteproxy.conf.getValue('fteproxy.default_length'))
 
 
 def spec_min_length(spec):
-    """Reserved for variable-length covertexts (phase F7); default ``None``."""
+    """The shortest covertext a variable-length format emits; ``None`` if fixed."""
     return spec.get('min_length', None)
 
 
 def spec_max_length(spec):
-    """Reserved for variable-length covertexts (phase F7); default ``None``."""
+    """The longest covertext a variable-length format emits; ``None`` if fixed."""
     return spec.get('max_length', None)
+
+
+def spec_terminator(spec):
+    """The byte string every covertext of a variable-length format ends with.
+
+    It is what the decoder frames on, so the format's regex must be unable to
+    produce it anywhere but as that final suffix -- checked by
+    ``fteproxy.defs.validate``. ``None`` for a fixed-length format, which is
+    framed by its length instead. Returned as ``bytes``; the JSON carries it as
+    a string (``"\\r\\n"``).
+    """
+    terminator = spec.get('terminator', None)
+    if terminator is None:
+        return None
+    if isinstance(terminator, str):
+        return terminator.encode('latin-1')
+    return bytes(terminator)
+
+
+def spec_is_variable(spec):
+    """Whether this format emits covertexts of more than one length.
+
+    True only when all three of ``min_length``, ``max_length`` and
+    ``terminator`` are present: a length range with nothing to frame on could
+    not be decoded, so a partial declaration is not a variable format (and
+    :func:`fteproxy.defs.validate.validate_format` rejects it outright).
+    """
+    return (spec_min_length(spec) is not None
+            and spec_max_length(spec) is not None
+            and spec_terminator(spec) is not None)
+
+
+def spec_allowed_lengths(spec):
+    """The covertext lengths this format may emit, ascending.
+
+    One length for a fixed-length format; for a variable-length one,
+    :data:`LENGTH_STEPS` points spread evenly across
+    ``[min_length, max_length]`` and including both ends. Both ends of a
+    connection derive the set from the same definitions entry, so the sender
+    picks a length out of it and the receiver checks a frame's length against
+    it without either being negotiated.
+
+    Deliberately *not* a continuous range: see :data:`LENGTH_STEPS`, and
+    ``docs/format-authoring.md`` for why the length is chosen per record rather
+    than left to libfte's ranking over a ``min_length``/``max_length`` format.
+    """
+    low, high = spec_min_length(spec), spec_max_length(spec)
+    if low is None or high is None:
+        return (spec_length(spec),)
+    steps = max(2, min(LENGTH_STEPS, high - low + 1))
+    return tuple(sorted({round(low + i * (high - low) / (steps - 1))
+                         for i in range(steps)}))
 
 
 def spec_port(spec):
@@ -234,6 +358,21 @@ def _spec(format_name):
 
 def get_port(format_name):
     return spec_port(_spec(format_name))
+
+
+def get_terminator(format_name):
+    """The covertext terminator of a loaded format, or ``None`` if fixed."""
+    return spec_terminator(_spec(format_name))
+
+
+def get_allowed_lengths(format_name):
+    """The covertext lengths a loaded format may emit, ascending."""
+    return spec_allowed_lengths(_spec(format_name))
+
+
+def is_variable(format_name):
+    """Whether a loaded format emits covertexts of more than one length."""
+    return spec_is_variable(_spec(format_name))
 
 
 def get_role(format_name):

--- a/fteproxy/defs/parts/dns.json
+++ b/fteproxy/defs/parts/dns.json
@@ -8,7 +8,7 @@
     "role": "request",
     "mode_hint": "format",
     "default": false,
-    "description": "DNS over TCP query (RFC 1035 4.2.2): 2-byte length prefix, 12-byte header, one A/AAAA question; the fixed 272-byte covertext pads QNAME to 254 octets -- inside the 255-octet limit but far longer than a real name (see F7)"
+    "description": "DNS over TCP query (RFC 1035 4.2.2): 2-byte length prefix, 12-byte header, one A/AAAA question; the fixed 272-byte covertext pads QNAME to 254 octets -- inside the 255-octet limit but far longer than a real name (dns stays fixed length: its 2-byte length prefix is a literal in the regex, so every covertext length would need its own regex)"
   },
   "dns-response": {
     "regex": "^\u0001\u000e[\u0000-\u00ff][\u0000-\u00ff]\u0081\u0080\u0000\u0001\u0000\u0001\u0000\u0000\u0000\u0000(\u0002[a-zA-Z0-9][a-zA-Z0-9]|\u0003[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]|\u0004[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0005[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0006[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0007[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0008[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u0009[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000a[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000b[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000c[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000d[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000e[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9]|\u000f[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9-][a-zA-Z0-9])+(\u0003[cC][oO][mM]|\u0003[nN][eE][tT]|\u0003[oO][rR][gG]|\u0003[eE][dD][uU]|\u0004[iI][nN][fF][oO]|\u0002[iI][oO]|\u0002[dD][eE]|\u0002[uU][kK])\u0000\u0000\u0001\u0000\u0001\u00c0\u000c\u0000\u0001\u0000\u0001\u0000\u0000[\u0000-\u00ff][\u0000-\u00ff]\u0000\u0004[\u0001-~\u0080-\u00df][\u0000-\u00ff][\u0000-\u00ff][\u0000-\u00ff]$",
@@ -19,6 +19,6 @@
     "role": "response",
     "mode_hint": "format",
     "default": false,
-    "description": "DNS over TCP NOERROR response (RFC 1035 4.2.2): the question echoed plus one A record via a 0xc00c name pointer; the fixed 272-byte covertext pads QNAME to 238 octets -- valid but far longer than a real name (see F7)"
+    "description": "DNS over TCP NOERROR response (RFC 1035 4.2.2): the question echoed plus one A record via a 0xc00c name pointer; the fixed 272-byte covertext pads QNAME to 238 octets -- valid but far longer than a real name (dns stays fixed length: its 2-byte length prefix is a literal in the regex, so every covertext length would need its own regex)"
   }
 }

--- a/fteproxy/defs/parts/ftp.json
+++ b/fteproxy/defs/parts/ftp.json
@@ -1,20 +1,24 @@
 {
   "ftp-request": {
     "regex": "^((USER|PASS|CWD|RETR|STOR|LIST) [a-zA-Z0-9._@/-]+|TYPE [AI]|PASV|QUIT)\r\n$",
-    "length": 256,
+    "min_length": 64,
+    "max_length": 256,
+    "terminator": "\r\n",
     "port": [21],
     "role": "request",
     "mode_hint": "format",
     "default": false,
-    "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated"
+    "description": "FTP control-channel command: a verb (USER/PASS/CWD/TYPE/PASV/RETR/STOR/LIST/QUIT) with a realistic argument, CRLF-terminated; 64-256 bytes per line"
   },
   "ftp-response": {
     "regex": "^(220|230|331|250|150|226|550) [a-zA-Z0-9 .,:()/-]+\r\n$",
-    "length": 256,
+    "min_length": 64,
+    "max_length": 256,
+    "terminator": "\r\n",
     "port": [21],
     "role": "response",
     "mode_hint": "format",
     "default": false,
-    "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated"
+    "description": "FTP control-channel reply: a 3-digit status code, a space, human-readable text, CRLF-terminated; 64-256 bytes per line"
   }
 }

--- a/fteproxy/defs/parts/http.json
+++ b/fteproxy/defs/parts/http.json
@@ -1,20 +1,24 @@
 {
   "http-request": {
     "regex": "^(GET|POST|HEAD) /[a-zA-Z0-9/._?=&%-]* HTTP/1\\.1\r\nHost: [a-z0-9.-]+\r\nUser-Agent: Mozilla/5\\.0 \\([a-zA-Z0-9;: .()/_-]+\\)\r\nAccept: [a-zA-Z0-9/*,;= .+-]+\r\nAccept-Language: [a-z,;=0-9. -]+\r\n\r\n$",
-    "length": 512,
+    "min_length": 200,
+    "max_length": 700,
+    "terminator": "\r\n\r\n",
     "port": [80, 8080, 8000],
     "role": "request",
     "mode_hint": "hybrid",
     "default": true,
-    "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers"
+    "description": "HTTP/1.1 GET, POST, or HEAD request with common browser headers; 200-700 bytes per message in format mode"
   },
   "http-response": {
-    "regex": "^HTTP/1\\.1 (200 OK|302 Found|404 Not Found)\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: [0-9]+\r\nServer: [a-zA-Z0-9/. ()_-]+\r\n\r\n[a-zA-Z0-9/+= \r\n-]*$",
-    "length": 512,
+    "regex": "^HTTP/1\\.1 (200 OK|302 Found|304 Not Modified|404 Not Found)\r\nServer: [a-zA-Z0-9/. ()_-]+\r\nContent-Type: [a-zA-Z0-9/;=. +-]+\r\nContent-Length: 0\r\nETag: \"[a-zA-Z0-9]+\"\r\nSet-Cookie: [a-zA-Z0-9]+=[a-zA-Z0-9%_-]+; Path=/\r\n\r\n$",
+    "min_length": 200,
+    "max_length": 700,
+    "terminator": "\r\n\r\n",
     "port": [80, 8080, 8000],
     "role": "response",
     "mode_hint": "hybrid",
     "default": true,
-    "description": "HTTP/1.1 200/302/404 response with headers and a body"
+    "description": "HTTP/1.1 200/302/304/404 response, header block only (Content-Length: 0), so the CRLF CRLF that ends it cannot occur inside it; 200-700 bytes per message in format mode"
   }
 }

--- a/fteproxy/defs/parts/sip.json
+++ b/fteproxy/defs/parts/sip.json
@@ -1,24 +1,28 @@
 {
   "sip-request": {
     "regex": "^(INVITE|REGISTER|ACK|BYE|OPTIONS) sip:[a-z0-9._-]+@[a-z0-9.-]+ SIP/2\\.0\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
-    "length": 512,
+    "min_length": 300,
+    "max_length": 800,
+    "terminator": "\r\n\r\n",
     "port": [
       5060
     ],
     "role": "request",
     "mode_hint": "format",
     "default": false,
-    "description": "SIP/2.0 request line (INVITE/REGISTER/ACK/BYE/OPTIONS) with the mandatory Via/From/To/Call-ID/CSeq headers"
+    "description": "SIP/2.0 request line (INVITE/REGISTER/ACK/BYE/OPTIONS) with the mandatory Via/From/To/Call-ID/CSeq headers; 300-800 bytes per message"
   },
   "sip-response": {
     "regex": "^SIP/2\\.0 (100 Trying|180 Ringing|200 OK|404 Not Found)\r\nVia: SIP/2\\.0/TCP [a-z0-9.-]+;branch=z9hG4bK[a-zA-Z0-9]+\r\nFrom: <sip:[a-z0-9._-]+@[a-z0-9.-]+>;tag=[a-zA-Z0-9]+\r\nTo: <sip:[a-z0-9._-]+@[a-z0-9.-]+>\r\nCall-ID: [a-zA-Z0-9]+@[a-z0-9.-]+\r\nCSeq: [0-9]+ (INVITE|REGISTER|ACK|BYE|OPTIONS)\r\nContent-Length: 0\r\n\r\n$",
-    "length": 512,
+    "min_length": 300,
+    "max_length": 800,
+    "terminator": "\r\n\r\n",
     "port": [
       5060
     ],
     "role": "response",
     "mode_hint": "format",
     "default": false,
-    "description": "SIP/2.0 status line (100/180/200/404) with the mandatory Via/From/To/Call-ID/CSeq headers"
+    "description": "SIP/2.0 status line (100/180/200/404) with the mandatory Via/From/To/Call-ID/CSeq headers; 300-800 bytes per message"
   }
 }

--- a/fteproxy/defs/parts/smtp.json
+++ b/fteproxy/defs/parts/smtp.json
@@ -1,7 +1,9 @@
 {
   "smtp-request": {
     "regex": "^(EHLO [a-z0-9.-]+|HELO [a-z0-9.-]+|MAIL FROM:<[a-z0-9._%+-]+@[a-z0-9.-]+>|RCPT TO:<[a-z0-9._%+-]+@[a-z0-9.-]+>|VRFY [a-z0-9._%+-]+|DATA|RSET|NOOP|QUIT)\r\n$",
-    "length": 320,
+    "min_length": 80,
+    "max_length": 320,
+    "terminator": "\r\n",
     "port": [
       25,
       587
@@ -9,11 +11,13 @@
     "role": "request",
     "mode_hint": "format",
     "default": false,
-    "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated"
+    "description": "SMTP client command line (EHLO/MAIL FROM/RCPT TO/DATA/QUIT), CRLF-terminated; 80-320 bytes per line"
   },
   "smtp-response": {
     "regex": "^((220|250|354|421|550) |250-)[a-zA-Z0-9 .,;:()<>@_-]+\r\n$",
-    "length": 256,
+    "min_length": 80,
+    "max_length": 320,
+    "terminator": "\r\n",
     "port": [
       25,
       587
@@ -21,6 +25,6 @@
     "role": "response",
     "mode_hint": "format",
     "default": false,
-    "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form"
+    "description": "SMTP server reply line (2xx/3xx/4xx/5xx status), with 250- continuation form; 80-320 bytes per line"
   }
 }

--- a/fteproxy/defs/validate.py
+++ b/fteproxy/defs/validate.py
@@ -7,14 +7,19 @@ regex compiles and holds a handshake. This module goes further and exercises a
 format the way a live connection does, so a definition that compiles but cannot
 carry traffic is caught before it ships:
 
-* build the libfte cipher and require ``max_plaintext_bytes >=`` the capacity
-  floor (:data:`fteproxy.defs.MIN_CAPACITY`);
+* build the libfte cipher at every length the format may emit and require
+  ``max_plaintext_bytes >=`` the capacity floor
+  (:data:`fteproxy.defs.MIN_CAPACITY`) at the length the handshake seals at;
 * round-trip a batch of random payloads through
   :class:`fteproxy.record_layer.Encoder`/:class:`~fteproxy.record_layer.Decoder`
   in the format's ``mode_hint`` -- and in *both* modes when the hint is
   ``hybrid``, since the client's ``--mode`` may override it either way;
 * assert every sealed **format-mode** covertext fully matches the regex, so the
-  bytes on the wire really are drawn from the format's language.
+  bytes on the wire really are drawn from the format's language;
+* for a **variable-length** format, prove its terminator can only ever be the
+  final suffix of a covertext -- statically, from the pattern, and again over
+  sampled covertexts. Framing depends on that, so it is checked here rather
+  than assumed of whoever wrote the regex.
 
 The covertexts checked here come out of the record layer's sealing path (see the
 seal-padding note in ``docs/format-authoring.md``), never a bare
@@ -57,6 +62,301 @@ def _compiled_regex(regex):
     return re.compile(regex.encode('latin-1'), re.DOTALL)
 
 
+# --------------------------------------------------------------------------- #
+# Terminator uniqueness
+#
+# A variable-length format is framed by reading up to its terminator, so if the
+# format's language could produce that byte string anywhere else in a covertext,
+# the decoder would cut a record in half -- and, since the halves do not unseal,
+# fail the connection closed on traffic that was perfectly valid. The property
+# has to hold for the *language*, not merely for the covertexts anyone happened
+# to sample, so it is checked from the pattern, and the sampled check below is a
+# second opinion rather than the proof.
+# --------------------------------------------------------------------------- #
+
+#: Backslash escapes the regex2dfa dialect gives a non-literal meaning *outside*
+#: a character class. Inside a class there are no escapes at all (see the
+#: dialect notes in ``docs/format-authoring.md``), which is why the class scanner
+#: below reads raw characters.
+_ESCAPES = {'r': '\r', 'n': '\n', 't': '\t', 'f': '\f', 'v': '\v'}
+
+#: Regex operators that produce no covertext byte of their own.
+_METACHARACTERS = '()|+*?'
+
+#: Stands for one character drawn from a character class in a literal skeleton.
+#: Sound because the class check runs first: no class in a variable-length
+#: format may admit a terminator byte, so whatever a class produces can only
+#: separate its neighbours, never take part in a terminator.
+_ANY = '\x00'
+
+#: Most literal skeletons one pattern may expand to before the check gives up.
+#: Every alternation branch and every optional atom multiplies the count, so a
+#: pathological pattern could blow up; the shipped formats expand to fewer than
+#: 30 each. Exceeding it is a validation *failure*, never a pass: a pattern too
+#: complex to prove is a pattern whose framing is not proven.
+_SKELETON_CAP = 4096
+
+
+def _scan_pattern(pattern):
+    """Split a pattern into ``('literal', ch)`` and ``('class', members)`` atoms.
+
+    ``members`` is the set of characters a ``[...]`` class admits, or ``None``
+    for a negated class (which admits so much that it is refused outright).
+    Raises :class:`ValueError` on a pattern this scanner cannot read, so an
+    unreadable pattern fails validation rather than passing unchecked.
+    """
+    atoms = []
+    index = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if character == '\\':
+            if index + 1 >= len(pattern):
+                raise ValueError('pattern ends in a backslash')
+            escaped = pattern[index + 1]
+            atoms.append(('literal', _ESCAPES.get(escaped, escaped)))
+            index += 2
+        elif character == '[':
+            close = pattern.find(']', index + 1)
+            if close < 0:
+                raise ValueError('unterminated character class')
+            atoms.append(('class', _class_members(pattern[index + 1:close])))
+            index = close + 1
+        elif character in _METACHARACTERS:
+            index += 1
+        else:
+            atoms.append(('literal', character))
+            index += 1
+    return atoms
+
+
+def _literal_skeletons(pattern):
+    """Every literal skeleton the pattern can produce, as a set of strings.
+
+    A *skeleton* is one covertext with each character-class run collapsed to a
+    single :data:`_ANY` placeholder: it keeps exactly the literal characters and
+    exactly the adjacencies between them, which is all a terminator search
+    needs. Unlike deleting the operators and concatenating what is left, this
+    expands each alternation branch separately, so it does not invent an
+    adjacency between two branches that never occur together *and* does not
+    miss the adjacency between a branch's last character and whatever follows
+    the group -- the case a single concatenated skeleton silently drops.
+
+    Repetition (``+``, ``*``) is expanded to one and two copies: two exposes the
+    junction where a repeated unit meets itself. A terminator that only appears
+    across *three* or more copies of one repeated group would slip through; the
+    sampled check in :func:`validate_format` is the second net for that.
+
+    Raises :class:`ValueError` on a pattern this cannot read or that expands
+    past :data:`_SKELETON_CAP`.
+    """
+    skeletons, index = _skeleton_alternation(pattern, 0)
+    if index != len(pattern):
+        raise ValueError('unexpected %r at offset %d'
+                         % (pattern[index], index))
+    return skeletons
+
+
+def _capped(strings):
+    if len(strings) > _SKELETON_CAP:
+        raise ValueError('the pattern expands to more than %d literal '
+                         'skeletons, too many to prove the terminator unique'
+                         % _SKELETON_CAP)
+    return strings
+
+
+def _skeleton_alternation(pattern, index):
+    """``a|b|c`` -> the union of the branches. Stops at ``)`` or the end."""
+    options = set()
+    while True:
+        branch, index = _skeleton_sequence(pattern, index)
+        options = _capped(options | branch)
+        if index < len(pattern) and pattern[index] == '|':
+            index += 1
+            continue
+        return options, index
+
+
+def _skeleton_sequence(pattern, index):
+    """A run of atoms -> every concatenation of their expansions."""
+    strings = {''}
+    while index < len(pattern) and pattern[index] not in '|)':
+        atom, index = _skeleton_atom(pattern, index)
+        strings = _capped({prefix + suffix
+                           for prefix in strings for suffix in atom})
+    return strings, index
+
+
+def _skeleton_atom(pattern, index):
+    """One atom and its quantifier -> the strings it can contribute."""
+    character = pattern[index]
+    if character == '(':
+        strings, index = _skeleton_alternation(pattern, index + 1)
+        if index >= len(pattern) or pattern[index] != ')':
+            raise ValueError('unbalanced (')
+        index += 1
+        repeatable = True
+    elif character == '[':
+        close = pattern.find(']', index + 1)
+        if close < 0:
+            raise ValueError('unterminated character class')
+        index = close + 1
+        # A class cannot produce a terminator byte, so one placeholder stands
+        # for any number of them: repeating it would change no adjacency.
+        strings, repeatable = {_ANY}, False
+    elif character == '\\':
+        if index + 1 >= len(pattern):
+            raise ValueError('pattern ends in a backslash')
+        strings = {_ESCAPES.get(pattern[index + 1], pattern[index + 1])}
+        index += 2
+        repeatable = True
+    elif character == ')':
+        raise ValueError('unbalanced )')
+    else:
+        strings = {character}
+        index += 1
+        repeatable = True
+
+    if index < len(pattern) and pattern[index] in '+*?':
+        quantifier = pattern[index]
+        index += 1
+        variants = set(strings)
+        if repeatable and quantifier in '+*':
+            variants |= {first + second
+                         for first in strings for second in strings}
+        if quantifier in '*?':
+            variants.add('')
+        strings = _capped(variants)
+    return strings, index
+
+
+def _class_members(body):
+    """The characters a ``[...]`` class body admits; ``None`` if it is negated.
+
+    Ranges (``a-z``) expand; a ``-`` first or last is itself. There are no
+    backslash escapes inside a class in this dialect, so every character stands
+    for itself.
+    """
+    if body.startswith('^'):
+        return None
+    members = set()
+    index = 0
+    while index < len(body):
+        if index + 2 < len(body) and body[index + 1] == '-':
+            for point in range(ord(body[index]), ord(body[index + 2]) + 1):
+                members.add(chr(point))
+            index += 3
+        else:
+            members.add(body[index])
+            index += 1
+    return members
+
+
+def check_terminator_uniqueness(name, regex, terminator):
+    """Prove from the pattern that only a covertext's suffix is the terminator.
+
+    Two conditions, both conservative -- a pattern this refuses may still be
+    safe, but a pattern it accepts cannot produce the terminator anywhere but at
+    the end:
+
+    1. **No character class admits a terminator byte.** With CRLF terminators
+       that means no field may contain a CR or an LF at all. A weaker rule (no
+       single class admits *both*) leaves the case where one class supplies the
+       CR and the next atom the LF, which would need the whole language to rule
+       out; forbidding the bytes outright is what makes the literal check below
+       exhaustive, because every terminator byte then comes from a literal.
+    2. **No literal skeleton contains the terminator before its end.** A
+       skeleton (:func:`_literal_skeletons`) is one covertext with each
+       character-class run collapsed to a placeholder, expanded over every
+       alternation branch and every optional atom. Since rule 1 leaves the
+       literals as the only source of terminator bytes, a terminator that
+       occurs in no skeleton occurs in no covertext -- except as the trailing
+       literal the pattern ends with.
+
+    Raises :class:`FormatValidationError` naming ``name``.
+    """
+    terminator_text = terminator.decode('latin-1')
+    if _ANY in terminator_text:
+        raise FormatValidationError(
+            '%s: a terminator containing a NUL cannot be checked' % name)
+    body = regex
+    if body.startswith('^'):
+        body = body[1:]
+    if body.endswith('$'):
+        body = body[:-1]
+    if not body.endswith(terminator_text):
+        raise FormatValidationError(
+            '%s: the pattern does not end with its terminator %r, so the '
+            'terminator is not the covertext\'s final suffix'
+            % (name, terminator))
+    body = body[:-len(terminator_text)]
+
+    try:
+        atoms = _scan_pattern(body)
+    except ValueError as e:
+        raise FormatValidationError('%s: cannot read the pattern: %s' % (name, e))
+
+    terminator_set = set(terminator_text)
+    for kind, value in atoms:
+        if kind != 'class':
+            continue
+        if value is None:
+            raise FormatValidationError(
+                '%s: a negated character class may admit a terminator byte; a '
+                'variable-length format must spell its classes out' % name)
+        overlap = sorted(value & terminator_set)
+        if overlap:
+            raise FormatValidationError(
+                '%s: a character class admits %r, a byte of the terminator %r, '
+                'so a covertext could carry the terminator inside it'
+                % (name, ''.join(overlap), terminator))
+
+    try:
+        skeletons = _literal_skeletons(body)
+    except ValueError as e:
+        raise FormatValidationError('%s: cannot read the pattern: %s' % (name, e))
+    for skeleton in skeletons:
+        text = skeleton + terminator_text
+        if text.find(terminator_text) != len(text) - len(terminator_text):
+            raise FormatValidationError(
+                '%s: the pattern\'s literal text can produce the terminator %r '
+                'before the end of a covertext' % (name, terminator))
+
+
+def _check_sampled_terminators(name, covertexts, terminator):
+    """Confirm on real covertexts what :func:`check_terminator_uniqueness` proves."""
+    for covertext in covertexts:
+        if not covertext.endswith(terminator):
+            raise FormatValidationError(
+                '%s: a sealed covertext does not end with the terminator %r'
+                % (name, terminator))
+        if terminator in covertext[:-len(terminator)]:
+            raise FormatValidationError(
+                '%s: a sealed covertext carries the terminator %r before its '
+                'end, so framing would cut it in half' % (name, terminator))
+
+
+def frame_covertexts(wire, terminator):
+    """Split a format-mode wire into covertexts on ``terminator``.
+
+    The decoder's framing, without the keys: everything up to and including each
+    terminator is one covertext. A trailing fragment with no terminator is
+    returned as the last element, so a caller can tell a complete wire from a
+    truncated one.
+    """
+    covertexts = []
+    offset = 0
+    while True:
+        end = wire.find(terminator, offset)
+        if end < 0:
+            break
+        end += len(terminator)
+        covertexts.append(wire[offset:end])
+        offset = end
+    if offset < len(wire):
+        covertexts.append(wire[offset:])
+    return covertexts
+
+
 def _modes_for(mode_hint):
     """Which record-layer modes to exercise for a given ``mode_hint``.
 
@@ -69,8 +369,34 @@ def _modes_for(mode_hint):
     return (fteproxy.defs.MODE_FORMAT,)
 
 
+def _variable_lengths(name, regex, spec):
+    """The :class:`~fteproxy.record_layer.VariableLength` a spec describes.
+
+    Building it proves every allowed length compiles and can carry a record;
+    a length that cannot is a definitions bug that would otherwise surface as a
+    connection which encodes fine and then cannot chunk.
+    """
+    import fteproxy
+
+    for length in fteproxy.defs.spec_allowed_lengths(spec):
+        try:
+            fteproxy._make_cipher(regex, length, _KEY)
+        except Exception as e:
+            raise FormatValidationError(
+                '%s: unusable at length %d, one of the lengths it would emit: '
+                '%s' % (name, length, e))
+    try:
+        return fteproxy._variable_lengths_for_spec(spec, _KEY)
+    except ValueError as e:
+        raise FormatValidationError('%s: %s' % (name, e))
+
+
 def validate_format(name, spec, samples=_SAMPLES):
     """Validate one format entry. Returns ``(name, length, capacity, mode_hint)``.
+
+    ``length`` and ``capacity`` are reported at :func:`fteproxy.defs.spec_length`
+    -- the length the handshake seals at, which for a variable-length format is
+    its ``max_length``.
 
     Raises :class:`FormatValidationError` naming ``name`` on any failure.
     """
@@ -80,7 +406,13 @@ def validate_format(name, spec, samples=_SAMPLES):
     if 'regex' not in spec:
         raise FormatValidationError('%s: no regex' % name)
     regex = spec['regex']
+    try:
+        fteproxy.defs._check_variable_keys(name, spec)
+    except fteproxy.defs.DefinitionsError as e:
+        raise FormatValidationError(str(e))
     length = fteproxy.defs.spec_length(spec)
+    variable = fteproxy.defs.spec_is_variable(spec)
+    terminator = fteproxy.defs.spec_terminator(spec)
     mode_hint = fteproxy.defs.spec_mode_hint(spec)
     if mode_hint not in fteproxy.defs.MODE_HINTS:
         raise FormatValidationError(
@@ -101,22 +433,41 @@ def validate_format(name, spec, samples=_SAMPLES):
             '%s: capacity %d bytes at length %d is below the %d-byte floor'
             % (name, capacity, length, fteproxy.defs.MIN_CAPACITY))
 
+    lengths = None
+    if variable:
+        # Every length this format may emit has to compile and carry a record,
+        # and the terminator it is framed by has to be unique to a covertext's
+        # end -- both before the round trip, since the round trip depends on
+        # them.
+        lengths = _variable_lengths(name, regex, spec)
+        check_terminator_uniqueness(name, regex, terminator)
+
     pattern = _compiled_regex(regex)
     for mode in _modes_for(mode_hint):
         hybrid = (mode == fteproxy.defs.MODE_HYBRID)
+        # A variable-length format varies only in format mode: a hybrid record
+        # is a fixed-length header plus a raw body.
+        variable_lengths = None if hybrid else lengths
         encoder = rl.Encoder(
             cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None,
+            variable=variable_lengths)
         decoder = rl.Decoder(
             cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
+            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None,
+            variable=variable_lengths)
         for i in range(samples):
             payload = os.urandom((i * 7) % (encoder.capacity + 1))
             encoder.push(payload)
             wire = encoder.pop()
             if not hybrid:
-                for offset in range(0, len(wire), length):
-                    covertext = wire[offset:offset + length]
+                if variable_lengths is not None:
+                    covertexts = frame_covertexts(wire, terminator)
+                    _check_sampled_terminators(name, covertexts, terminator)
+                else:
+                    covertexts = [wire[offset:offset + length]
+                                  for offset in range(0, len(wire), length)]
+                for covertext in covertexts:
                     if not pattern.fullmatch(covertext):
                         raise FormatValidationError(
                             '%s: a sealed format-mode covertext does not match '

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -4,8 +4,7 @@
 
 libfte 0.4 encrypts one message into exactly one fixed-length covertext and
 has no stream framing of its own, so this module defines the wire layout.
-Every record starts with a *sealed* covertext of exactly ``length`` bytes (the
-format's fixed covertext length): its plaintext is
+Every record starts with a *sealed* covertext: its plaintext is
 ``len(4) || seq(8) || message || random pad`` filled to the format's capacity,
 so it reads as random format text and only unseals at stream position
 ``seq``. The two modes differ in what the sealed covertext carries:
@@ -34,9 +33,20 @@ a stream is rejected. Since 1.0 each direction of a connection has its own
 header and body keys, derived per connection by :mod:`fteproxy.handshake`, so
 a record cannot be replayed into another stream or the other direction either.
 See SECURITY.md for what is not covered.
+
+**Framing.** A fixed-length format frames on its length: one record is one
+``length``-byte slice (plus, in hybrid mode, the raw body its header announces).
+A *variable-length* format (:class:`VariableLength`) instead frames on a
+terminator its language can only produce as a covertext's final suffix: the
+encoder picks one of the format's allowed lengths per record and seals at it,
+and the decoder reads up to the next terminator and checks that what it found
+is a length this format emits. That removes the fixed-length fingerprint from
+format-mode data records; hybrid headers and the two handshake records stay
+fixed-length. See ``docs/format-authoring.md``.
 """
 
 import os
+import random
 import struct
 
 import fte
@@ -118,22 +128,117 @@ def _unseal(plaintext, seq):
     return plaintext[_SEAL_OVERHEAD:_SEAL_OVERHEAD + length]
 
 
+#: Where a record's covertext length comes from. ``os.urandom``-backed, so the
+#: length sequence is not predictable from earlier records and cannot be
+#: replayed out of a seeded PRNG.
+_LENGTHS = random.SystemRandom()
+
+
+class VariableLength:
+    """The lengths one variable-length format may emit, and the ciphers for them.
+
+    A format-mode record is sealed with a *fixed-length* cipher, as it always
+    was; what changes is that there is now more than one of them and the
+    encoder chooses per record. ``ciphers`` maps each allowed covertext length
+    to the libfte cipher built at that length, and ``terminator`` is the byte
+    string every covertext of the format ends with and that its language cannot
+    produce anywhere else (enforced by ``fteproxy.defs.validate``).
+
+    **Why the length is chosen here and not by libfte.** ``fte.RegexFormat``
+    accepts a ``min_length``/``max_length`` pair and ranks the whole range, but
+    a language's string count grows exponentially with length, so a uniformly
+    random rank lands in the longest length class almost every time: a 64..512
+    range would emit ~512-byte covertexts and the fingerprint would survive.
+    The record layer therefore picks the length itself, from a small discrete
+    set, and seals at exactly that length.
+
+    One instance serves one direction of one connection: the per-length ciphers
+    are built once here rather than per record, and the expensive half of each
+    (the DFA) comes from the process-wide cache in
+    :func:`fteproxy._regex_format`, so the ciphers themselves cost a few
+    microseconds each and hold nothing beyond this connection's key.
+    """
+
+    def __init__(self, ciphers, terminator):
+        if not ciphers:
+            raise ValueError('a variable-length format needs at least one length')
+        if not terminator:
+            raise ValueError('a variable-length format needs a terminator')
+        self.terminator = bytes(terminator)
+        self.lengths = tuple(sorted(ciphers))
+        self._ciphers = dict(ciphers)
+        self.min_length = self.lengths[0]
+        self.max_length = self.lengths[-1]
+        #: Payload bytes one record of each length carries, after the seal's
+        #: length/sequence fields and the record type byte.
+        self.capacities = {
+            length: (cipher.max_plaintext_bytes - _SEAL_OVERHEAD - _TYPE_LEN)
+            for length, cipher in self._ciphers.items()}
+        smallest = min(self.capacities.values())
+        if smallest < 1:
+            raise ValueError('a covertext length of this format carries no '
+                             'payload (capacity %d)' % smallest)
+        #: The largest payload any one record can carry.
+        self.capacity = max(self.capacities.values())
+
+    def cipher(self, length):
+        """The fixed-length cipher for one allowed covertext length."""
+        return self._ciphers[length]
+
+    def choose_length(self, pending):
+        """A covertext length for a record with ``pending`` payload bytes queued.
+
+        Never shorter than the shortest length that holds ``pending`` bytes, so
+        a record is never split just to make it look short. Beyond that the
+        choice is random, weighted so that a stream's length histogram matches
+        what it is carrying: when more data is queued than the largest record
+        holds the weights favour the long lengths (a bulk transfer looks like
+        long messages), and when the payload fits in one record they favour the
+        short ones (interactive traffic looks like short messages). Throughput
+        is not what the weighting is for -- the byte rate is nearly flat across
+        a format's range, see PERFORMANCE.md -- realism is.
+
+        The weights are quadratic rather than flat so the bias is visible in a
+        histogram, and rather than exponential so no single length takes a
+        commanding share -- an all-shortest stream would be as much of a
+        fingerprint as an all-longest one.
+        """
+        if pending > self.capacity:
+            eligible = self.lengths
+            weights = [(rank + 1) ** 2 for rank in range(len(eligible))]
+        else:
+            eligible = tuple(length for length in self.lengths
+                             if self.capacities[length] >= pending)
+            weights = [(len(eligible) - rank) ** 2
+                       for rank in range(len(eligible))]
+        return _LENGTHS.choices(eligible, weights)[0]
+
+
 class Encoder:
 
     def __init__(
         self,
         cipher,
         body_cipher=None,
+        variable=None,
     ):
         self._cipher = cipher
         self._body_cipher = body_cipher
+        self._variable = variable
+        if body_cipher is not None and variable is not None:
+            raise ValueError('hybrid mode frames a fixed-length header; it '
+                             'cannot also carry variable-length covertexts')
         if body_cipher is None:
             # 'format' mode: one sealed covertext per chunk. Reserve the length
             # prefix, sequence number and record type; the rest of the covertext
             # capacity is real payload, random-padded when the payload does not
-            # fill it.
-            self._capacity = (cipher.max_plaintext_bytes
-                              - _SEAL_OVERHEAD - _TYPE_LEN)
+            # fill it. With a variable-length format the capacity depends on the
+            # length chosen for the record, and this is the largest of them: the
+            # most any one record can carry, which is what bounds a control
+            # record and what chunking measures itself against.
+            self._capacity = (
+                variable.capacity if variable is not None
+                else cipher.max_plaintext_bytes - _SEAL_OVERHEAD - _TYPE_LEN)
         else:
             # 'hybrid' mode: a sealed FTE header (carrying the body length)
             # followed by the raw authenticated body. Chunk by the body's capacity, far
@@ -152,11 +257,22 @@ class Encoder:
         """The largest payload one record of this stream can carry."""
         return self._capacity
 
-    def _emit(self, record_type, payload):
-        """One complete record on the wire, advancing the stream position."""
+    def _emit(self, record_type, payload, length=None):
+        """One complete record on the wire, advancing the stream position.
+
+        ``length`` names the covertext length to seal at, for a variable-length
+        format whose caller has already chosen one (:meth:`pop` picks the length
+        first, because the chunk size follows from it). Otherwise the length is
+        chosen here, from the lengths that can carry this payload.
+        """
         message = bytes((record_type,)) + payload
         if self._body_cipher is None:
-            record = _seal(self._cipher, message, self._seq)
+            cipher = self._cipher
+            if self._variable is not None:
+                if length is None:
+                    length = self._variable.choose_length(len(payload))
+                cipher = self._variable.cipher(length)
+            record = _seal(cipher, message, self._seq)
         else:
             body = self._body_cipher.encrypt(message, self._seq)
             record = (_seal(self._cipher, _OVERFLOW_LEN.pack(len(body)),
@@ -195,9 +311,22 @@ class Encoder:
         # the loop instead would recopy the whole remaining buffer every
         # iteration, making a single large ``push`` quadratic.
         records = []
-        for offset in range(0, len(buffer), self._capacity):
-            records.append(
-                self._emit(DATA, buffer[offset:offset + self._capacity]))
+        if self._variable is None:
+            for offset in range(0, len(buffer), self._capacity):
+                records.append(
+                    self._emit(DATA, buffer[offset:offset + self._capacity]))
+        else:
+            # A variable-length format chunks by the length it picked for this
+            # record, not by one fixed capacity: pick the length from what is
+            # still queued (so a long queue biases long), then fill it.
+            offset = 0
+            while offset < len(buffer):
+                pending = len(buffer) - offset
+                length = self._variable.choose_length(pending)
+                take = min(self._variable.capacities[length], pending)
+                records.append(self._emit(DATA, buffer[offset:offset + take],
+                                          length=length))
+                offset += take
 
         self._buffer = b''
         return b''.join(records)
@@ -209,9 +338,14 @@ class Decoder:
         self,
         cipher,
         body_cipher=None,
+        variable=None,
     ):
         self._cipher = cipher
         self._body_cipher = body_cipher
+        self._variable = variable
+        if body_cipher is not None and variable is not None:
+            raise ValueError('hybrid mode frames a fixed-length header; it '
+                             'cannot also carry variable-length covertexts')
         # A fixed-length output format emits one covertext of exactly
         # ``max_length`` bytes, and ``decrypt`` consumes exactly one such value
         # (no remainder). The record layer frames the byte stream itself: in
@@ -221,11 +355,15 @@ class Decoder:
         self._frame_size = cipher.output_format.max_length
         # The largest record this decoder is ever asked to hold: one header
         # covertext plus, in hybrid mode, the largest framed body a header may
-        # announce. After every pop the buffer is shorter than this, so a
+        # announce; for a variable-length format, one covertext of its longest
+        # allowed length. After every pop the buffer is shorter than this, so a
         # stream that fails to authenticate cannot grow the buffer without
         # bound (see the fail-closed behavior below).
-        self.max_record_bytes = self._frame_size + (
-            body_cipher.max_framed_bytes if body_cipher is not None else 0)
+        if variable is not None:
+            self.max_record_bytes = variable.max_length
+        else:
+            self.max_record_bytes = self._frame_size + (
+                body_cipher.max_framed_bytes if body_cipher is not None else 0)
         self._buffer = b''
         self._seq = 0
         # Set once a record fails to authenticate: nothing later can decode,
@@ -307,6 +445,8 @@ class Decoder:
         # preserved.
         if self._failed:
             return []
+        if self._variable is not None:
+            return self._pop_variable_records(limit)
         buffer = self._buffer
         records = []
         offset = 0
@@ -384,6 +524,65 @@ class Decoder:
                 break
             self._seq += 1
             offset = body_start + body_len
+            records.append(self._split_type(message))
+
+        self._buffer = b'' if self._failed else buffer[offset:]
+        return records
+
+    def _pop_variable_records(self, limit=None):
+        """:meth:`pop_records` for a variable-length format: terminator framing.
+
+        A record runs to the end of the next terminator. Its length must be one
+        the format emits -- anything else is not a covertext this peer wrote, so
+        the stream fails closed exactly as a bad decrypt does, rather than
+        hunting for a later terminator that might line up.
+
+        Every other guarantee is the fixed-length path's: the seal must unseal
+        at the current sequence number, any authentication failure is fatal to
+        the stream, and the buffer is bounded -- here by refusing to hold more
+        than one longest covertext without a terminator, so a peer cannot grow
+        it by simply never sending one.
+        """
+        buffer = self._buffer
+        terminator = self._variable.terminator
+        records = []
+        offset = 0
+
+        while True:
+            if limit is not None and len(records) >= limit:
+                break
+            end = buffer.find(terminator, offset)
+            if end < 0:
+                if len(buffer) - offset > self._variable.max_length:
+                    fteproxy.info(
+                        "fteproxy.record_layer: %d bytes with no covertext "
+                        "terminator, more than the %d-byte maximum"
+                        % (len(buffer) - offset, self._variable.max_length))
+                    self._failed = True
+                # Otherwise: a partial covertext, still arriving. Wait.
+                break
+            end += len(terminator)
+            length = end - offset
+            if length not in self._variable.lengths:
+                fteproxy.debug(
+                    "fteproxy.record_layer: covertext of %d bytes is not a "
+                    "length this format emits" % length)
+                self._failed = True
+                break
+            plaintext = self._decrypt(self._variable.cipher(length),
+                                      buffer[offset:end])
+            if plaintext is None:
+                self._failed = True
+                break
+            message = _unseal(plaintext, self._seq)
+            if message is None:
+                fteproxy.debug(
+                    "fteproxy.record_layer: malformed or out-of-order sealed "
+                    "record at seq " + str(self._seq))
+                self._failed = True
+                break
+            self._seq += 1
+            offset = end
             records.append(self._split_type(message))
 
         self._buffer = b'' if self._failed else buffer[offset:]

--- a/fteproxy/tests/realism/__init__.py
+++ b/fteproxy/tests/realism/__init__.py
@@ -17,13 +17,14 @@ calls ``check`` on each, plus :func:`statistical_guard` over the batch.
 
 The seal-padding rule (see ``docs/format-authoring.md``) is why this harness
 samples through :func:`format_covertexts`, which drives the real record-layer
-:class:`fteproxy.record_layer.Encoder` in **format** mode and slices the wire
-into individual sealed covertexts. A bare ``fte.FTE.encrypt`` of a short message
-ranks low and unranks into a degenerate covertext (one long run of the field's
-lowest character); a sealed covertext is padded to the format's full capacity
-first, so its variable fields are filled with high-entropy format bytes exactly
-as they are in production. Realism MUST be judged on sealed covertexts, never on
-raw ``encrypt`` output.
+:class:`fteproxy.record_layer.Encoder` in **format** mode and cuts the wire back
+into individual sealed covertexts -- by length for a fixed-length format, on the
+terminator for a variable-length one, exactly as the decoder frames it. A bare
+``fte.FTE.encrypt`` of a short message ranks low and unranks into a degenerate
+covertext (one long run of the field's lowest character); a sealed covertext is
+padded to the format's full capacity first, so its variable fields are filled
+with high-entropy format bytes exactly as they are in production. Realism MUST
+be judged on sealed covertexts, never on raw ``encrypt`` output.
 """
 
 import json
@@ -32,6 +33,7 @@ import re
 
 import fteproxy
 import fteproxy.defs
+import fteproxy.defs.validate
 import fteproxy.record_layer as rl
 
 
@@ -42,22 +44,83 @@ class RealismError(Exception):
 _KEY = b'\x00' * 32
 
 
-def format_covertexts(regex, length, n=2000):
-    """``n`` individual sealed covertexts of ``length`` bytes each.
+def format_covertexts(spec_or_regex, length=None, n=2000):
+    """``n`` individual sealed covertexts of one format.
 
     Drives the record layer's format-mode :class:`~fteproxy.record_layer.Encoder`
     (which seals: pads plaintext to the format's capacity with random bytes
-    before encrypting) over ``n`` capacity-sized chunks of random payload, then
-    slices the resulting wire into the fixed-length covertexts. This is the
+    before encrypting) over ``n`` records of random payload, then cuts the
+    resulting wire back into individual covertexts. This is the
     seal-padding-correct sampler the module docstring describes; do not sample
     with a bare ``fte.FTE.encrypt``.
+
+    Called either with a **definitions spec** (the dict from a ``parts/*.json``
+    fragment or a release) or, for a fixed-length format, with its
+    ``regex, length`` directly:
+
+    * a **fixed-length** format is chunked at its one capacity and the wire is
+      sliced at ``length``, exactly as the decoder frames it;
+    * a **variable-length** format picks a length per record, so the payloads
+      are varied to exercise the choice and the wire is framed on the format's
+      terminator -- again, exactly as the decoder frames it. The covertexts come
+      back at the mix of lengths a real stream would carry.
     """
-    cipher = fteproxy._make_cipher(regex, length, _KEY)
-    encoder = rl.Encoder(cipher=cipher)  # format mode: one covertext per chunk
-    encoder.push(os.urandom(n * encoder.capacity))
-    wire = encoder.pop()
-    covertexts = [wire[i:i + length] for i in range(0, len(wire), length)]
-    return covertexts[:n]
+    if isinstance(spec_or_regex, dict):
+        spec = spec_or_regex
+        regex = spec['regex']
+        length = fteproxy.defs.spec_length(spec)
+    else:
+        regex, spec = spec_or_regex, None
+
+    if spec is None or not fteproxy.defs.spec_is_variable(spec):
+        cipher = fteproxy._make_cipher(regex, length, _KEY)
+        encoder = rl.Encoder(cipher=cipher)  # format mode: one covertext/chunk
+        encoder.push(os.urandom(n * encoder.capacity))
+        wire = encoder.pop()
+        return [wire[i:i + length] for i in range(0, len(wire), length)][:n]
+
+    variable = fteproxy._variable_lengths_for_spec(spec, _KEY)
+    encoder = rl.Encoder(cipher=fteproxy._make_cipher(regex, length, _KEY),
+                         variable=variable)
+    wire = b''
+    for i in range(n):
+        # One record each time, at a payload size that walks the whole range a
+        # real stream produces, so the sample carries the mix of covertext
+        # lengths the length choice is meant to produce.
+        encoder.push(os.urandom(1 + (i * 37) % variable.capacity))
+        wire += encoder.pop()
+    return frame_covertexts(wire, variable.terminator)[:n]
+
+
+def frame_covertexts(wire, terminator):
+    """Split a format-mode wire into covertexts on ``terminator``."""
+    return fteproxy.defs.validate.frame_covertexts(wire, terminator)
+
+
+def record_layer_pair(spec, hybrid=False, key=_KEY):
+    """An ``(Encoder, Decoder)`` pair for one definitions entry, in one mode.
+
+    The same wiring :func:`fteproxy._session_channel` does for a live
+    connection, minus the handshake: in ``format`` mode a variable-length format
+    also gets the ciphers for every length it may emit, and in ``hybrid`` mode
+    it does not, because a hybrid record is a fixed-length header plus a raw
+    body. A protocol's test file uses this so it exercises the framing the
+    product actually uses rather than a hand-rolled approximation of it.
+    """
+    regex = spec['regex']
+    length = fteproxy.defs.spec_length(spec)
+    variable = (None if hybrid or not fteproxy.defs.spec_is_variable(spec)
+                else fteproxy._variable_lengths_for_spec(spec, key))
+    body = fteproxy._make_body_cipher(key) if hybrid else None
+    return (rl.Encoder(cipher=fteproxy._make_cipher(regex, length, key),
+                       body_cipher=body, variable=variable),
+            rl.Decoder(cipher=fteproxy._make_cipher(regex, length, key),
+                       body_cipher=body, variable=variable))
+
+
+def allowed_lengths(spec):
+    """The covertext lengths one definitions entry may emit, ascending."""
+    return fteproxy.defs.spec_allowed_lengths(spec)
 
 
 def statistical_guard(covertexts, max_run_fraction=0.5):

--- a/fteproxy/tests/realism/http.py
+++ b/fteproxy/tests/realism/http.py
@@ -26,7 +26,9 @@ import io
 
 
 _METHODS = ('GET', 'POST', 'HEAD')
-_STATUS = {200: 'OK', 302: 'Found', 404: 'Not Found'}
+#: 304 joined the format when the response dropped its body: a response whose
+#: status says "no body" is the honest shape for a header-block-only covertext.
+_STATUS = {200: 'OK', 302: 'Found', 304: 'Not Modified', 404: 'Not Found'}
 _REQUEST_HEADERS = ('Host', 'User-Agent', 'Accept', 'Accept-Language')
 _RESPONSE_HEADERS = ('Content-Type', 'Content-Length', 'Server')
 

--- a/fteproxy/tests/test_format_ftp.py
+++ b/fteproxy/tests/test_format_ftp.py
@@ -15,17 +15,25 @@ This is the seal-padding limitation documented in ``docs/format-authoring.md``
 (realistic value content and length distribution are not reachable by uniform
 rank sampling); the regex and the realism check still model every command and
 reply the format supports.
+
+``ftp`` is variable length (phase F7): a format-mode record picks one of the
+lengths in ``[min_length, max_length]``, so these tests read the length from
+:func:`fteproxy.defs.spec_length` (the ``max_length`` the handshake seals at)
+and check a covertext's length against the allowed set rather than against one
+number. ``fteproxy/tests/test_variable_length.py`` covers the framing itself.
 """
 
+import os
 import re
 
 import pytest
 
 import fteproxy
 import fteproxy.defs
-import fteproxy.record_layer as rl
 from fteproxy.tests.realism import (
+    allowed_lengths,
     format_covertexts,
+    record_layer_pair,
     statistical_guard,
     load_part,
 )
@@ -45,7 +53,8 @@ def _spec(name):
 @pytest.mark.parametrize('name', _ENTRIES)
 def test_cipher_builds_and_clears_capacity_floor(name):
     spec = _spec(name)
-    cipher = fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    cipher = fteproxy._make_cipher(
+        spec['regex'], fteproxy.defs.spec_length(spec), _KEY)
     assert cipher.max_plaintext_bytes >= fteproxy.defs.MIN_CAPACITY
     assert cipher.max_plaintext_bytes >= 128
 
@@ -53,21 +62,7 @@ def test_cipher_builds_and_clears_capacity_floor(name):
 @pytest.mark.parametrize('name', _ENTRIES)
 @pytest.mark.parametrize('hybrid', [False, True], ids=['format', 'hybrid'])
 def test_roundtrip_through_record_layer(name, hybrid):
-    spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-
-    def make_encoder():
-        return rl.Encoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    def make_decoder():
-        return rl.Decoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    encoder, decoder = make_encoder(), make_decoder()
-    import os
+    encoder, decoder = record_layer_pair(_spec(name), hybrid=hybrid, key=_KEY)
     for i in range(16):
         payload = os.urandom((i * 11) % (encoder.capacity + 1))
         encoder.push(payload)
@@ -79,13 +74,14 @@ def test_roundtrip_through_record_layer(name, hybrid):
 @pytest.mark.parametrize('name', _ENTRIES)
 def test_sealed_covertexts_are_real_ftp(name):
     spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+    pattern = re.compile(spec['regex'].encode('latin-1'), re.DOTALL)
+    allowed = allowed_lengths(spec)
 
-    covertexts = format_covertexts(regex, length, n=256)
+    covertexts = format_covertexts(spec, n=256)
     assert len(covertexts) == 256
 
     for covertext in covertexts:
+        assert len(covertext) in allowed
         assert pattern.fullmatch(covertext), covertext[:64]
         ftp_realism.check(covertext)  # raises if not a valid FTP line
 

--- a/fteproxy/tests/test_format_http.py
+++ b/fteproxy/tests/test_format_http.py
@@ -13,6 +13,12 @@ For both ``http-request`` and ``http-response``:
   the independent-parser realism :func:`~fteproxy.tests.realism.http.check`, and
   clear :func:`~fteproxy.tests.realism.statistical_guard`;
 * the base name ``http`` is exposed by :func:`fteproxy.defs.base_names`.
+
+``http`` is variable length (phase F7): a format-mode record picks one of the
+lengths in ``[min_length, max_length]``, so these tests read the length from
+:func:`fteproxy.defs.spec_length` (the ``max_length`` the handshake seals at)
+and check a covertext's length against the allowed set rather than against one
+number. ``fteproxy/tests/test_variable_length.py`` covers the framing itself.
 """
 
 import os
@@ -22,7 +28,6 @@ import pytest
 
 import fteproxy
 import fteproxy.defs
-import fteproxy.record_layer as rl
 import fteproxy.tests.realism as realism
 import fteproxy.tests.realism.http as http_realism
 
@@ -38,7 +43,8 @@ def _spec(name):
 
 def _cipher(name):
     spec = _spec(name)
-    return fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    return fteproxy._make_cipher(
+        spec['regex'], fteproxy.defs.spec_length(spec), _KEY)
 
 
 @pytest.mark.parametrize('name', _NAMES)
@@ -51,21 +57,8 @@ def test_cipher_builds_with_capacity_floor(name):
 @pytest.mark.parametrize('name', _NAMES)
 @pytest.mark.parametrize('hybrid', [False, True])
 def test_round_trip_through_record_layer(name, hybrid):
-    spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-
-    def make_encoder():
-        return rl.Encoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    def make_decoder():
-        return rl.Decoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    encoder = make_encoder()
-    decoder = make_decoder()
+    encoder, decoder = realism.record_layer_pair(_spec(name), hybrid=hybrid,
+                                                 key=_KEY)
     for i in range(16):
         payload = os.urandom((i * 11) % (encoder.capacity + 1))
         encoder.push(payload)
@@ -77,12 +70,13 @@ def test_round_trip_through_record_layer(name, hybrid):
 @pytest.mark.parametrize('name', _NAMES)
 def test_sealed_covertexts_are_realistic(name):
     spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+    pattern = re.compile(spec['regex'].encode('latin-1'), re.DOTALL)
+    allowed = realism.allowed_lengths(spec)
 
-    covertexts = realism.format_covertexts(regex, length, n=256)
+    covertexts = realism.format_covertexts(spec, n=256)
     assert len(covertexts) == 256
     for covertext in covertexts:
+        assert len(covertext) in allowed
         assert pattern.fullmatch(covertext), covertext[:80]
         http_realism.check(covertext)
     realism.statistical_guard(covertexts)

--- a/fteproxy/tests/test_format_sip.py
+++ b/fteproxy/tests/test_format_sip.py
@@ -14,6 +14,12 @@ For both ``sip-request`` and ``sip-response``:
   the independent-parser realism :func:`~fteproxy.tests.realism.sip.check`, and
   clear :func:`~fteproxy.tests.realism.statistical_guard`;
 * the base name ``sip`` is exposed by :func:`fteproxy.defs.base_names`.
+
+``sip`` is variable length (phase F7): a format-mode record picks one of the
+lengths in ``[min_length, max_length]``, so these tests read the length from
+:func:`fteproxy.defs.spec_length` (the ``max_length`` the handshake seals at)
+and check a covertext's length against the allowed set rather than against one
+number. ``fteproxy/tests/test_variable_length.py`` covers the framing itself.
 """
 
 import os
@@ -23,7 +29,6 @@ import pytest
 
 import fteproxy
 import fteproxy.defs
-import fteproxy.record_layer as rl
 import fteproxy.tests.realism as realism
 import fteproxy.tests.realism.sip as sip_realism
 
@@ -39,7 +44,8 @@ def _spec(name):
 
 def _cipher(name):
     spec = _spec(name)
-    return fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    return fteproxy._make_cipher(
+        spec['regex'], fteproxy.defs.spec_length(spec), _KEY)
 
 
 @pytest.mark.parametrize('name', _NAMES)
@@ -64,21 +70,8 @@ def test_schema_v2_keys(name):
 @pytest.mark.parametrize('name', _NAMES)
 @pytest.mark.parametrize('hybrid', [False, True])
 def test_round_trip_through_record_layer(name, hybrid):
-    spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-
-    def make_encoder():
-        return rl.Encoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    def make_decoder():
-        return rl.Decoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    encoder = make_encoder()
-    decoder = make_decoder()
+    encoder, decoder = realism.record_layer_pair(_spec(name), hybrid=hybrid,
+                                                 key=_KEY)
     for i in range(16):
         payload = os.urandom((i * 13) % (encoder.capacity + 1))
         encoder.push(payload)
@@ -90,12 +83,13 @@ def test_round_trip_through_record_layer(name, hybrid):
 @pytest.mark.parametrize('name', _NAMES)
 def test_sealed_covertexts_are_realistic(name):
     spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+    pattern = re.compile(spec['regex'].encode('latin-1'), re.DOTALL)
+    allowed = realism.allowed_lengths(spec)
 
-    covertexts = realism.format_covertexts(regex, length, n=256)
+    covertexts = realism.format_covertexts(spec, n=256)
     assert len(covertexts) == 256
     for covertext in covertexts:
+        assert len(covertext) in allowed
         assert pattern.fullmatch(covertext), covertext[:80]
         sip_realism.check(covertext)
     realism.statistical_guard(covertexts)

--- a/fteproxy/tests/test_format_smtp.py
+++ b/fteproxy/tests/test_format_smtp.py
@@ -8,6 +8,12 @@ the record layer in both ``format`` and ``hybrid`` modes, and a batch of sealed
 format-mode covertexts is drawn through the real record layer and judged for
 realism (regex fullmatch, the SMTP grammar :func:`~fteproxy.tests.realism.smtp.check`,
 and the statistical guard against degenerate single-byte runs).
+
+``smtp`` is variable length (phase F7): a format-mode record picks one of the
+lengths in ``[min_length, max_length]``, so these tests read the length from
+:func:`fteproxy.defs.spec_length` (the ``max_length`` the handshake seals at)
+and check a covertext's length against the allowed set rather than against one
+number. ``fteproxy/tests/test_variable_length.py`` covers the framing itself.
 """
 
 import os
@@ -17,10 +23,11 @@ import pytest
 
 import fteproxy
 import fteproxy.defs
-import fteproxy.record_layer as rl
 from fteproxy.tests.realism import (
+    allowed_lengths,
     format_covertexts,
     load_part,
+    record_layer_pair,
     statistical_guard,
 )
 from fteproxy.tests.realism import smtp as smtp_realism
@@ -37,7 +44,8 @@ def _spec(name):
 @pytest.mark.parametrize('name', _ROLES)
 def test_cipher_builds_and_meets_capacity_floor(name):
     spec = _spec(name)
-    cipher = fteproxy._make_cipher(spec['regex'], spec['length'], _KEY)
+    cipher = fteproxy._make_cipher(
+        spec['regex'], fteproxy.defs.spec_length(spec), _KEY)
     assert cipher.max_plaintext_bytes >= 128
     assert cipher.max_plaintext_bytes >= fteproxy.defs.MIN_CAPACITY
 
@@ -45,21 +53,7 @@ def test_cipher_builds_and_meets_capacity_floor(name):
 @pytest.mark.parametrize('name', _ROLES)
 @pytest.mark.parametrize('hybrid', [False, True], ids=['format', 'hybrid'])
 def test_round_trip_through_record_layer(name, hybrid):
-    spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-
-    def build_encoder():
-        return rl.Encoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    def build_decoder():
-        return rl.Decoder(
-            cipher=fteproxy._make_cipher(regex, length, _KEY),
-            body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None)
-
-    encoder = build_encoder()
-    decoder = build_decoder()
+    encoder, decoder = record_layer_pair(_spec(name), hybrid=hybrid, key=_KEY)
     for i in range(16):
         payload = os.urandom((i * 5) % (encoder.capacity + 1))
         encoder.push(payload)
@@ -71,13 +65,13 @@ def test_round_trip_through_record_layer(name, hybrid):
 @pytest.mark.parametrize('name', _ROLES)
 def test_format_covertexts_are_realistic(name):
     spec = _spec(name)
-    regex, length = spec['regex'], spec['length']
-    pattern = re.compile(regex.encode('latin-1'), re.DOTALL)
+    pattern = re.compile(spec['regex'].encode('latin-1'), re.DOTALL)
+    allowed = allowed_lengths(spec)
 
-    covertexts = format_covertexts(regex, length, n=256)
+    covertexts = format_covertexts(spec, n=256)
     assert len(covertexts) == 256
     for covertext in covertexts:
-        assert len(covertext) == length
+        assert len(covertext) in allowed
         assert pattern.fullmatch(covertext), repr(covertext[:64])
         smtp_realism.check(covertext)
     statistical_guard(covertexts)

--- a/fteproxy/tests/test_system.py
+++ b/fteproxy/tests/test_system.py
@@ -324,6 +324,26 @@ class TestEndToEnd:
         finally:
             terminate(proc)
 
+    def test_a_line_protocol_in_format_mode_end_to_end(self, server, state_dir,
+                                                       destination):
+        """A variable-length line protocol through the real relay.
+
+        ``ftp`` in ``format`` mode is the demanding combination: every byte on
+        the wire is a covertext, the covertexts vary in length from 64 to 256
+        bytes, and they are framed on a two-byte terminator, so a payload larger
+        than one record crosses many frames and several of the lengths.
+        """
+        proc = start(['client', '--format', 'ftp', '--mode', 'format',
+                      '-L', '%s:%d:%s:%d'
+                      % (BIND_IP, FORWARD_PORT, BIND_IP, destination.port),
+                      '--state-dir', state_dir])
+        try:
+            assert wait_for_port(BIND_IP, FORWARD_PORT)
+            payload = bytes(range(256)) * 12
+            assert transfer((BIND_IP, FORWARD_PORT), payload) == payload
+        finally:
+            terminate(proc)
+
     def test_a_non_default_format_end_to_end(self, server, state_dir,
                                              destination):
         """The server is told no format; it learns it from the first record."""

--- a/fteproxy/tests/test_variable_length.py
+++ b/fteproxy/tests/test_variable_length.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Variable-length covertexts (phase F7).
+
+Until now every covertext of a format was exactly one length, which SECURITY.md
+called out as its own fingerprint: a length-distribution test separates a tunnel
+from real traffic without looking at a single byte. The four text formats
+(``http``, ``ftp``, ``smtp``, ``sip``) now pick a covertext length per
+format-mode record from a small set spanning ``[min_length, max_length]``, and
+the decoder frames the wire on the format's terminator instead of on a fixed
+slice.
+
+What these tests pin down:
+
+* the **length set** both ends derive from the definitions, without negotiating it;
+* **framing**: a record delivered in fragments, including a split inside the
+  terminator itself, reassembles; a length the format does not emit, a corrupted
+  covertext, and a peer that never sends a terminator each fail the stream
+  closed rather than being buffered or guessed at;
+* the **spread**: a stream of small and large writes produces many distinct
+  covertext lengths and no dominant one, which is the point of the change;
+* **terminator uniqueness**, the property framing rests on, including that the
+  pre-F7 ``http-response`` regex (which absorbed a body and so could carry a
+  CRLF CRLF inside a covertext) is rejected by the check;
+* what did **not** change: the two handshake records and a ``hybrid`` header are
+  still one fixed ``max_length`` covertext, and ``dns`` and the shape catalog
+  are still framed by their fixed length.
+"""
+
+import collections
+import os
+import re
+import socket
+import threading
+
+import pytest
+
+import fteproxy
+import fteproxy.conf
+import fteproxy.defs
+import fteproxy.defs.validate as validate
+import fteproxy.handshake
+import fteproxy.record_layer as rl
+import fteproxy.tests.realism as realism
+
+
+_KEY = bytes(range(32))
+
+#: The variable-length formats the 20260903 release ships, with the terminator
+#: each one is framed on.
+VARIABLE = {
+    'http-request': b'\r\n\r\n',
+    'http-response': b'\r\n\r\n',
+    'ftp-request': b'\r\n',
+    'ftp-response': b'\r\n',
+    'smtp-request': b'\r\n',
+    'smtp-response': b'\r\n',
+    'sip-request': b'\r\n\r\n',
+    'sip-response': b'\r\n\r\n',
+}
+
+SERVER_PRIVATE, SERVER_PUBLIC = fteproxy.generate_server_key()
+
+
+@pytest.fixture(autouse=True)
+def _release():
+    """The shipped release, restored afterwards (one test selects another)."""
+    previous = fteproxy.conf.getValue('fteproxy.defs.release')
+    saved = fteproxy.defs._definitions
+    fteproxy.conf.setValue('fteproxy.defs.release', '20260903')
+    fteproxy.defs._definitions = None
+    fteproxy.defs.load_definitions()
+    yield
+    fteproxy.conf.setValue('fteproxy.defs.release', previous)
+    fteproxy.defs._definitions = saved
+
+
+def _spec(name):
+    return fteproxy.defs.load_definitions()[name]
+
+
+def _pair(name, key=_KEY):
+    """An ``(Encoder, Decoder)`` pair in format mode for one variable format."""
+    return realism.record_layer_pair(_spec(name), hybrid=False, key=key)
+
+
+def _variable(name, key=_KEY):
+    return fteproxy._variable_lengths_for_spec(_spec(name), key)
+
+
+# --------------------------------------------------------------------------- #
+# The length set
+# --------------------------------------------------------------------------- #
+
+class TestAllowedLengths:
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_the_set_spans_the_declared_range(self, name):
+        spec = _spec(name)
+        lengths = fteproxy.defs.spec_allowed_lengths(spec)
+        assert lengths == tuple(sorted(set(lengths)))
+        assert len(lengths) == fteproxy.defs.LENGTH_STEPS
+        assert lengths[0] == spec['min_length']
+        assert lengths[-1] == spec['max_length']
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_every_length_carries_at_least_one_data_record(self, name):
+        """The floor for the *shortest* length: a type byte, the seal, and a
+        byte of payload. The 128-byte capacity floor applies at max_length,
+        where the handshake lives."""
+        variable = _variable(name)
+        assert min(variable.capacities.values()) >= 1
+        assert variable.capacities[variable.max_length] >= \
+            fteproxy.defs.MIN_CAPACITY - rl._SEAL_OVERHEAD - rl._TYPE_LEN
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_both_ends_derive_the_same_set(self, name):
+        """Nothing about the length set is negotiated: it is a function of the
+        definitions entry, so a sender's choice is a receiver's expectation."""
+        spec = _spec(name)
+        assert (fteproxy.defs.get_allowed_lengths(name)
+                == fteproxy.defs.spec_allowed_lengths(spec))
+        assert fteproxy.defs.get_terminator(name) == VARIABLE[name]
+        assert fteproxy.defs.is_variable(name)
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_get_length_is_the_top_of_the_range(self, name):
+        """What the fixed-frame paths use: the handshake, the server's
+        first-record scan, and a hybrid header."""
+        assert fteproxy.defs.getLength(name) == _spec(name)['max_length']
+
+    def test_a_partial_declaration_is_refused_at_load(self):
+        """A range with no terminator would silently load as fixed length and
+        emit one length again, so it fails at load instead."""
+        for broken in ({'regex': r'^[a-z]+\r\n$', 'min_length': 64,
+                        'max_length': 256},
+                       {'regex': r'^[a-z]+\r\n$', 'terminator': '\r\n'},
+                       {'regex': r'^[a-z]+\r\n$', 'min_length': 64,
+                        'max_length': 256, 'terminator': '\r\n',
+                        'length': 128}):
+            with pytest.raises(fteproxy.defs.DefinitionsError):
+                fteproxy.defs.check_capacities({'broken-request': broken})
+
+    def test_an_inverted_range_is_refused(self):
+        with pytest.raises(fteproxy.defs.DefinitionsError):
+            fteproxy.defs.check_capacities({'broken-request': {
+                'regex': r'^[a-z]+\r\n$', 'min_length': 256,
+                'max_length': 64, 'terminator': '\r\n'}})
+
+
+# --------------------------------------------------------------------------- #
+# Framing
+# --------------------------------------------------------------------------- #
+
+class TestTerminatorFraming:
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_records_of_many_sizes_round_trip(self, name):
+        encoder, decoder = _pair(name)
+        for i in range(24):
+            payload = os.urandom((i * 29) % (encoder.capacity + 1))
+            encoder.push(payload)
+            decoder.push(encoder.pop())
+            assert decoder.pop() == payload
+        assert not decoder.failed
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_every_covertext_ends_with_the_terminator_and_nothing_else_does(
+            self, name):
+        terminator = VARIABLE[name]
+        encoder, _decoder = _pair(name)
+        encoder.push(os.urandom(20000))
+        wire = encoder.pop()
+        covertexts = validate.frame_covertexts(wire, terminator)
+        assert len(covertexts) > 1
+        for covertext in covertexts:
+            assert covertext.endswith(terminator)
+            assert terminator not in covertext[:-len(terminator)]
+        assert b''.join(covertexts) == wire
+
+    @pytest.mark.parametrize('name', ['ftp-request', 'http-request'])
+    def test_a_record_split_at_every_byte_reassembles(self, name):
+        """Including every split *inside* the terminator, which is the case a
+        fixed-length decoder never had to think about: a partial terminator
+        must read as "not yet", never as a short record."""
+        encoder, _ = _pair(name)
+        payload = b'the quick brown fox'
+        encoder.push(payload)
+        wire = encoder.pop()
+        assert len(validate.frame_covertexts(wire, VARIABLE[name])) == 1
+
+        for split in range(1, len(wire)):
+            _encoder, decoder = _pair(name)
+            decoder.push(wire[:split])
+            assert decoder.pop() == b'', 'emitted early at split %d' % split
+            assert not decoder.failed, 'failed at split %d' % split
+            decoder.push(wire[split:])
+            assert decoder.pop() == payload, 'lost at split %d' % split
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_a_multi_record_wire_delivered_in_odd_chunks(self, name):
+        encoder, decoder = _pair(name)
+        payload = bytes(range(256)) * 40
+        encoder.push(payload)
+        wire = encoder.pop()
+        out = b''
+        for offset in range(0, len(wire), 37):
+            decoder.push(wire[offset:offset + 37])
+            out += decoder.pop()
+        assert out == payload
+
+    def test_control_records_interleave_with_data(self):
+        encoder, decoder = _pair('http-request')
+        wire = encoder.encode(rl.OPEN, b'dest')
+        encoder.push(b'payload')
+        wire += encoder.pop()
+        wire += encoder.encode(rl.CLOSE)
+        decoder.push(wire)
+        assert decoder.pop_records() == [
+            (rl.OPEN, b'dest'),
+            (rl.DATA, b'payload'),
+            (rl.CLOSE, b''),
+        ]
+
+    def test_a_reordered_record_is_rejected(self):
+        """The seal still stamps the stream position, so the same record in the
+        wrong place does not decode -- variable length changes framing, not the
+        anti-replay guarantee."""
+        encoder, _ = _pair('ftp-request')
+        encoder.push(b'first')
+        first = encoder.pop()
+        encoder.push(b'second')
+        second = encoder.pop()
+
+        _e, ordered = _pair('ftp-request')
+        ordered.push(first + second)
+        assert ordered.pop() == b'firstsecond'
+
+        _e, swapped = _pair('ftp-request')
+        swapped.push(second + first)
+        assert swapped.pop() == b''
+        assert swapped.failed
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed
+# --------------------------------------------------------------------------- #
+
+class TestFailsClosed:
+
+    def test_a_length_the_format_does_not_emit_is_refused(self):
+        """A covertext that is in the format's language, sealed with the right
+        key, at a length between two allowed ones. Only the length is wrong, and
+        that alone kills the stream: framing cannot be salvaged by hunting for a
+        later terminator."""
+        spec = _spec('http-request')
+        lengths = fteproxy.defs.spec_allowed_lengths(spec)
+        odd = (lengths[0] + lengths[1]) // 2
+        assert odd not in lengths
+        odd_cipher = fteproxy._make_cipher(spec['regex'], odd, _KEY)
+        record = rl._seal(odd_cipher, bytes((rl.DATA,)) + b'hello', 0)
+        assert len(record) == odd
+        assert record.endswith(b'\r\n\r\n')
+
+        _encoder, decoder = _pair('http-request')
+        decoder.push(record)
+        assert decoder.pop_records() == []
+        assert decoder.failed
+        assert decoder._buffer == b''
+        with pytest.raises(rl.StreamFailedError):
+            decoder.push(b'more')
+
+    def test_a_corrupted_covertext_is_refused(self):
+        """One flipped bit in a field, so the length and the terminator are
+        untouched and only the seal notices."""
+        encoder, decoder = _pair('sip-request')
+        encoder.push(b'payload')
+        wire = bytearray(encoder.pop())
+        index = next(i for i, byte in enumerate(wire)
+                     if i > 40 and byte >= 0x20)      # inside a field, printable
+        wire[index] ^= 0x01
+        decoder.push(bytes(wire))
+        assert decoder.pop_records() == []
+        assert decoder.failed
+
+    def test_good_records_before_a_bad_one_are_delivered(self):
+        encoder, decoder = _pair('ftp-response')
+        encoder.push(b'first')
+        good = encoder.pop()
+        decoder.push(good + b'X' * 8 + b'\r\n')
+        assert decoder.pop() == b'first'
+        assert decoder.failed
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_a_peer_that_never_terminates_cannot_grow_the_buffer(self, name):
+        """Terminator framing has no natural bound of its own, so one is
+        imposed: more than one longest covertext with no terminator in it is
+        not a record that is still arriving, it is a peer feeding the buffer."""
+        _encoder, decoder = _pair(name)
+        maximum = _spec(name)['max_length']
+
+        decoder.push(b'A' * maximum)            # could still become a record
+        assert decoder.pop_records() == []
+        assert not decoder.failed
+        assert len(decoder._buffer) == maximum
+
+        decoder.push(b'A')                      # now it cannot
+        assert decoder.pop_records() == []
+        assert decoder.failed
+        assert decoder._buffer == b''
+        with pytest.raises(rl.StreamFailedError):
+            decoder.push(b'A' * 64)
+
+    def test_the_decoder_bounds_itself_by_the_longest_covertext(self):
+        for name in sorted(VARIABLE):
+            _encoder, decoder = _pair(name)
+            assert decoder.max_record_bytes == _spec(name)['max_length']
+
+
+# --------------------------------------------------------------------------- #
+# The spread: the fingerprint this phase exists to remove
+# --------------------------------------------------------------------------- #
+
+class TestLengthSpread:
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_a_mixed_stream_produces_many_lengths_and_no_dominant_one(self, name):
+        """Interactive-sized writes and bulk writes together, as a relayed
+        session carries. Before F7 this histogram had exactly one bar."""
+        terminator = VARIABLE[name]
+        encoder, _decoder = _pair(name)
+        wire = b''
+        for i in range(120):
+            encoder.push(os.urandom(1 + (i * 13) % 40))      # small messages
+            wire += encoder.pop()
+        for _ in range(12):
+            encoder.push(os.urandom(4096))                   # bulk
+            wire += encoder.pop()
+
+        covertexts = validate.frame_covertexts(wire, terminator)
+        histogram = collections.Counter(len(c) for c in covertexts)
+        allowed = set(fteproxy.defs.spec_allowed_lengths(_spec(name)))
+        assert set(histogram) <= allowed
+        assert len(histogram) >= 6, histogram
+        assert max(histogram.values()) <= 0.5 * len(covertexts), histogram
+
+    def test_small_writes_lean_short_and_bulk_leans_long(self):
+        """The bias is what makes the spread look like traffic rather than like
+        a random number generator: a chat session should not emit 700-byte
+        requests every time, and a download should not emit 200-byte ones."""
+        name = 'http-request'
+        terminator = VARIABLE[name]
+        lengths = fteproxy.defs.spec_allowed_lengths(_spec(name))
+        midpoint = lengths[len(lengths) // 2]
+
+        def mean_length(chunks):
+            encoder, _ = _pair(name)
+            wire = b''
+            for chunk in chunks:
+                encoder.push(chunk)
+                wire += encoder.pop()
+            sizes = [len(c) for c in
+                     validate.frame_covertexts(wire, terminator)]
+            return sum(sizes) / len(sizes)
+
+        interactive = mean_length([os.urandom(8) for _ in range(200)])
+        bulk = mean_length([os.urandom(20000) for _ in range(4)])
+        assert interactive < midpoint < bulk
+
+    def test_a_record_is_never_split_to_look_shorter(self):
+        """A payload that fits in one record travels as one record: the length
+        choice never picks a length too small to hold what is queued."""
+        for name in sorted(VARIABLE):
+            terminator = VARIABLE[name]
+            encoder, _ = _pair(name)
+            payload = os.urandom(encoder.capacity)
+            encoder.push(payload)
+            wire = encoder.pop()
+            assert len(validate.frame_covertexts(wire, terminator)) == 1
+            assert len(wire) == max(
+                fteproxy.defs.spec_allowed_lengths(_spec(name)))
+
+
+# --------------------------------------------------------------------------- #
+# Terminator uniqueness
+# --------------------------------------------------------------------------- #
+
+#: What ``http-response`` looked like before F7: the trailing field absorbed a
+#: body and admitted CR and LF, so a covertext could carry ``\r\n\r\n`` inside
+#: it and terminator framing would cut the record in half.
+_PRE_F7_HTTP_RESPONSE = (
+    '^HTTP/1\\.1 (200 OK|302 Found|404 Not Found)\r\n'
+    'Content-Type: [a-zA-Z0-9/;=. +-]+\r\n'
+    'Content-Length: [0-9]+\r\n'
+    'Server: [a-zA-Z0-9/. ()_-]+\r\n'
+    '\r\n[a-zA-Z0-9/+= \r\n-]*$')
+
+
+class TestTerminatorUniqueness:
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_every_shipped_variable_format_passes_the_static_check(self, name):
+        validate.check_terminator_uniqueness(
+            name, _spec(name)['regex'], VARIABLE[name])
+
+    @pytest.mark.parametrize('name', sorted(VARIABLE))
+    def test_sampled_covertexts_agree_with_the_static_check(self, name):
+        covertexts = realism.format_covertexts(_spec(name), n=64)
+        validate._check_sampled_terminators(name, covertexts, VARIABLE[name])
+
+    def test_the_pre_f7_http_response_body_field_is_rejected(self):
+        """The regression this check exists for: a body-absorbing field. It
+        fails on the first condition -- a pattern whose last atom is a field
+        rather than the terminator cannot have the terminator as its suffix at
+        all, which is why F7 ended the response at the header block."""
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.check_terminator_uniqueness(
+                'http-response', _PRE_F7_HTTP_RESPONSE, b'\r\n\r\n')
+        assert 'does not end with its terminator' in str(excinfo.value)
+
+    def test_a_class_that_admits_a_terminator_byte_is_rejected(self):
+        """Even ending in the terminator is not enough: a field that can carry
+        a CR or an LF could reproduce it mid-covertext."""
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.check_terminator_uniqueness(
+                'x-response', '^Body: [a-z\r\n]+\r\n\r\n$', b'\r\n\r\n')
+        assert 'character class' in str(excinfo.value)
+
+    def test_a_literal_that_repeats_the_terminator_is_rejected(self):
+        """No class carries a terminator byte here; the literals do, twice."""
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.check_terminator_uniqueness(
+                'x-request', '^A: [a-z]+\r\n\r\nB: [a-z]+\r\n\r\n$',
+                b'\r\n\r\n')
+        assert 'literal text' in str(excinfo.value)
+
+    @pytest.mark.parametrize('regex,terminator,why', [
+        ('^(X\r|Y)\nZ: [a-z]+\r\n$', b'\r\n',
+         'a branch ends in CR and what follows the group starts with LF'),
+        ('^A\rB?\nC: [a-z]+\r\n$', b'\r\n',
+         'an optional literal, absent, puts CR next to LF'),
+        ('^X(\r\n)+Y: [a-z]+\r\n\r\n$', b'\r\n\r\n',
+         'a repeated unit meets itself'),
+    ])
+    def test_adjacencies_a_single_concatenation_would_miss(self, regex,
+                                                           terminator, why):
+        """The literal check expands alternation branches and optional atoms
+        rather than concatenating the pattern's literals once. Each of these
+        can produce the terminator mid-covertext, and a single concatenated
+        skeleton shows none of them."""
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.check_terminator_uniqueness('x-request', regex, terminator)
+        assert 'literal text' in str(excinfo.value), why
+
+    def test_a_pattern_too_complex_to_prove_is_refused_not_passed(self):
+        """Failing open here would mean shipping a format whose framing is not
+        proven, so the expansion cap is a validation failure."""
+        explosive = '^' + '(a|b|c|d)' * 20 + 'X\r\n$'
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.check_terminator_uniqueness('x-request', explosive, b'\r\n')
+        assert 'too many' in str(excinfo.value)
+
+    def test_a_pattern_that_does_not_end_with_its_terminator_is_rejected(self):
+        with pytest.raises(validate.FormatValidationError):
+            validate.check_terminator_uniqueness(
+                'x-request', '^GET /[a-z]+ HTTP/1\\.1$', b'\r\n')
+
+    def test_a_negated_class_is_rejected(self):
+        with pytest.raises(validate.FormatValidationError):
+            validate.check_terminator_uniqueness(
+                'x-request', '^[^!]+\r\n$', b'\r\n')
+
+    def test_validate_format_refuses_a_format_whose_terminator_is_not_unique(self):
+        spec = {'regex': _PRE_F7_HTTP_RESPONSE, 'min_length': 200,
+                'max_length': 700, 'terminator': '\r\n\r\n',
+                'mode_hint': 'format'}
+        with pytest.raises(validate.FormatValidationError):
+            validate.validate_format('http-response', spec, samples=2)
+
+    def test_the_class_scanner_reads_the_dialect(self):
+        """Ranges expand, a leading or trailing ``-`` is itself, and there are
+        no backslash escapes inside a class."""
+        assert validate._class_members('a-c') == set('abc')
+        assert validate._class_members('a-z.-') == set('abcdefghijklmnopqrstuvwxyz.-')
+        assert validate._class_members('-ab') == set('-ab')
+        assert validate._class_members('^a') is None
+
+    def test_skeletons_expand_branches_and_optional_atoms(self):
+        any_ = validate._ANY
+        assert validate._literal_skeletons('(GET|PUT) /') == {'GET /', 'PUT /'}
+        assert validate._literal_skeletons('/[a-z]*x') == {'/x', '/' + any_ + 'x'}
+        assert validate._literal_skeletons('[a-z]+') == {any_}
+        assert validate._literal_skeletons('a?b') == {'b', 'ab'}
+
+
+# --------------------------------------------------------------------------- #
+# What did not change
+# --------------------------------------------------------------------------- #
+
+class _Recorder:
+    """A socket that remembers every ``sendall``, and is otherwise the real one."""
+
+    def __init__(self, sock):
+        self._sock = sock
+        self.sent = []
+
+    def sendall(self, data):
+        self.sent.append(bytes(data))
+        return self._sock.sendall(data)
+
+    def __getattr__(self, name):
+        return getattr(self._sock, name)
+
+
+class _Reader(threading.Thread):
+    """Drains a wrapper in the background while the other end writes.
+
+    A ``socketpair``'s kernel buffer is a few kilobytes, so a sender that writes
+    more than that with nobody reading blocks forever. One reader and one
+    writer on a wrapper is exactly how the relay uses it.
+    """
+
+    def __init__(self, wrapper, expected):
+        super().__init__(daemon=True)
+        self._wrapper = wrapper
+        self._expected = expected
+        self.data = b''
+
+    def run(self):
+        while len(self.data) < self._expected:
+            chunk = self._wrapper.recv(65536)
+            if not chunk:
+                break
+            self.data += chunk
+
+
+class TestFixedFramingSurvives:
+
+    def _handshaken(self, base, mode):
+        """A real client/server pair over a socketpair, handshake completed."""
+        client_sock, server_sock = socket.socketpair()
+        client = fteproxy.wrap_socket(client_sock, server_id=SERVER_PUBLIC,
+                                      format=base, mode=mode)
+        client._socket = _Recorder(client_sock)
+        server = fteproxy.wrap_socket(server_sock, server_key=SERVER_PRIVATE)
+        errors = []
+
+        def accept():
+            try:
+                server.handshake()
+            except Exception as e:                      # pragma: no cover
+                errors.append(e)
+
+        thread = threading.Thread(target=accept)
+        thread.start()
+        try:
+            client.handshake()
+        finally:
+            thread.join(10)
+        assert not errors, errors
+        return client, server
+
+    @pytest.mark.parametrize('mode', ['format', 'hybrid'])
+    def test_the_client_hello_is_one_max_length_covertext(self, mode):
+        """The handshake is fixed length in both modes: the server's
+        first-record scan reads exactly ``max_length`` bytes and tries to unseal
+        them, so a hello at any other length would never be found."""
+        client, server = self._handshaken('http', mode)
+        try:
+            hello = client._socket.sent[0]
+            assert len(hello) == fteproxy.defs.getLength('http-request')
+            assert len(hello) == _spec('http-request')['max_length']
+            assert server.handshake_complete
+            assert server.negotiated_mode == mode
+        finally:
+            client.close()
+            server.close()
+
+    def test_format_mode_carries_traffic_and_varies_its_lengths(self):
+        """End to end through the socket wrapper: the session encoder is the
+        variable one, and what goes on the wire after the hello is a spread of
+        lengths that all decode."""
+        client, server = self._handshaken('http', 'format')
+        try:
+            assert client._encoder._variable is not None
+            assert client._decoder._variable is not None
+            expected = b''.join(b'x' * (1 + i * 7) for i in range(60))
+            reader = _Reader(server, len(expected))
+            reader.start()
+            for i in range(60):
+                client.send(b'x' * (1 + i * 7))
+            reader.join(20)
+            assert reader.data == expected
+
+            data_records = b''.join(client._socket.sent[1:])
+            lengths = {len(c) for c in
+                       validate.frame_covertexts(data_records, b'\r\n\r\n')}
+            assert len(lengths) >= 3, lengths
+            assert lengths <= set(
+                fteproxy.defs.spec_allowed_lengths(_spec('http-request')))
+        finally:
+            client.close()
+            server.close()
+
+    def test_a_hybrid_header_is_still_fixed_at_max_length(self):
+        client, server = self._handshaken('http', 'hybrid')
+        try:
+            assert client._encoder._variable is None
+            assert client._decoder._variable is None
+            reader = _Reader(server, 4000)
+            reader.start()
+            client.send(b'z' * 4000)
+            reader.join(20)
+            assert reader.data == b'z' * 4000
+            header = client._socket.sent[1]
+            length = fteproxy.defs.getLength('http-request')
+            pattern = re.compile(
+                _spec('http-request')['regex'].encode('latin-1'), re.DOTALL)
+            assert pattern.fullmatch(header[:length])
+            assert len(header) > length          # header plus a raw body
+        finally:
+            client.close()
+            server.close()
+
+    def test_dns_is_still_fixed_length(self):
+        """Its 2-byte length prefix is a literal in the regex, so a second
+        covertext length would need a second regex. It stays at 272."""
+        for name in ('dns-request', 'dns-response'):
+            spec = _spec(name)
+            assert not fteproxy.defs.spec_is_variable(spec)
+            assert fteproxy.defs.spec_allowed_lengths(spec) == (272,)
+            assert fteproxy.defs.getLength(name) == 272
+            assert fteproxy._variable_for(name, _KEY) is None
+
+        encoder, decoder = realism.record_layer_pair(_spec('dns-request'),
+                                                     key=_KEY)
+        assert encoder._variable is None
+        encoder.push(os.urandom(1000))
+        wire = encoder.pop()
+        assert len(wire) % 272 == 0
+        decoder.push(wire)
+        assert len(decoder.pop()) == 1000
+
+    def test_the_shape_catalog_is_still_fixed_length(self):
+        fteproxy.conf.setValue('fteproxy.defs.release', '20260110')
+        fteproxy.defs._definitions = None
+        definitions = fteproxy.defs.load_definitions()
+        for name, spec in definitions.items():
+            assert not fteproxy.defs.spec_is_variable(spec), name
+            assert len(fteproxy.defs.spec_allowed_lengths(spec)) == 1, name
+        assert fteproxy._variable_for('manual-http-request', _KEY) is None
+
+    def test_hybrid_refuses_to_carry_a_variable_length_format(self):
+        """The two framings are exclusive; wiring both would be a bug that only
+        showed up as a stream that will not decode."""
+        variable = _variable('http-request')
+        cipher = fteproxy._make_cipher(
+            _spec('http-request')['regex'], 700, _KEY)
+        body = fteproxy._make_body_cipher(_KEY)
+        with pytest.raises(ValueError):
+            rl.Encoder(cipher=cipher, body_cipher=body, variable=variable)
+        with pytest.raises(ValueError):
+            rl.Decoder(cipher=cipher, body_cipher=body, variable=variable)


### PR DESCRIPTION
Removes the fixed-length fingerprint for http, ftp, smtp and sip in format
mode: every covertext of a format used to be exactly one length, which a
length-distribution test separated from real traffic immediately.

Design. libfte's min/max ranking is deliberately NOT used: a language's
string count grows exponentially with length, so a uniform rank lands in
the longest class almost always and a range would emit max-length
covertexts nearly every time. Instead the record layer chooses each
format-mode record's length from a bounded discrete set (8 evenly spaced
points between the format's min_length and max_length, derived identically
by both ends with no negotiation), biased shorter when the payload fits
one record and longer when more is queued, and seals the chunk (padded to
that length's capacity, per the seal-padding rule) with a fixed-length
cipher at exactly that length (record_layer.VariableLength). The decoder
frames the wire on the format's terminator (\r\n\r\n for http and sip, \r\n
for ftp and smtp), checks the framed length against the allowed set, and
fails closed on anything else; a partial record without a terminator
waits, under a buffer bound. Measured over mixed payloads: all 8 lengths
appear for every text format and no single length exceeds ~30% of records.

Terminator uniqueness is enforced in defs/validate.py by a static proof
from the pattern (no character class may admit a terminator byte, no
literal may contain the terminator before the end) plus a sampled
re-check. http-response therefore drops its body-absorbing field, which
admitted CR and LF, and ends at the header block with Content-Length: 0;
its capacity moves into Server, Content-Type, ETag and Set-Cookie headers,
and 304 Not Modified is added.

Unchanged by design: the client and server hellos and hybrid-mode headers
are sealed at max_length (getLength returns max_length for a variable
format, so the first-record scan and the hybrid path are untouched, and
the flow-start fingerprint is confined to the two handshake records); dns
stays fixed at 272 because its 2-byte length prefix is a regex literal
(varying it needs a regex per length; deferred and documented); the shape
catalog keeps fixed-length framing.

Schema: min_length, max_length and terminator per entry; the release is
regenerated from parts/. validate.py checks every allowed length compiles
and matches; the realism harness frames by terminator. RegexFormat is
cached per (pattern, length) with the lru_cache raised to 1024; the keyed
FTE is built once per connection per direction and reused, since session
keys are per connection and a global key-keyed cache would never hit.

Tests: new test_variable_length.py (framing split at every byte across a
terminator, length spread, uniqueness, unknown-length fail-closed, hello
at max_length, hybrid and dns unchanged); the four protocol tests read the
length via spec_length and assert each covertext's length is in the
allowed set; the smtp fixed-length assertion is the one expectation that
legitimately changed. Docs: format-authoring (the design and the
uniqueness rule), SECURITY.md (the fixed-length claim rewritten), README,
PERFORMANCE.md, release notes, plan-formats F7 status.

Suite green at 734 (was 614).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
