### PR TITLE
Handshake review fixes: timing oracle, scan cost, eviction, control queue, redaction

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,20 +79,31 @@ first. This section covers what fteproxy adds on top of it.
 - **Replay window and filter.** A client hello carries an *epoch*: hours since
   the Unix epoch, accepted within plus or minus one hour. The server remembers
   the client ephemeral public key of every hello it accepted inside that
-  window, bucketed by epoch, and refuses a repeat. So a recorded hello can only
-  be replayed inside a two-hour window, and inside it the filter refuses it.
-  The filter is in memory only and bounded; past its cap the oldest hour is
-  forgotten, which re-opens replay only for hellos already at the edge of the
-  window. The check runs last, so a hello refused for any other reason cannot
-  be used to fill the filter and lock out a real client.
+  window, bucketed by epoch, and refuses a repeat. So a recorded hello can
+  only be replayed inside a window of up to three hours -- the hour it names
+  plus the one on either side, since both are accepted -- and inside that
+  window the filter refuses it, while past it the epoch check does. The
+  filter is in memory only and bounded; past its cap it drops entries from
+  whichever hour holds the most, so a flood cannot evict the hour real clients
+  are using, only itself. A flood that names the *current* hour shares that
+  bucket with real clients and can push their entries out, re-enabling replay
+  of those hellos inside the window; mounting it needs the connection string,
+  so it grants its holder nothing a fresh handshake does not, and a
+  pre-authentication rate limit is the real bound. The check runs last, so a hello refused for any other
+  reason cannot be used to fill the filter and lock out a real client.
 
 - **Behaviour on a failed handshake.** Every rejection is answered
-  identically: no reply, read and discard for a random 1 to 5 seconds, then
-  close, and one line in the DEBUG log. Unknown version, a reserved flag bit,
-  the wrong definitions release, an unknown format, a stale epoch, a replayed
-  hello and a hello sealed under someone else's key are indistinguishable from
-  each other and from a service with nothing to say. This is obfs4's behaviour
-  and is what stops an active prober learning anything from a bad guess.
+  identically: no reply, read and discard, then close, and one line in the
+  DEBUG log. The close comes a random 1 to 5 seconds after the handshake
+  timeout has run out, counted from when the connection was accepted -- not
+  from when the check failed, which would separate the rejections that are
+  decided on the first record from those that are only decided when the
+  timeout expires, and let one replayed capture confirm the server. Unknown
+  version, a reserved flag bit, the wrong definitions release, an unknown
+  format, a stale epoch, a replayed hello and a hello sealed under someone
+  else's key are indistinguishable from each other and from a service with
+  nothing to say. This is obfs4's behaviour and is what stops an active prober
+  learning anything from a bad guess.
 
 - **Which destinations a server will dial.** By default every destination
   *except* the server host's own loopback and link-local addresses, checked

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -59,8 +59,9 @@ exits on SIGINT or SIGTERM.
   ordinary covertexts, so the shape on the wire is unchanged.
 - **A failed handshake is answered with silence.** Wrong key, wrong format,
   stale clock, replayed hello: all identical from outside — no reply, read and
-  discard for a random 1 to 5 seconds, then close. A replay filter keyed on the
-  client's ephemeral key covers the ±1 hour epoch window.
+  discard, then close a random 1 to 5 seconds after the handshake timeout,
+  timed from the accept so that when the check failed does not show. A replay
+  filter keyed on the client's ephemeral key covers the ±1 hour epoch window.
 - **SOCKS5 and ssh-style forwards.** `-D [BIND:]PORT` is a SOCKS5 CONNECT
   listener (the default is `127.0.0.1:1080`); `-L [BIND:]PORT:HOST:PORT` is a
   fixed forward. Both are repeatable and can be mixed. Names are resolved at

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -414,9 +414,26 @@ class _FTESocketWrapper(object):
     #: speaking this protocol.
     _MAX_PRE_HANDSHAKE_BYTES = 1 << 16
 
+    #: How many control records may sit unread before the peer is treated as
+    #: hostile. A legitimate peer has at most an OPEN and its OPEN_RESULT
+    #: outstanding, and something has to read them for the session to make
+    #: progress; a peer that keeps sending them without being asked is filling
+    #: this end's memory, which only the holder of the session keys can do.
+    _MAX_CONTROL_RECORDS = 16
+    #: Largest control payload a real peer sends: an OPEN naming a 255-byte
+    #: host is 259 bytes, an OPEN_RESULT is 1. In hybrid mode a record can
+    #: carry a mebibyte, so the count bound alone would still let a peer park
+    #: 16 MiB per connection; the byte bound closes that.
+    _MAX_CONTROL_BYTES = 512
+
     def __init__(self, _socket, role, server_key=None, server_public=None,
                  format=None, mode=None, defs=None):
         self._socket = _socket
+        #: When this connection began, in the monotonic clock the reject path
+        #: measures against. Every rejection is timed from here rather than
+        #: from the moment the failure was noticed, so that *when* a hello
+        #: fails a check cannot be read off the close.
+        self._accepted_at = time.monotonic()
         self._role = role
         self._server_key = server_key
         self._server_public = server_public
@@ -433,6 +450,9 @@ class _FTESocketWrapper(object):
         self._incoming_buffer = b''
         self._pre_handshake_incoming = b''
         self._pre_handshake_outgoing = b''
+        #: Request formats whose covertext this connection's first bytes have
+        #: already failed to unseal; see :meth:`_server_handshake`.
+        self._failed_formats = set()
         self._control = collections.deque()
         self._peer_closed = False
         self._broken = False
@@ -580,12 +600,23 @@ class _FTESocketWrapper(object):
         ``InvalidCovertextError`` from the AE tag, so the scan simply falls
         through to the next candidate.
 
+        This runs again on every chunk that arrives, because a hello can be
+        split across reads -- but a candidate is only ever *tried* once. A
+        covertext starts at the first byte of the connection and has a fixed
+        length, so once enough bytes are in hand to try a candidate, the bytes
+        it would decrypt are settled: they cannot change as more arrive, and a
+        failure cannot turn into a success. Remembering the failures is what
+        stops a peer that dribbles unauthenticated bytes in one at a time from
+        buying a full scan (one AE decrypt per candidate format) per byte.
+
         Returns the bytes left over after the hello. Raises
         :class:`_NeedMoreData` while the hello could still be incomplete and
         :class:`HandshakeFailedException` once it cannot be one.
         """
         buffered = self._pre_handshake_incoming
         for name in _request_scan_order():
+            if name in self._failed_formats:
+                continue
             length = fteproxy.defs.getLength(name)
             if len(buffered) < length:
                 continue
@@ -593,9 +624,11 @@ class _FTESocketWrapper(object):
             try:
                 plaintext = cipher.decrypt(buffered[:length])
             except fte.FTEError:
+                self._failed_formats.add(name)
                 continue
             hello_bytes = fteproxy.record_layer._unseal(plaintext, 0)
             if hello_bytes is None:
+                self._failed_formats.add(name)
                 continue
             return self._accept_hello(name, hello_bytes, buffered[length:])
 
@@ -694,8 +727,23 @@ class _FTESocketWrapper(object):
         reading and discarding, for a random interval, so an active prober
         that guessed the connection string wrong learns only that something
         accepted a TCP connection.
+
+        The interval is measured from when the connection was accepted, not
+        from when the failure was noticed, and covers the whole handshake
+        timeout as well. Otherwise *when* the check failed would leak: a hello
+        that unseals under this server's ``K_cover`` but is refused (replayed,
+        stale epoch, wrong definitions release, unknown format, a reserved
+        flag bit) fails on the first read, while one that does not unseal at
+        all -- the wrong server, or bytes that are not this protocol -- is
+        only known to have failed when the handshake deadline passes. Timing
+        the close from the failure would put those in two disjoint buckets,
+        and one replayed capture would then confirm a bridge for good. Anchored
+        here, every rejection closes at the same distribution of wall-clock
+        times whatever went wrong and whenever it was spotted.
         """
-        self._reject_deadline = time.monotonic() + fteproxy.handshake.reject_delay()
+        timeout = fteproxy.conf.getValue('runtime.fteproxy.handshake.timeout')
+        self._reject_deadline = (self._accepted_at + timeout
+                                 + fteproxy.handshake.reject_delay())
         fteproxy.debug('rejecting handshake without reply: %s' % (reason,))
 
     def _discard_until_deadline(self):
@@ -727,7 +775,9 @@ class _FTESocketWrapper(object):
         A record type this version does not define marks the connection
         broken: only a peer holding the session keys can produce one, so it is
         a version mismatch, and continuing would mean guessing at the meaning
-        of the bytes that follow.
+        of the bytes that follow. So does a peer that queues more control
+        records than :attr:`_MAX_CONTROL_RECORDS`, which is a peer spending
+        this end's memory rather than talking to it.
         """
         if self._broken:
             return
@@ -753,6 +803,23 @@ class _FTESocketWrapper(object):
                 self._peer_closed = True
             elif record_type == fteproxy.record_layer.PADDING:
                 continue
+            elif len(payload) > self._MAX_CONTROL_BYTES:
+                fteproxy.warn('closing connection: a %d-byte control record '
+                              'exceeds the %d-byte limit'
+                              % (len(payload), self._MAX_CONTROL_BYTES))
+                self._broken = True
+                self._control.clear()
+                return
+            elif len(self._control) >= self._MAX_CONTROL_RECORDS:
+                # Dropping the record silently would leave the peer waiting
+                # for an answer that is never coming, so the connection ends
+                # instead: recv() reports EOF and the relay closes it.
+                fteproxy.warn('closing connection: the peer queued more than '
+                              '%d unread control records'
+                              % self._MAX_CONTROL_RECORDS)
+                self._broken = True
+                self._control.clear()
+                return
             else:
                 self._control.append((record_type, payload))
 
@@ -923,6 +990,15 @@ class _FTESocketWrapper(object):
         return self._socket.getsockopt(level, optname, buflen)
 
     def recv(self, bufsize):
+        """Application bytes, or ``b''`` at end of stream.
+
+        On the server role a handshake this end will not accept is answered
+        with silence, so recv() reports the discard interval's end as an
+        ordinary EOF. On the client role there is no prober to mislead and no
+        discard interval: the failure is this end's own, and
+        :class:`HandshakeFailedException` comes out of recv() exactly as it
+        does out of :meth:`handshake`.
+        """
         if self._reject_deadline is not None:
             return self._discard_until_deadline()
         try:
@@ -933,6 +1009,11 @@ class _FTESocketWrapper(object):
                            else 'peer closed without sending anything')
             return b''
         except HandshakeFailedException:
+            if self._reject_deadline is None:
+                # The client role never calls _begin_reject, so there is no
+                # deadline to discard until. Report the failure rather than
+                # tripping over a None.
+                raise
             return self._discard_until_deadline()
 
         while True:

--- a/fteproxy/config.py
+++ b/fteproxy/config.py
@@ -24,6 +24,7 @@ hands out. Resolution order: ``--state-dir``, ``FTEPROXY_STATE_DIR``,
 import base64
 import os
 import stat
+import ipaddress
 import urllib.parse
 
 import fteproxy
@@ -100,7 +101,7 @@ class ConnectionString:
         if not host:
             raise ConfigError('a connection string needs a host')
         if not 0 < port <= 0xFFFF:
-            raise ConfigError('port %r is out of range' % (port,))
+            raise ConfigError('connection string port is out of range')
         if mode is not None and mode not in fteproxy.handshake.MODES:
             raise ConfigError('mode must be one of %s'
                               % ', '.join(fteproxy.handshake.MODES))
@@ -123,7 +124,14 @@ class ConnectionString:
         text = text.strip()
         if not text:
             raise ConfigError('empty connection string')
-        parsed = urllib.parse.urlsplit(text)
+        try:
+            parsed = urllib.parse.urlsplit(text)
+        except ValueError:
+            # urlsplit raises on, for instance, an unbalanced [ in the
+            # authority. That is a malformed connection string like any other,
+            # not a bug, so it gets a usage error rather than a traceback --
+            # and, like every other message here, without the string in it.
+            raise ConfigError('connection string is not a valid URI')
         if parsed.scheme != SCHEME:
             raise ConfigError('connection string must start with %s://'
                               % SCHEME)
@@ -139,8 +147,11 @@ class ConnectionString:
 
         try:
             host, port = split_host_port(authority, default_port=DEFAULT_PORT)
-        except ValueError as e:
-            raise ConfigError(str(e))
+        except ValueError:
+            # split_host_port's own messages quote what they were given,
+            # which is fine for a --listen flag and not for a connection
+            # string: the host and port are part of the secret.
+            raise ConfigError('connection string has an invalid host or port')
         if not host:
             raise ConfigError('a connection string needs a host')
 
@@ -254,7 +265,15 @@ def split_host_port(text, default_port=None, allow_bare_port=False):
         host, _, port = text.partition(':')
         return host, _parse_port(port, text)
     if ':' in text:
-        # Several colons and no brackets: a bare IPv6 literal.
+        # Several colons and no brackets: only a bare IPv6 literal belongs
+        # here (a host name cannot contain a colon), and ::1:8080 is a
+        # complete address, so a port never follows a bare literal.
+        try:
+            ipaddress.IPv6Address(text)
+        except ValueError:
+            raise ValueError('%r is neither host:port nor an IPv6 literal; '
+                             'write an IPv6 literal with a port as [addr]:port'
+                             % text)
         return text, _require_port(default_port, text)
     if allow_bare_port and text.isdigit():
         return '', _parse_port(text, text)
@@ -366,16 +385,49 @@ def ensure_state_dir(path):
 
 
 def _write_private(path, text):
-    """Write ``text`` to ``path`` at mode 0600, creating it exclusively."""
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    descriptor = os.open(path, flags, FILE_MODE)
+    """Write ``text`` to ``path`` at mode 0600, never through a symlink.
+
+    The bytes go to a fresh sibling file, created exclusively (and with
+    ``O_NOFOLLOW`` where the platform has it) so that it is this process's
+    file and no one else's, and that file is then renamed onto ``path``.
+
+    Opening ``path`` itself would follow a symlink another local user had
+    planted in the state directory: the private key would land wherever the
+    link pointed, and the ``chmod`` would be applied to their file rather than
+    to ours. Renaming replaces the link instead of writing through it. It also
+    makes the write atomic, so a reader never sees a half-written key, and it
+    keeps the overwrite that ``fteproxy server`` does on every start.
+    """
+    directory = os.path.dirname(path) or os.curdir
+    flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
+             | getattr(os, 'O_NOFOLLOW', 0))
+    temporary = os.path.join(
+        directory, '.%s.%s.tmp' % (os.path.basename(path),
+                                   os.urandom(8).hex()))
+    descriptor = os.open(temporary, flags, FILE_MODE)
     try:
-        os.chmod(path, FILE_MODE)
-        with os.fdopen(descriptor, 'w') as handle:
-            handle.write(text)
-    except Exception:
+        handle = os.fdopen(descriptor, 'w')
+    except BaseException:
+        # fdopen did not take the descriptor, so it is still ours to close;
+        # past this point the file object owns it and closes it exactly once.
         os.close(descriptor)
+        _remove_quietly(temporary)
         raise
+    try:
+        with handle:
+            handle.write(text)
+        os.replace(temporary, path)
+    except BaseException:
+        _remove_quietly(temporary)
+        raise
+
+
+def _remove_quietly(path):
+    """Delete ``path``, ignoring a file that is already gone."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def server_key_path(directory):

--- a/fteproxy/handshake.py
+++ b/fteproxy/handshake.py
@@ -71,7 +71,7 @@ EPOCH_SECONDS = 3600
 EPOCH_WINDOW = 1
 
 #: A ``c_pub`` is remembered for the whole accepted window. Past this many
-#: entries the oldest hour is forgotten; see :class:`ReplayFilter`.
+#: entries the fullest hour starts forgetting; see :class:`ReplayFilter`.
 REPLAY_MAX_ENTRIES = 1 << 17
 
 _HASH_PREFIX = b'fteproxy/v1'
@@ -424,18 +424,33 @@ class ReplayFilter:
     def _enforce_cap(self):
         """Bound memory under a flood of distinct ``c_pub`` values.
 
-        Dropping the oldest bucket re-opens replay only for hellos that are
-        already at the far edge of the window and about to expire anyway; the
-        alternative, refusing new clients, would hand an attacker a way to
-        deny service to everyone else.
+        The epoch a hello is filed under is chosen by the client, so eviction
+        must not let one bucket push another out: dropping the *oldest* hour
+        would let a flood stamped an hour in the future clear the hour real
+        clients are using, and re-open replay for exactly the hellos the
+        filter exists to refuse. Entries go from whichever bucket holds the
+        most instead, so a flood can only displace itself, and refusing new
+        clients -- which would hand an attacker a way to deny service to
+        everyone else -- never happens.
+
+        Evicting entries rather than whole buckets also bounds the filter when
+        every hello names the same hour, where there is no other bucket to
+        drop.
         """
-        while sum(len(b) for b in self._buckets.values()) > self._max_entries \
-                and len(self._buckets) > 1:
-            del self._buckets[min(self._buckets)]
+        while self._total() > self._max_entries:
+            epoch = max(self._buckets,
+                        key=lambda e: (len(self._buckets[e]), e))
+            bucket = self._buckets[epoch]
+            bucket.pop()
+            if not bucket:
+                del self._buckets[epoch]
+
+    def _total(self):
+        return sum(len(bucket) for bucket in self._buckets.values())
 
     def __len__(self):
         with self._lock:
-            return sum(len(b) for b in self._buckets.values())
+            return self._total()
 
 
 # --------------------------------------------------------------------------- #

--- a/fteproxy/tests/test_cli.py
+++ b/fteproxy/tests/test_cli.py
@@ -104,10 +104,23 @@ class TestConnectionString:
         'fte://%s@host:8080?mode=nonsense' % SERVER_ID,
         'fte://%s@host:8080?defs=lastweek' % SERVER_ID,
         'fte://%s@:8080' % SERVER_ID,
+        # urlsplit itself raises on these, rather than returning a bad parse.
+        'fte://[bad',
+        'fte://%s@[::1:8080' % SERVER_ID,
     ])
     def test_bad_strings_are_refused(self, text):
         with pytest.raises(fteproxy.config.ConfigError):
             fteproxy.config.ConnectionString.parse(text)
+
+    def test_an_unsplittable_uri_is_a_config_error(self):
+        """An unbalanced bracket makes urlsplit raise ValueError. That is a
+        malformed connection string, so it has to reach the user as a usage
+        error and not as a traceback -- and still without the string in it."""
+        with pytest.raises(fteproxy.config.ConfigError) as excinfo:
+            fteproxy.config.ConnectionString.parse(
+                'fte://%s@[2001:db8::1:8080' % SERVER_ID)
+        assert SERVER_ID not in str(excinfo.value)
+        assert '2001:db8' not in str(excinfo.value)
 
     def test_errors_never_quote_the_string(self):
         """An unparseable connection string is still a secret."""
@@ -237,6 +250,46 @@ class TestStateDirectory:
             handle.write(contents)
         with pytest.raises(fteproxy.config.ConfigError):
             fteproxy.config.load_server_key(directory)
+
+    @pytest.mark.parametrize('filename', [fteproxy.config.SERVER_KEY_FILE,
+                                          fteproxy.config.CONNECTION_FILE])
+    def test_a_symlink_at_the_target_is_not_followed(self, tmp_path, filename):
+        """Opening the path itself would write the private key wherever a
+        symlink planted in the state directory pointed, and apply the 0600 to
+        that file rather than to ours."""
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        outside = tmp_path / 'outside.txt'
+        outside.write_text('not the key\n')
+        planted = tmp_path / 'state' / filename
+        planted.symlink_to(outside)
+
+        private, public = fteproxy.generate_server_key()
+        fteproxy.config.save_server_key(directory, private)
+        fteproxy.config.write_connection_string(
+            directory, fteproxy.config.ConnectionString(public, 'host', 8080))
+
+        assert outside.read_text() == 'not the key\n'
+        assert not planted.is_symlink()
+        assert stat.S_IMODE(os.stat(str(planted)).st_mode) == 0o600
+        assert fteproxy.config.load_server_key(directory) == private
+        # And nothing was left lying around beside them.
+        assert sorted(entry.name for entry in (tmp_path / 'state').iterdir()) \
+            == sorted([fteproxy.config.SERVER_KEY_FILE,
+                       fteproxy.config.CONNECTION_FILE])
+
+    def test_a_failed_write_leaves_nothing_behind(self, tmp_path):
+        """The error the caller sees is the one that happened.
+
+        A lone surrogate cannot be encoded, so the write fails on the way out.
+        The descriptor has to be closed exactly once on that path: closing it
+        twice raised EBADF from the handler and buried the real error -- or,
+        worse, closed whatever file had since been given the number.
+        """
+        directory = fteproxy.config.ensure_state_dir(str(tmp_path / 'state'))
+        path = fteproxy.config.server_key_path(directory)
+        with pytest.raises(UnicodeEncodeError):
+            fteproxy.config._write_private(path, 'key\ud800\n')
+        assert list((tmp_path / 'state').iterdir()) == []
 
 
 class TestResolveClientUri:
@@ -761,3 +814,38 @@ class TestModeFollowsTheFormat:
         assert fteproxy.cli.mode_hint_for('ftp') == 'format'
         assert fteproxy.cli.mode_hint_for('http') == 'hybrid'
         assert fteproxy.cli.mode_hint_for('no-such-format') is None
+
+
+class TestParseNeverEchoesTheAuthority:
+    """Every part of a malformed connection string is secret, host and port
+    included, so no ConfigError may quote any of it -- not via urlsplit, not
+    via split_host_port, not via the port-range check."""
+
+    @pytest.mark.parametrize('authority,pieces', [
+        ('example-host.test:notaport', ('example-host.test', 'notaport')),
+        ('example-host.test:99999', ('example-host.test', '99999')),
+        ('[::1', ('::1',)),
+        ('example-host.test:1:2', ('example-host.test', '1:2')),
+    ])
+    def test_bad_authority_is_redacted(self, authority, pieces):
+        with pytest.raises(fteproxy.config.ConfigError) as info:
+            fteproxy.config.ConnectionString.parse(
+                'fte://%s@%s' % (SERVER_ID, authority))
+        message = str(info.value)
+        for piece in pieces:
+            assert piece not in message
+
+
+class TestBareMultiColonHostsMustBeIPv6:
+    """An unbracketed host with several colons is accepted only if it really
+    is an IPv6 literal; a host name cannot contain a colon, so anything else
+    is malformed rather than a strange name with the default port."""
+
+    @pytest.mark.parametrize('text', ['2001:db8::1', '::1', 'fe80::1'])
+    def test_a_bare_ipv6_literal_still_works(self, text):
+        assert fteproxy.config.split_host_port(text, default_port=8080) == (text, 8080)
+
+    @pytest.mark.parametrize('text', ['example-host.test:1:2', 'a:b:c', 'host:1:2:3'])
+    def test_colon_bearing_garbage_is_rejected(self, text):
+        with pytest.raises(ValueError):
+            fteproxy.config.split_host_port(text, default_port=8080)

--- a/fteproxy/tests/test_handshake.py
+++ b/fteproxy/tests/test_handshake.py
@@ -411,6 +411,35 @@ class TestReplayFilter:
                                now)
         assert len(replay) <= 64 + 64
 
+    def test_the_filter_is_bounded_within_one_epoch(self):
+        """The single-bucket path: with one hour in play there is no other
+        bucket to drop, so entries have to go instead."""
+        replay = hs.ReplayFilter(max_entries=64)
+        now = 100
+        for i in range(500):
+            assert replay.observe(i.to_bytes(32, 'big'), now, now)
+        assert len(replay) <= 64
+
+    def test_a_flood_at_a_future_epoch_cannot_evict_the_current_hour(self):
+        """The epoch a hello is filed under is chosen by the client.
+
+        Evicting the *oldest* bucket let a flood stamped an hour ahead clear
+        the hour real clients are using, and re-open replay for exactly the
+        hellos already captured -- for a whole hour, from anywhere, with no
+        key. Eviction has to come out of the bucket doing the flooding.
+        """
+        replay = hs.ReplayFilter(max_entries=64)
+        now = 100
+        legitimate = b'\x09' * 32
+        assert replay.observe(legitimate, now, now)
+
+        for i in range(64 + 16):
+            replay.observe(i.to_bytes(32, 'big'), now + 1, now)
+
+        assert not replay.observe(legitimate, now, now), \
+            'the flood evicted a hello the filter had already seen'
+        assert len(replay) <= 64
+
     def test_a_rejected_hello_does_not_enter_the_filter(self):
         """observe() runs last, so a hello refused for its epoch or format
         cannot be used to fill the filter and lock out a real client."""

--- a/fteproxy/tests/test_socket_wrapper.py
+++ b/fteproxy/tests/test_socket_wrapper.py
@@ -7,9 +7,17 @@ connection while undecodable bytes remain buffered (the peer was cut off
 part-way through a covertext), and what the server does with a first record it
 cannot validate. Both are places where returning "not ready yet" instead of
 EOF used to leave a relay worker polling a dead socket forever.
+
+The reject-path cases go further than "no reply": they pin *when* the
+connection closes, because a rejection that is timed from the moment a check
+failed tells a prober which check that was.
 """
 
+import collections
+import itertools
+import os
 import socket
+import threading
 import time
 
 import pytest
@@ -70,6 +78,40 @@ def _completed(sock, keys, is_client, mode=MODE):
     return wrapper
 
 
+def _client_driver(**overrides):
+    """A :class:`ClientHandshake` aimed at this module's server key."""
+    settings = dict(server_public=SERVER_PUBLIC, format=FORMAT, mode=MODE,
+                    defs=int(SHAPE_CATALOG))
+    settings.update(overrides)
+    return fteproxy.handshake.ClientHandshake(**settings)
+
+
+def _seal_hello(hello_bytes, cover_key=None, covertext_format=FORMAT):
+    """One client hello sealed as it goes on the wire."""
+    if cover_key is None:
+        cover_key = fteproxy.handshake.cover_key(SERVER_PUBLIC)
+    cipher = fteproxy._cipher_for(covertext_format + '-request', cover_key,
+                                  cover=True)
+    return fteproxy.record_layer._seal(cipher, hello_bytes, 0)
+
+
+def _sealed_hello(**overrides):
+    """A fresh, valid, sealed client hello for this module's server."""
+    return _seal_hello(_client_driver(**overrides).hello_bytes)
+
+
+def _short_handshake_timeout(monkeypatch, seconds):
+    """Shorten the handshake timeout, restored when the test ends.
+
+    Worth doing in any test that waits for a rejection: the reject deadline is
+    anchored to the accept and spans the whole handshake timeout, so the
+    default five seconds is five seconds of test.
+    """
+    monkeypatch.setitem(fteproxy.conf.conf,
+                        'runtime.fteproxy.handshake.timeout', seconds)
+    return seconds
+
+
 class FakeSocket:
     """A minimal socket stand-in.
 
@@ -86,6 +128,7 @@ class FakeSocket:
         self.eof_reads = 0
         self.sent = b''
         self.timeout = None
+        self.closed = False
 
     def recv(self, _bufsize):
         if self._chunks:
@@ -110,6 +153,9 @@ class FakeSocket:
     def settimeout(self, value):
         self.timeout = value
 
+    def close(self):
+        self.closed = True
+
 
 class SilentSocket(FakeSocket):
     """A peer that stays connected but says nothing more.
@@ -129,6 +175,56 @@ class SilentSocket(FakeSocket):
             return self._chunks.pop(0)
         time.sleep(self.timeout if self.timeout else 0.01)
         raise socket.timeout()
+
+
+class Clock:
+    """A monotonic clock a test drives by hand."""
+
+    START = 1000.0
+
+    def __init__(self):
+        self.now = self.START
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class TimeSkippingSocket(FakeSocket):
+    """A silent peer on a hand-driven clock.
+
+    Like :class:`SilentSocket`, but each read that would block moves the clock
+    forward by its timeout instead of sleeping, so a test can walk past the
+    handshake deadline and the discard deadline after it in no time at all.
+    """
+
+    def __init__(self, clock, chunks=()):
+        super().__init__(chunks)
+        self._clock = clock
+
+    def recv(self, _bufsize):
+        if self._chunks:
+            return self._chunks.pop(0)
+        self._clock.advance(self.timeout if self.timeout else 0.1)
+        raise socket.timeout()
+
+
+class CountingCipher:
+    """A cipher that records every ``decrypt`` call against its format name."""
+
+    def __init__(self, inner, name, counts):
+        self._inner = inner
+        self._name = name
+        self._counts = counts
+
+    def __getattr__(self, attribute):
+        return getattr(self._inner, attribute)
+
+    def decrypt(self, data):
+        self._counts[self._name] += 1
+        return self._inner.decrypt(data)
 
 
 class TestServerHandshakeEOF:
@@ -159,15 +255,10 @@ class TestServerRejectPath:
     """A hello that decodes but does not validate is answered with silence."""
 
     def _hello_for(self, **overrides):
-        settings = dict(server_public=SERVER_PUBLIC, format=FORMAT,
-                        mode=MODE, defs=int(SHAPE_CATALOG))
-        settings.update(overrides)
-        return fteproxy.handshake.ClientHandshake(**settings)
+        return _client_driver(**overrides)
 
     def _seal(self, hello_bytes, cover_key):
-        cipher = fteproxy._cipher_for(FORMAT + '-request', cover_key,
-                                      cover=True)
-        return fteproxy.record_layer._seal(cipher, hello_bytes, 0)
+        return _seal_hello(hello_bytes, cover_key)
 
     def test_stale_epoch_gets_no_reply(self, monkeypatch):
         monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.05)
@@ -204,6 +295,9 @@ class TestServerRejectPath:
         discarding, so a prober that stays connected cannot time the failure
         or tell it from a service with nothing to say."""
         monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 0.25)
+        # The wait spans the handshake timeout as well, so shorten that too
+        # rather than spending the default five seconds here.
+        _short_handshake_timeout(monkeypatch, 0.1)
         driver = self._hello_for(epoch=0)
         sealed = self._seal(driver.hello_bytes,
                             fteproxy.handshake.cover_key(SERVER_PUBLIC))
@@ -422,3 +516,339 @@ class TestFormatAgreement:
         server.handshake()
         assert server.negotiated_format == 'twin'
         assert fake.sent, 'the server answered'
+
+
+class TestRejectDeadlineIsAnchoredToTheAccept:
+    """When a rejection closes must not say which check failed.
+
+    A hello that unseals under this server's cover key but is refused -- a
+    replay, a stale epoch, the wrong definitions release -- is known to be bad
+    on the first read. A hello that does not unseal at all, or bytes that are
+    not this protocol, are only known to be bad when the handshake timeout
+    runs out. Timing the discard interval from the *detection* put those in
+    two disjoint buckets, so one captured hello, replayed, identified the
+    server for good: a stale hello is refused for ever, so the signal never
+    stops repeating. Both must be timed from the accept instead.
+    """
+
+    def test_the_deadline_does_not_move_with_the_detection(self, monkeypatch):
+        """Detected at t=0 and detected at t=timeout give the same deadline."""
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 2.0)
+        timeout = _short_handshake_timeout(monkeypatch, 5)
+        clock = Clock()
+        monkeypatch.setattr(time, 'monotonic', clock)
+
+        # Detected at once: this unseals here, but names a stale epoch.
+        immediate = FakeSocket([_sealed_hello(epoch=0)])
+        early = fteproxy.wrap_socket(immediate, server_key=SERVER_PRIVATE)
+        assert early.recv(65536) == b''
+        assert immediate.sent == b''
+
+        # Detected only at the deadline: bytes that never unseal, from a peer
+        # that stays connected rather than hanging up.
+        clock.now = Clock.START
+        silent = TimeSkippingSocket(clock, [b'not a client hello'])
+        late = fteproxy.wrap_socket(silent, server_key=SERVER_PRIVATE)
+        assert late.recv(65536) == b''
+        assert silent.sent == b''
+
+        assert late._reject_deadline == early._reject_deadline
+        assert early._reject_deadline == Clock.START + timeout + 2.0
+
+    def test_the_pre_handshake_cap_uses_the_same_anchor(self, monkeypatch):
+        """The other way a rejection is decided early: too many bytes with no
+        hello in them."""
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay', lambda: 2.0)
+        timeout = _short_handshake_timeout(monkeypatch, 5)
+        clock = Clock()
+        monkeypatch.setattr(time, 'monotonic', clock)
+
+        cap = fteproxy._FTESocketWrapper._MAX_PRE_HANDSHAKE_BYTES
+        fake = FakeSocket([b'\x00' * (cap + 1)])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b''
+        assert server._reject_deadline == Clock.START + timeout + 2.0
+
+    def test_a_completed_handshake_sets_no_deadline(self, monkeypatch):
+        clock = Clock()
+        monkeypatch.setattr(time, 'monotonic', clock)
+        fake = FakeSocket([_sealed_hello()])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        server.handshake()
+        assert server.handshake_complete
+        assert server._reject_deadline is None
+
+
+def _warm_the_scan():
+    """Build every cover cipher the server's first-record scan may use.
+
+    The first use of a format compiles its DFA; a timing test must measure the
+    reject deadline, not that.
+    """
+    cover = fteproxy.handshake.cover_key(SERVER_PUBLIC)
+    for name in fteproxy.defs.load_definitions():
+        fteproxy._cipher_for(name, cover, cover=True)
+
+
+class _LoopbackServer:
+    """One fteproxy server on 127.0.0.1, serving connections one at a time.
+
+    It answers a handshake it will not accept exactly as ``fteproxy.relay``
+    does: ``reject_and_close()``, which reads and discards until the deadline
+    and only then closes.
+    """
+
+    def __init__(self):
+        self._listener = socket.socket()
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind(('127.0.0.1', 0))
+        self._listener.listen(8)
+        self.address = self._listener.getsockname()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while True:
+            try:
+                conn, _addr = self._listener.accept()
+            except OSError:
+                return
+            tunnel = fteproxy.wrap_socket(conn, server_key=SERVER_PRIVATE)
+            try:
+                tunnel.handshake()
+            except fteproxy.HandshakeFailedException:
+                tunnel.reject_and_close()
+                continue
+            except (fteproxy._PeerClosed, OSError):
+                conn.close()
+                continue
+            tunnel.close()
+
+    def close(self):
+        self._listener.close()
+        self._thread.join(timeout=5)
+
+
+def _seconds_until_close(address, payload):
+    """Send ``payload`` and time how long the server holds the connection."""
+    sock = socket.create_connection(address, timeout=30)
+    try:
+        started = time.monotonic()
+        sock.sendall(payload)
+        while sock.recv(65536):
+            pass
+        return time.monotonic() - started
+    finally:
+        sock.close()
+
+
+class TestRejectTimingOverLoopback:
+    """The same property as above, measured on a real socket end to end."""
+
+    def test_a_replay_and_garbage_close_in_the_same_window(self, monkeypatch):
+        timeout = _short_handshake_timeout(monkeypatch, 0.2)
+        # A real delay is random; two values, dealt out in the same order to
+        # both cases, keep the assertion deterministic while still moving.
+        delays = itertools.cycle([0.10, 0.20])
+        monkeypatch.setattr(fteproxy.handshake, 'reject_delay',
+                            lambda: next(delays))
+        _warm_the_scan()
+
+        sealed = _sealed_hello()
+        server = _LoopbackServer()
+        try:
+            # Accepted, so the same bytes are a replay from here on.
+            _seconds_until_close(server.address, sealed)
+            replayed = [_seconds_until_close(server.address, sealed)
+                        for _ in range(2)]
+            garbage = [_seconds_until_close(server.address, os.urandom(512))
+                       for _ in range(2)]
+        finally:
+            server.close()
+
+        for elapsed in replayed + garbage:
+            assert timeout + 0.10 - 0.05 <= elapsed <= timeout + 0.20 + 0.9, (
+                'closed %.3fs in, outside the window every rejection shares'
+                % elapsed)
+        # Overlapping ranges, which is the point: before the fix a replay
+        # closed at about the delay and garbage at the timeout plus the delay,
+        # with nothing in between.
+        assert max(replayed) >= min(garbage)
+        assert max(garbage) >= min(replayed)
+
+
+class TestFirstRecordScanIsBounded:
+    """A candidate format is tried once per connection, not once per read.
+
+    The scan re-runs whenever more bytes arrive, because a hello can be split
+    across reads. It used to re-decrypt every candidate that already fitted,
+    so a peer dribbling unauthenticated bytes one at a time bought a full scan
+    per byte -- server CPU for nothing, before anything had been authenticated.
+    """
+
+    def _request_names(self):
+        return [name for name in fteproxy.defs.load_definitions()
+                if name.endswith('-request')]
+
+    def _count_decrypts(self, monkeypatch):
+        counts = collections.Counter()
+        real = fteproxy._cipher_for
+
+        def counting(format_name, key, cover=False):
+            return CountingCipher(real(format_name, key, cover=cover),
+                                  format_name, counts)
+
+        monkeypatch.setattr(fteproxy, '_cipher_for', counting)
+        return counts
+
+    def test_each_candidate_is_decrypted_at_most_once(self, monkeypatch):
+        names = self._request_names()
+        longest = max(fteproxy.defs.getLength(name) for name in names)
+        counts = self._count_decrypts(monkeypatch)
+
+        garbage = os.urandom(longest + 8)
+        fake = FakeSocket([garbage[i:i + 1] for i in range(len(garbage))])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        assert server.recv(65536) == b''
+        assert fake.sent == b''
+
+        assert counts, 'the scan ran at all'
+        assert max(counts.values()) == 1, dict(counts)
+        # Every candidate the bytes were long enough for was still tried.
+        assert set(counts) == set(names)
+
+    def test_a_fragmented_hello_still_handshakes(self):
+        """Remembering a failure must not cost a client whose hello arrives in
+        pieces, which is what a small MTU or a slow link gives."""
+        sealed = _sealed_hello()
+        fake = FakeSocket([sealed[i:i + 1] for i in range(len(sealed))])
+        server = fteproxy.wrap_socket(fake, server_key=SERVER_PRIVATE)
+        server.handshake()
+        assert server.negotiated_format == FORMAT
+        assert server.negotiated_mode == MODE
+        assert fake.sent, 'the server answered'
+
+
+class TestControlQueueIsBounded:
+    """An authorised peer cannot spend this end's memory on control records.
+
+    Only the holder of the session keys can produce one, so this is not a
+    prober -- but a peer that keeps sending OPENs nobody reads is filling a
+    queue that had no limit at all.
+    """
+
+    def _peer(self):
+        keys = _session_keys()
+        return keys, _completed(FakeSocket(), keys, is_client=False)
+
+    def test_a_flood_breaks_the_connection(self, caplog):
+        import logging
+
+        keys, peer = self._peer()
+        cap = fteproxy._FTESocketWrapper._MAX_CONTROL_RECORDS
+        wire = b''.join(
+            peer._encoder.encode(fteproxy.record_layer.OPEN, b'dest')
+            for _ in range(cap + 1))
+        fake = FakeSocket([wire], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        with caplog.at_level(logging.WARNING, logger='fteproxy'):
+            assert wrapper.recv(65536) == b''
+        assert wrapper._broken
+        assert len(wrapper._control) <= cap
+        assert wrapper.pending_eof()
+        assert any('control records' in record.message
+                   for record in caplog.records), 'the drop was not silent'
+
+    def test_an_ordinary_exchange_is_unaffected(self):
+        keys, peer = self._peer()
+        wire = (peer._encoder.encode(fteproxy.record_layer.OPEN, b'dest')
+                + peer._encoder.encode(fteproxy.record_layer.OPEN_RESULT,
+                                       b'\x00'))
+        fake = FakeSocket([wire], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b''
+        assert not wrapper._broken
+        assert wrapper.next_control_record() == (
+            fteproxy.record_layer.OPEN, b'dest')
+        assert wrapper.next_control_record() == (
+            fteproxy.record_layer.OPEN_RESULT, b'\x00')
+
+
+class TestClientHandshakeFailure:
+    """A client whose handshake fails says so.
+
+    The discard interval is the server's answer to a prober; the client role
+    never sets one, so its failure path must not try to wait one out.
+    """
+
+    def test_recv_reports_the_failure(self, monkeypatch):
+        _short_handshake_timeout(monkeypatch, 0.1)
+        fake = SilentSocket()
+        client = fteproxy.wrap_socket(fake, server_id=SERVER_PUBLIC,
+                                      format=FORMAT, mode=MODE)
+        with pytest.raises(fteproxy.HandshakeFailedException):
+            client.recv(65536)
+        assert client._reject_deadline is None
+
+    def test_handshake_reports_the_same_failure(self, monkeypatch):
+        _short_handshake_timeout(monkeypatch, 0.1)
+        client = fteproxy.wrap_socket(SilentSocket(), server_id=SERVER_PUBLIC,
+                                      format=FORMAT, mode=MODE)
+        with pytest.raises(fteproxy.HandshakeTimeoutException):
+            client.handshake()
+
+    def test_reject_and_close_is_safe_on_a_client(self, monkeypatch):
+        _short_handshake_timeout(monkeypatch, 0.1)
+        client = fteproxy.wrap_socket(SilentSocket(), server_id=SERVER_PUBLIC,
+                                      format=FORMAT, mode=MODE)
+        with pytest.raises(fteproxy.HandshakeFailedException):
+            client.handshake()
+        fake = client._socket
+        client.reject_and_close()
+        assert fake.closed, 'the socket was closed, not waited on'
+
+
+class TestControlRecordSizeIsBounded:
+    """The control-queue cap bounds records; this bounds their bytes.
+
+    In hybrid mode a record can carry a mebibyte, so a count cap alone would
+    still let an authorised peer park 16 MiB per connection. No real control
+    record is anywhere near the limit: an OPEN naming a 255-byte host is 259
+    bytes and an OPEN_RESULT is one.
+    """
+
+    def _peer(self):
+        keys = _session_keys()
+        return keys, _completed(FakeSocket(), keys, is_client=False)
+
+    def test_an_oversize_control_record_breaks_the_connection(self, caplog):
+        import logging
+
+        keys, peer = self._peer()
+        limit = fteproxy._FTESocketWrapper._MAX_CONTROL_BYTES
+        wire = peer._encoder.encode(fteproxy.record_layer.OPEN,
+                                    b'x' * (limit + 1))
+        fake = FakeSocket([wire], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        with caplog.at_level(logging.WARNING, logger='fteproxy'):
+            assert wrapper.recv(65536) == b''
+        assert wrapper._broken
+        assert not wrapper._control
+        assert wrapper.pending_eof()
+        assert any('control record' in record.message
+                   for record in caplog.records), 'the drop was not silent'
+
+    def test_the_largest_legitimate_open_is_accepted(self):
+        import fteproxy.stream
+
+        keys, peer = self._peer()
+        payload = fteproxy.stream.encode_open('a' * 255, 443)
+        assert len(payload) <= fteproxy._FTESocketWrapper._MAX_CONTROL_BYTES
+        wire = peer._encoder.encode(fteproxy.record_layer.OPEN, payload)
+        fake = FakeSocket([wire], spin_cap=10)
+        wrapper = _completed(fake, keys, is_client=True)
+        assert wrapper.recv(65536) == b''
+        assert not wrapper._broken
+        assert wrapper.next_control_record() == (
+            fteproxy.record_layer.OPEN, payload)


### PR DESCRIPTION
Closes the five findings an adversarial multi-lens review confirmed against
the 1.0 handshake, plus four advisory items, each with a test that fails on
the previous code. Every fix was re-verified by two independent checkers
re-running the original attack against the fixed code.

F1 (high) Reject-path timing oracle. The discard clock started when a
failure was DETECTED: a hello that unseals under this server's cover key but
is refused (replayed, stale epoch, wrong defs, unknown format) was detected
on the first recv and closed in 1-5 s, while one that does not unseal was
only detected at the 5 s handshake timeout and closed in 6-10 s. Disjoint
windows, so one archived packet confirmed a bridge with certainty, forever,
since the cover key never rotates. Every rejection is now anchored to the
connection's start: accepted_at + handshake timeout + the random delay, so
all rejection classes close in one overlapping window with no reply.

F2 (high) The first-record scan re-ran every candidate format on every
received chunk, turning unauthenticated bytes into unbounded server CPU (a
1328-byte garbage prefix delivered a byte at a time cost up to 1105
decrypts per format). A candidate is now tried once per connection, since
the covertext starts at byte 0 at a fixed length and a failed decrypt can
never become a success.

F3 (low) The replay filter evicted the bucket with the smallest epoch, and
epoch is client-chosen, so a flood stamped one hour ahead evicted the
current hour and re-enabled replay. It now evicts single entries from the
largest bucket, so a flood can only displace itself, and the bound holds on
the single-bucket path too (which previously never evicted). A same-hour
flood can still push real entries out; mounting it needs the connection
string, so it grants nothing a fresh handshake does not, and SECURITY.md
now says so.

F4 (medium) The control-record queue was unbounded, so an authorised peer
could exhaust memory. Capped at 16 records AND 512 bytes per record (an
OPEN naming a 255-byte host is 259 bytes, an OPEN_RESULT one; in hybrid
mode a record can carry a mebibyte, so the count cap alone still allowed
16 MiB). Overflow marks the connection broken rather than dropping silently.

F5 (low) ConnectionString.parse let urlsplit's ValueError escape as a
traceback and, through split_host_port and the port-range check, echoed the
host and port of a malformed string. All three paths now raise ConfigError
without quoting any part of the input. Along the way: split_host_port
accepted any unbracketed multi-colon text as a "bare IPv6 literal" without
checking, so example-host.test:1:2 passed as a host name with the default
port; it now requires a real IPv6 address there.

Advisory: _write_private creates a randomly named sibling with
O_CREAT|O_EXCL|O_NOFOLLOW and os.replace()s it into place (no symlink
following, atomic overwrite), and closes its descriptor exactly once; the
client-role wrapper raises HandshakeFailedException on a failed handshake
instead of a TypeError; SECURITY.md's replay window is stated as up to
three hours, not two, and its failed-handshake bullet describes the
accept-anchored close.

Operator-visible consequence: a rejected connection is now held for the
handshake timeout plus 1-5 s (6-10 s by default) rather than 1-5 s; the
setup thread per connection means the accept loop is unaffected.

Suite green at 764 (was 734).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
