### PR TITLE
Hybrid headers seal at the shortest capable length

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,112 +1,208 @@
 # fteproxy performance analysis
 
-Companion to [`benchmark.py`](benchmark.py). The numbers below were produced by
-that script on loopback (Apple M3 Pro, macOS, Python 3.14.7) on 2026-09-02 for
-**fteproxy 1.0.0 with `fte` 0.4.0** (the tree of the 1.0 release stack), with
-**fteproxy 0.3.1 + `fte` 0.3.0** measured the same day on the same machine for
-comparison, and a **plain-TCP relay of identical two-hop topology** so the cost
-of Format-Transforming Encryption is isolated from the network. Everything here
-was measured unless marked *estimated*.
+Companion to [`benchmark.py`](benchmark.py). Everything below was measured
+unless marked *estimated*.
+
+**What was measured**
+
+| | |
+|---|---|
+| commit | `7093571` (fteproxy 1.0.0) |
+| definitions | release `20260903` — `http`, `ftp`, `smtp`, `sip`, `dns` |
+| default configuration | format `http`, mode `hybrid` (both directions variable length, 200–700 B) |
+| machine | Apple M3 Pro, 12 cores, 36 GB, macOS 26.6.2 (arm64) |
+| interpreter | CPython 3.12.14, `fte` 0.4.0, `cryptography` OpenSSL backend |
+| date | 2026-09-03, loopback only |
 
 Reproduce:
 
 ```bash
-pip install -e .                       # needs fte>=0.4.0,<0.5.0
-python3 benchmark.py --baseline        # default 6 scenarios
-python3 benchmark.py --scenarios lan --sizes 64K 1M 8M --repeat 2 --baseline
-python3 benchmark.py --scenarios lan --sizes 8M --direction upload --no-latency --no-setup
-python3 benchmark.py --scenarios lan --sizes 64K 1M --mode format
+uv run python benchmark.py --scenarios lan --sizes 64K 1M 8M --repeat 3 --baseline
+uv run python benchmark.py --scenarios lan --sizes 64K 1M --repeat 3 --format smtp --mode format
+uv run python benchmark.py --scenarios lan --sizes 64K 1M --repeat 3 --format dns  --mode format
+uv run python benchmark.py --baseline          # the six shaped scenarios
 ```
+
+Latency and setup are `benchmark.py`'s own p50 over 50 and 20 samples; a
+throughput cell is the best of `--repeat 3` transfers, and the p50/range below
+is across three whole runs of the command. The record-layer figures come from a
+standalone script (not in the repo) that drives `fteproxy._session_channel`
+with random session keys and no sockets, reporting the median of 20–60
+encode+decode round trips.
 
 ---
 
 ## TL;DR
 
-1. **On any real-world link (≤ ~25 Mbit) fteproxy is as fast as raw TCP.** That was
-   true on 0.3 and is unchanged: the network is the bottleneck and FTE is invisible.
-   Everything below is about LAN/datacenter-speed links and interactive latency.
-2. **The 0.4 record layer is 5–7x faster than 0.3.1 in bulk on LAN** (8 MB echo
-   0.7 → 4.6 Gbit/s, ~75% of plain TCP) and **3x lower in interactive overhead**
-   (64 B RTT 1.5 → 0.5 ms). The per-record fixed cost fell from ~0.9 ms to ~0.17 ms
-   (round trip), and the body is OpenSSL AES-CTR+HMAC instead of a big-integer frame.
-3. **The ceiling is now the relay loop and the GIL, not FTE.** The record layer alone
-   runs 650–950 MB/s (5–7.5 Gbit/s) per direction; the two-thread-per-connection
-   relay gets ~4.6 Gbit/s echo out of it.
-4. **`format` mode (every byte in the target format) is interactive-only:** same RTT
-   class as `hybrid` (0.7 vs 0.5 ms) but 4–7 Mbit/s bulk, because the DFA runs on
-   every ~140 bytes instead of once per record. Its cost is inherent to the mode.
-   Since the variable-length formats landed, the payload per DFA run is whatever
-   the chosen covertext length holds rather than one number — for `http-request`,
-   50 bytes at length 200 and 435 at length 700 — but the rate barely moves,
-   because a longer covertext costs proportionally more to rank. Measured
-   encode-side across that format's whole range: **0.65 MB/s at the shortest
-   length, 0.91 at the middle, 0.71 at the longest** (0.08 to 0.62 ms per
-   record). So variable length costs `format` mode nothing worth quoting, and
-   the mode's cost is still inherent to the mode.
-5. **libfte 0.4 caches nothing.** 0.3 cached its DFA tables globally, so building an
-   encoder was free; 0.4 compiles a DFA per `RegexFormat` (0.5–1.5 ms). fteproxy
-   therefore caches ciphers itself (`_make_cipher`, one per pattern/length/key),
-   which brings connection setup to ~1 ms. Without the cache it was 8–12 ms, and a
-   connection closed before negotiating pinned the server at 64–100% CPU. A
-   variable-length format needs one DFA per length it can emit, which is why the
-   set of lengths is small (eight) and fixed: the whole shipped catalog is 80
-   DFAs (10 variable entries × 8 lengths each), compiled once per process and
-   shared by every connection.
-6. **Four of the five shipped formats run in `format` mode by design, so point 4
-   is their normal operating point.** Since the `20260903` definitions release the
-   default catalog is five cleartext protocols: `http` is `mode_hint: hybrid` (an
-   HTTP message with a raw body is what HTTP looks like), while the line protocols
-   `ftp`, `smtp`, `sip` and the binary `dns` format are `mode_hint: format`,
-   because a line protocol has no place to put a high-entropy tail. Expect about
-   1 MB/s and interactive-class latency on those four — fine for a shell, a chat,
-   or SOCKS-proxied browsing of text, and not a bulk-transfer channel. Pick `http`
-   (or pass `--mode hybrid`, accepting the tail) when throughput is what matters.
-   The measurements below predate the release and were taken on
-   `manual-http-request`/`-response` from the shape catalog; the `hybrid` column
-   is representative of `http`, and the `format` column of the other four.
-7. **The relay's `select`+throttle poll loop is unchanged** and still carries the
-   caveats from 0.3: do not delete the throttle, and a dropped link can still wedge
-   an application connection (see *Resilience*).
+1. **On any real-world link (≤ ~25 Mbit) fteproxy is as fast as raw TCP.** That
+   has been true since 0.3 and is unchanged: the network is the bottleneck and
+   FTE is invisible. Everything below is about LAN/datacenter-speed links and
+   interactive latency.
+2. **On the shipped default the per-record cost is one 700-byte covertext:
+   1.24 ms in the record layer, and that one number sets everything else.**
+   A 64 B round trip costs 2.5 ms (two such records); bulk runs at 166 MB/s
+   through the record layer at the relay's 256 KiB record size, and the relay
+   gets ~1.1 Gbit/s of 8 MB echo out of it against ~5.9 Gbit/s for plain TCP.
+3. **That cost is a property of the format's length, not of the mode.** An FTE
+   covertext gets more expensive faster than linearly in its length: the same
+   code ranks a 200-byte `http-request` in 0.165 ms and a 700-byte one in
+   1.24 ms. `http` is variable length 200–700 and every `hybrid` header is
+   sealed at its **max**, so the default pays the top of that curve on every
+   record. Picking a format with a shorter maximum is the single biggest
+   throughput lever available today without a code change: the same 1 MiB
+   record costs 2.31 ms with an `http` header and 1.22 ms with an `smtp` one.
+4. **`format` mode (every byte in the target format) is interactive-only:**
+   *better* RTT than the default (0.42 ms on `smtp`, 0.61 ms on `dns`, against
+   2.5 ms on `http`/hybrid, because those formats' covertexts are short) and
+   2.5–4 Mbit/s of bulk. Its bulk cost is inherent to the mode: the DFA runs on
+   every covertext, which carries 7–168 bytes on `smtp` and 9–141 on `dns`.
+5. **Four of the five shipped formats run in `format` mode by design, so point 4
+   is their normal operating point.** `http` is `mode_hint: hybrid` (an HTTP
+   message with a raw body is what HTTP looks like); the line protocols `ftp`,
+   `smtp`, `sip` and the binary `dns` are `mode_hint: format`, because a line
+   protocol has no place to put a high-entropy tail. Expect **0.3–0.5 MB/s**
+   and sub-millisecond added latency on those four — fine for a shell, a chat,
+   or SOCKS-proxied browsing of text, and not a bulk-transfer channel.
+6. **A DFA is compiled per (pattern, length) and then cached for the life of
+   the process.** One compile costs 2.4–10.8 ms for `http` and 2.8–5.4 ms for
+   `dns`, growing with the length; a variable-length format needs one per
+   length it may emit (eight), per direction. The client pre-compiles its
+   format's sixteen at startup (121 ms for `http`); **the server does not**, so
+   its first connection pays them. First connection vs steady state, measured
+   end to end: 18.0 vs 10.4 ms on the default, 68.0 vs 3.5 ms on `dns` in
+   `format` mode.
+7. **The relay's `select`+throttle poll loop is unchanged** and still carries
+   the caveats from 0.3: do not delete the throttle, and a dropped link can
+   still wedge an application connection (see *Resilience*).
 
 ---
 
 ## Measured data (LAN, loopback)
 
-| metric | plain TCP | 0.3.1 | **0.4 hybrid (default)** | 0.4 format |
+Round-trip echo through both relays, p50 (range) across three runs.
+
+| metric | plain TCP | **`http` hybrid (default)** | `smtp` format | `dns` format |
 |---|---:|---:|---:|---:|
-| connection setup p50 | – | 2.7–3.3 ms | **1.1 ms** | ~1 ms |
-| RTT 64 B p50 (p90) | 0.15 (0.28) ms | 1.5–1.7 ms | **0.51 (0.55) ms** | 0.73 (0.92) ms |
-| 64 KB echo | 413–1225 Mbit/s | 113–144 Mbit/s | **557 Mbit/s** | 4.4 Mbit/s |
-| 1 MB echo | 2596 Mbit/s | 452–522 Mbit/s | **2540 Mbit/s** | 7.3 Mbit/s |
-| 8 MB echo | 6071 Mbit/s | 655–700 Mbit/s | **4626 Mbit/s** | – |
-| 8 MB upload (one direction) | – | 1069–1275 Mbit/s | **4412 Mbit/s** | – |
+| connection setup p50 | – | **10.0 ms** (10.0–10.0) | 2.8 ms (2.5–3.5) | 3.4 ms (3.4–3.6) |
+| RTT 64 B p50 | 0.20 ms (0.16–0.22) | **2.52 ms** (2.51–2.59) | 0.42 ms (0.41–0.53) | 0.61 ms (0.60–0.64) |
+| RTT 64 B p90 | 0.25 ms | **2.71 ms** | 0.51 ms | 0.75 ms |
+| 64 KiB echo | 981 Mbit/s (828–1337) | **53 Mbit/s** (52–54) | 2.66 Mbit/s (2.41–2.73) | 1.68 Mbit/s (1.65–1.69) |
+| 1 MiB echo | 5980 Mbit/s (5476–6520) | **574 Mbit/s** (546–595) | 4.12 Mbit/s (3.91–4.24) | 2.54 Mbit/s (2.50–2.63) |
+| 8 MiB echo | 5899 Mbit/s (5874–6177) | **1119 Mbit/s** (1117–1130) | – | – |
 
-Ranges are run-to-run spread across two runs; the 64 KB transfer window
-includes connection setup and the handshake, so it is the noisiest row (the
-plain-TCP 64 KB figure varied 3x between runs). On the shaped links
-(broadband 25 Mbit and slower) fteproxy matches plain TCP within measurement
-noise, as it did on 0.3; those rows are omitted.
+**Read the small-transfer rows carefully.** `benchmark.py` opens a fresh
+tunnelled connection per transfer, so every throughput cell includes one
+connection setup. On the default, one setup on its own costs 10.0 ms and the
+whole 64 KiB window is 9.8 ms: that row is a *setup* measurement wearing a
+throughput row's clothes, which is why it sits below the 1 MiB row. Netting the measured setup
+out of the 8 MiB run leaves ~50 ms for 8 MiB of echo, or **~1.34 Gbit/s of
+steady-state bulk** (*derived*), which is within 4% of the record layer's own
+256 KiB ceiling below — the relay is delivering essentially all of what the
+record layer can produce.
 
-### Record layer alone (no sockets), `manual-http-request`/`-response`
+One-directional upload (`--direction upload --sizes 8M`) reads 2071 Mbit/s
+(1733–2190) against 10107 Mbit/s (8183–10381) for plain TCP, but it stops the
+clock when the application's last `send()` returns rather than on delivery, so
+it measures the socket buffer as much as the tunnel. The echo rows are the
+honest ones.
 
-Median encrypt+decrypt round trip through `fteproxy.record_layer`, from the
-release review (same machine). `manual-http-*` is the shape catalog's HTTP
-entry (release `20260110`, length 256); the shipped `http` format is length 512
-with more capacity per record, which moves the small-message rows a little and
-leaves the bulk rows where they are:
+On the shaped links (`broadband` 25 Mbit and slower) fteproxy matches plain TCP
+within measurement noise, as it did on 0.3; those rows are omitted.
 
-| message | 0.3.1 | 0.4 hybrid | 0.4 format | wire expansion 0.3.1 → 0.4 hybrid / format |
+### Record layer alone (no sockets), shipped `http` in `hybrid` mode
+
+Median encrypt+decrypt round trip through `fteproxy.record_layer`, one record
+per row, p50 (range) over three runs. The header is one sealed `http-request`
+covertext at the format's max length, 700 bytes.
+
+| message | ms/record | MB/s | wire bytes | expansion |
 |---|---:|---:|---:|---:|
-| 64 B | 0.07–0.21 MB/s (0.9 ms/record) | 0.38–0.53 MB/s (0.17 ms) | 0.40–0.65 MB/s | 4.0x → 5.4x / 4.0x |
-| 4 KiB | 4.5–11.7 MB/s | 23–33 MB/s | 0.9–1.9 MB/s | 1.03x → 1.07x / 1.81x |
-| 256 KiB | 75–88 MB/s | 657–713 MB/s | 0.9–1.8 MB/s | 1.001x → 1.001x / 1.75x |
-| 1 MiB | 75–89 MB/s | 920–960 MB/s | 1.0–1.8 MB/s | 1.000x → 1.000x / 1.75x |
+| 64 B | 1.25 (1.24–1.31) | 0.05 | 793 | 12.4x |
+| 4 KiB | 1.25 (1.25–1.29) | 3.1 | 4825 | 1.18x |
+| 256 KiB (the relay's record size) | 1.51 (1.46–1.56) | 166 (160–171) | 262873 | 1.003x |
+| 1 MiB (the body cap) | 2.31 (2.19–2.35) | 433 (425–456) | 1049305 | 1.001x |
 
-(Request/response formats differ in capacity, hence the pairs.)
+Split of one record: the 700-byte header costs **1.20 ms** (0.66 to seal,
+0.54 to open) and does not depend on the payload; the AE body costs 0.24 ms per
+256 KiB and 0.91 ms per MiB round trip (~1.1 GB/s). So the header is 79% of a
+relay-sized record and 52% of a maximal one.
+
+### Record layer alone, `format` mode, per covertext length
+
+Every record is one covertext; the encoder picks the length per record
+(`VariableLength.choose_length`), so a stream's cost is a mix of these rows —
+biased long when a lot is queued, short when the payload fits in one record.
+
+`http-request` (also the shape of the `hybrid` header, whose row is the last one):
+
+| covertext length | 200 | 271 | 343 | 414 | 486 | 557 | 629 | 700 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| payload per record (B) | 50 | 105 | 160 | 215 | 270 | 325 | 380 | 435 |
+| ms per record (encode+decode) | 0.165 | 0.263 | 0.383 | 0.531 | 0.684 | 0.847 | 1.034 | 1.241 |
+| MB/s | 0.29 | 0.38 | 0.40 | 0.39 | 0.38 | 0.37 | 0.35 | 0.33 |
+| wire expansion | 4.00x | 2.58x | 2.14x | 1.93x | 1.80x | 1.71x | 1.66x | 1.61x |
+
+`dns-request` (a `length-prefix` format: the cipher runs at length − 2):
+
+| covertext length | 90 | 116 | 142 | 168 | 194 | 220 | 246 | 272 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| payload per record (B) | 9 | 28 | 47 | 66 | 84 | 103 | 122 | 141 |
+| ms per record (encode+decode) | 0.084 | 0.111 | 0.137 | 0.170 | 0.197 | 0.229 | 0.263 | 0.296 |
+| MB/s | 0.10 | 0.24 | 0.33 | 0.37 | 0.41 | 0.43 | 0.44 | 0.45 |
+| wire expansion | 10.0x | 4.14x | 3.02x | 2.55x | 2.31x | 2.14x | 2.02x | 1.93x |
+
+The byte rate is flat within about 1.4x across `http`'s range and rises with
+length on `dns`, so **which length a record picks is not a throughput
+decision** — it is a realism decision, which is what the weighting in
+`choose_length` is for. What the length *does* decide is the per-record
+latency, and that is why `http`'s 700-byte maximum is the default's headline
+cost. Encode-side only, for comparison with the historical table below:
+`http-request` runs 0.081 ms/record (0.59 MB/s) at length 200 and
+0.676 ms/record (0.61 MB/s) at 700.
+
+### The first record at each length: DFA compile
+
+`fteproxy._regex_format` is an `lru_cache` on `(pattern, length)` holding 1024
+entries, so a given length compiles once per process and every later record at
+that length gets the tables for free. Cold compile, p50 over three runs:
+
+| length | `http` | `dns` |
+|---|---:|---:|
+| shortest | 2.37 ms (at 200) | 2.84 ms (at 90) |
+| middle | 5.36 ms (at 414) | 3.77 ms (at 168) |
+| longest | 10.79 ms (at 700) | 5.35 ms (at 272) |
+| all eight | 50.0 ms | 32.0 ms |
+
+So the *first* record at a new length costs the compile plus the record —
+about 12.0 ms for `http` at 700 against 1.24 ms thereafter, and 5.6 ms for
+`dns` at 272 against 0.30 ms — and the keyed `fte.FTE` built on top of a cached
+DFA costs 0.003 ms, which is why a connection can afford to build all eight up
+front in `record_layer.VariableLength`.
+
+Standing up both directions of one connection, cold cache vs warm:
+
+| | cold | warm |
+|---|---:|---:|
+| `http`, hybrid (2 DFAs) | 23.1 ms | 0.010 ms |
+| `http`, format (16 DFAs) | 117.7 ms | 0.080 ms |
+| `dns`, format (16 DFAs) | 70.3 ms | 0.064 ms |
+| `smtp`, format (16 DFAs) | 14.6 ms | 0.065 ms |
+
+The client pays this at startup, in `cli.check_format`: 121 ms for `http`,
+226 ms for `sip`, 68 ms for `dns`, 14.5 ms for `smtp`, 7.9 ms for `ftp`
+(545 ms for all five, which is what `defs-check` costs). **The server pre-warms
+nothing**, so its first connection pays instead. Measured end to end (a fresh
+server and client, timing the genuinely first tunnelled connection), first vs
+steady state: 18.0 vs 10.4 ms on the default, 20.2 vs 3.2 ms on `smtp`/format,
+and **68.0 vs 3.5 ms on `dns`/format**. The two `format`-mode gaps are the
+sixteen compiles above almost exactly (64.5 ms and 17.0 ms observed against
+64.0 ms and 14.6 ms of compiles); the default's 7.6 ms gap is smaller than its
+two 700-byte compiles measured in isolation, so some of that cost is evidently
+paid more cheaply in a process that has not just had its cache cleared.
 
 ---
 
-## Where the time goes (0.4, `hybrid`)
+## Where the time goes (default: `http`, `hybrid`)
 
 ```
 app → [client relay] ──FTE──→ [server relay] → dest
@@ -114,96 +210,124 @@ app → [client relay] ──FTE──→ [server relay] → dest
         _FTESocketWrapper.send     _FTESocketWrapper.recv
         = record_layer.Encoder     = record_layer.Decoder
           per record:                per record:
-          1 sealed header            1 header rank+verify   ~0.07–0.08 ms
-            (DFA unrank, AE)         + body HMAC-SHA256 verify + AES-CTR
-          + body AES-CTR + HMAC        ~0.43 ms/MiB (HMAC is ~78% of it)
+          1 sealed 700 B header      1 header rank+verify   1.20 ms the pair
+            (DFA unrank, AE)         + body HMAC + AES-CTR  0.91 ms/MiB the pair
+          + body AES-CTR + HMAC
 ```
 
-- A record is one 256-byte formatted header plus a raw body. The relay hands
-  at most `2**18` bytes to `send()` per read (`network_io.recvall_from_socket`),
-  so records are ≤ 256 KiB and each pays one header (~0.08 ms ≈ 0.33 ms/MiB,
-  *estimated* ~40% of encode-side record-layer time). The 1 MiB body cap is
+- A record is one 700-byte formatted header plus a raw body. The relay hands at
+  most `2**18` bytes to `send()` per read (`network_io.recvall_from_socket`), so
+  records are ≤ 256 KiB and each pays one 1.20 ms header — **79% of a
+  relay-sized record**, or 4.8 ms per MiB of goodput. The 1 MiB body cap is
   never reached in the relay.
-- Sealing (random pad to capacity), per-record `Cipher` construction, buffer
+- **The header's cost is the seal, not the payload it carries.** A hybrid header
+  carries four bytes (the body length), but `_seal` pads the plaintext to the
+  format's full 448-byte capacity before encrypting, because a short message
+  ranks low and unranks into a degenerate covertext (see the seal-padding rule
+  in `docs/format-authoring.md`). Encrypting 16 bytes at length 700 costs
+  0.11 ms; encrypting the padded 448 costs 0.66 ms. Realism is buying that 6x,
+  and it is not optional.
+- **Covertext cost grows faster than linearly with length**: 0.83 µs per
+  covertext byte at length 200, 1.77 µs at 700. This is why the default is
+  slower than a format with a smaller maximum, and why nothing in the
+  variable-length machinery changes the byte rate much.
+- **A new length costs one DFA compile, once per process** (2.4–10.8 ms on
+  `http`, 2.8–5.4 ms on `dns`), and nothing thereafter: the tables are cached on
+  `(pattern, length)` and shared read-only by every connection and thread. The
+  set of lengths is small (eight) precisely because of this; a continuous range
+  would be one compile per byte. The client compiles its format's sixteen at
+  startup, the server on demand, so a *server*'s first connection is 2–19x its
+  steady-state setup.
+- Interactive traffic: one 64 B message costs one 700-byte header plus a 93-byte
+  body — 793 B on the wire, **12.4x expansion**, and 1.25 ms of CPU per
+  direction. In `format` mode the same message is one covertext: 200 B and
+  0.165 ms if the encoder picks the shortest `http` length, 80 B and 0.069 ms on
+  `smtp`.
+- Sealing's random pad (`os.urandom`), per-record `Cipher` construction, buffer
   concatenation and the body/remainder slices are each under 1% of a record.
-- Interactive traffic: one 64 B message costs one 256-byte header plus a
-  92-byte body (348 B, 5.4x; 0.3 and `format` mode send 256 B).
-- In `format` mode every ~140 bytes of payload is one DFA rank/unrank
-  (~0.16 ms), which is the 4–7 Mbit/s. That 140 was the capacity of the
-  fixed-length shape format these numbers were taken on. With the shipped
-  variable-length formats it is the capacity of the length the record picked
-  (50–435 bytes for `http-request`, 2–148 for `ftp-request`) — and the cost of
-  the rank scales with the length too, so the byte rate is nearly flat across a
-  format's range. Encode-side over `http-request`'s eight lengths:
-
-  | covertext length | 200 | 271 | 343 | 414 | 486 | 557 | 629 | 700 |
-  |---|---:|---:|---:|---:|---:|---:|---:|---:|
-  | payload per record (B) | 50 | 105 | 160 | 215 | 270 | 325 | 380 | 435 |
-  | ms per record | 0.08 | 0.12 | 0.18 | 0.24 | 0.32 | 0.41 | 0.51 | 0.62 |
-  | MB/s | 0.65 | 0.88 | 0.91 | 0.88 | 0.84 | 0.80 | 0.75 | 0.71 |
-
-  The shortest length is the worst rate (per-record fixed costs over the least
-  payload) and the middle is the best; the spread is well under 2x, so which
-  length a record picks is not a throughput decision.
+- In `format` mode every covertext is one DFA rank/unrank, so the payload per
+  rank is 50–435 bytes on `http`, 7–168 on `smtp` and 9–141 on `dns` — the
+  2.5–4 Mbit/s in the table above.
 
 ---
 
-## Improvements landed in 0.4
+## Improvements landed in 1.0
 
-1. **Hybrid record layer with an OpenSSL AE body** (the redesign): per-record cost
-   0.9 → 0.17 ms; bulk 75 → 650–950 MB/s in the record layer.
+1. **Hybrid record layer with an OpenSSL AE body** (the redesign): the DFA runs
+   once per record instead of once per 50–435 bytes, and the body itself moves at
+   ~1.1 GB/s round trip. On the shipped `http` format that is 166 MB/s at the
+   relay's record size against 0.32 MB/s for the same format in `format` mode.
 2. **Cipher cache**: the expensive half of a libfte cipher is the DFA, and
-   `_regex_format` memoizes it on pattern and length, so setup went 8–12 ms →
-   ~1 ms and the server's first-record scan on a failed connection 6 ms → free.
-   The keyed `fte.FTE` on top is built per session (a couple of microseconds),
-   because since 0.4 every connection derives its own keys. A variable-length
-   format wants one entry per length, so the cache holds 1024 and a connection
-   builds its eight keyed ciphers per direction up front, in
-   `record_layer.VariableLength`, rather than one per record.
+   `_regex_format` memoizes it on `(pattern, length)`, so a cached cipher costs
+   0.003 ms to build instead of 2.4–10.8 ms. Without it every connection — and
+   every candidate in the server's first-record scan — would recompile. The
+   keyed `fte.FTE` on top is built per session, because since 1.0 every
+   connection derives its own keys. A connection builds its eight ciphers per
+   direction up front in `record_layer.VariableLength` rather than one per
+   record.
 3. **A pending header is decrypted once.** A 256 KiB record arrives in ~3 reads;
    the decoder used to re-rank and re-verify the same header on each partial
-   delivery (two wasted header decrypts per record, more than the body itself).
-   +30% on 8 MB echo.
+   delivery. With a 1.20 ms header that would now cost more than double.
 4. **A peer that closes before handshaking gets EOF** instead of being polled
-   forever. On 0.4 without this, one dead connection (a port scan, a health
-   check, an active probe) cost 64% of a core; five saturated it and pushed
-   RTT p50 to 65 ms.
+   forever. Without this, one dead connection (a port scan, a health check, an
+   active probe) cost 64% of a core.
 5. **The handshake moved off the relay workers.** A per-connection setup thread
-   completes it, reads the client's OPEN and dials the destination before
-   either worker starts, so the accept loop no longer waits on a `connect()`
-   and the two workers never touch a half-built encoder. That was the
-   precondition for reworking the poll loop (lever #1 below).
+   completes it, reads the client's OPEN and dials the destination before either
+   worker starts, so the accept loop no longer waits on a `connect()` and the
+   two workers never touch a half-built encoder. That was the precondition for
+   reworking the poll loop (lever #2 below).
 6. Carried over from 0.3: `TCP_NODELAY` on both relay hops, O(n) buffer handling
-   in the record layer, and trying the most-recently-matched format first in
-   the server's first-record scan.
+   in the record layer, and trying the most-recently-matched format first in the
+   server's first-record scan.
 
-The handshake and the in-band destination add about 1.6 ms to connection
-setup, measured on one machine against the same build without them
-(0.7 -> 2.3 ms p50 on loopback): two X25519 key generations, four exchanges,
-and two extra round trips (the server hello, then OPEN/OPEN_RESULT). Bulk
-throughput is unchanged -- the record layer microbenchmark reads 673 MB/s at
-256 KiB and 973 MB/s at 1 MiB either way.
+Connection setup on the default is 10.0 ms, and it is records rather than
+crypto: five covertext round trips (client hello, server hello, OPEN,
+OPEN_RESULT, the first data record) at ~1.2 ms each account for ~6.2 ms of it,
+against 0.31 ms for both X25519 key generations and the exchange; the rest is
+the two TCP dials, the setup thread and the server's first-record scan. The
+same handshake on `smtp` costs 2.8 ms — the difference is the covertext
+length.
 
 ## Remaining levers, ranked by impact ÷ effort
 
-1. **Rework the polling relay loop** (large effort; fixes idle CPU, a latency
-   ripple, and the hang on link drop). The 0.3 caveat stands and was re-verified:
-   simply deleting `time.sleep(throttle)` in `worker.run()` regresses the real
-   subprocess deployment ~13x (a GIL-scheduling convoy between the two workers),
-   and on 0.3 a naive blocking-`recv` rework raced the in-band negotiation
-   between the two workers. 0.4 removes that second obstacle — the handshake
-   now finishes on a setup thread before either worker starts — so what is
-   left is the GIL convoy, and the shape to try is one `selectors` loop per
-   connection handling both directions. Still not a drive-by.
-2. **Carry small messages inline in the sealed header** (medium effort). A message
-   of ≤ ~140 bytes fits in the header's capacity, so it could travel as one
-   256-byte covertext instead of header + 92-byte body: 5.4x → 4.0x expansion
-   for interactive traffic, at the CPU cost `format` mode already pays per
-   record (identical for one record).
-3. **AES-GCM for the body** would roughly halve body CPU (*estimated*; HMAC-SHA256
-   runs at ~3 GB/s vs 16 GB/s for AES-CTR), but the body is now under 10% of
-   end-to-end time and it would be a wire change. Not worth it today.
-4. **`format` mode throughput is inherent** to transforming every byte; the only
+1. **Shorten what a `hybrid` header is sealed at** (small effort, wire change).
+   Hybrid formats only the header, and the header exists to carry a 4-byte
+   length, yet it is sealed at the format's *maximum* (700 B on `http`) because
+   that is where the handshake seals. Sealing hybrid headers at the format's
+   *shortest* length instead would take the per-record cost from 1.20 ms toward
+   0.165 ms — roughly 4x on bulk and 6x on interactive latency — at the cost of
+   a fixed short covertext
+   in a stream whose bodies are already high-entropy. Measured today by
+   substituting a shorter format's header: a 1 MiB record costs 2.31 ms with
+   `http`'s 700-byte header, 1.22 ms with `smtp`'s 320-byte one (818 MB/s), and
+   1.30 ms with `dns`'s 272-byte one.
+2. **Rework the polling relay loop** (large effort; fixes idle CPU, a latency
+   ripple, and the hang on link drop). The 0.3 caveat stands: simply deleting
+   `time.sleep(throttle)` in `worker.run()` regressed the real subprocess
+   deployment ~13x when it was tried (a GIL-scheduling convoy between the two
+   workers), and on 0.3 a naive blocking-`recv` rework raced the in-band
+   negotiation between the two workers. 1.0 removes that second obstacle — the
+   handshake now finishes on a setup thread before either worker starts — so
+   what is left is the GIL convoy, and the shape to try is one `selectors` loop
+   per connection handling both directions. Not re-measured in this run; still
+   not a drive-by.
+3. **Pre-warm the server's DFAs at startup** (small effort, no wire change). The
+   client already does this in `cli.check_format`; the server compiles on its
+   first connection instead, which costs that connection 18.0 ms on the default
+   and 68.0 ms on `dns` in `format` mode, against 10.4 ms and 3.5 ms once
+   warm. The server cannot know which format a
+   client will pick, so the honest version is to compile the whole catalog —
+   545 ms of startup for all five formats at all lengths, both directions.
+4. **Carry small messages inline in the sealed header** (medium effort). A
+   message of ≤ 435 bytes fits in the header's capacity, so it could travel as
+   one covertext instead of header + body. On its own that is 12.4x → 10.9x
+   expansion for a 64 B interactive message at no extra CPU (the header is
+   already sealed at full capacity, so the payload rides for free); combined
+   with lever #1 the same message becomes one 271-byte covertext — 4.2x and
+   0.26 ms instead of 793 B and 1.25 ms.
+5. **AES-GCM for the body** would cut body CPU (*estimated*), but the body is
+   16% of a 256 KiB record and the header is 79%. Not worth a wire change today.
+6. **`format` mode throughput is inherent** to transforming every byte; the only
    lever is a faster ranker (a C extension releasing the GIL).
 
 ---
@@ -215,9 +339,10 @@ cut, the relay usually frees the app within ~0.5 s, but in a minority of runs a
 worker blocked in `sendall` to one peer never checks its other peer and the
 connection wedges past the observation window. The nominal 30 s
 `runtime.fteproxy.relay.socket_timeout` cannot rescue it because the poll loop
-never issues a blocking `recv` that lasts long enough. Lever #1 above is the fix.
+never issues a blocking `recv` that lasts long enough. Lever #2 above is the
+fix. (`benchmark.py --resilience`; not re-run for this revision.)
 
-What is new in 0.4 is that the *other* stuck states are fixed: a connection
+What is new since 0.3 is that the *other* stuck states are fixed: a connection
 closed before the handshake, and one that opens and then falls silent, both
 release their worker — the first at EOF, the second at the handshake deadline.
 
@@ -226,8 +351,46 @@ release their worker — the first at EOF, the second at the handshake deadline.
 ## What did *not* turn out to be a problem
 
 - **Slow, high-latency or low-bandwidth links.** fteproxy matches raw TCP there.
-- **Server startup.** Building ciphers for all 46 formats takes ~23 ms cold.
-- **Random padding.** `os.urandom` for the seal pad is ~1 µs of an ~80 µs header.
-- **The 1 MiB body cap.** Never reached; records are bounded by the relay's read size.
-- **Cell/buffer size tuning.** As on 0.3, `network_io`'s `2**18` read size is the
-  right balance; larger buffers trade small-transfer latency for little bulk gain.
+- **Random padding.** `os.urandom` for the seal pad is 2 µs of a 660 µs header.
+  What costs is encrypting the pad, not generating it.
+- **The 1 MiB body cap.** Never reached; records are bounded by the relay's read
+  size.
+- **Cell/buffer size tuning.** As on 0.3, `network_io`'s `2**18` read size is
+  the right balance; larger buffers trade small-transfer latency for little bulk
+  gain — and with a 1.20 ms header, a *smaller* one would cost dearly.
+- **Variable length.** The eight-length machinery costs one DFA per length once
+  per process and leaves the byte rate flat within ~1.4x. It is the *value* of
+  the maximum, not the spread, that costs.
+
+Two entries moved off this list since 0.3.1: **server startup**, which is now
+0 ms only because the server defers every compile to its first connection
+(lever #3), and **the format's length**, which was a fixed 256 bytes in the old
+shape catalog and is now 700 on the default.
+
+---
+
+## Historical: 0.3.1 and the old shape catalog
+
+These numbers are **not current** and are kept only for the comparison they
+support. They were taken on 2026-09-02 on the same machine (then on CPython
+3.14.7) against `manual-http-request`/`-response` from the release `20260110`
+shape catalog — a *fixed* 256-byte covertext — before the five-protocol
+definitions release made `http` variable length 200–700.
+
+| metric | plain TCP | 0.3.1 (`fte` 0.3.0) | 1.0 hybrid, 256 B format | 1.0 format, 256 B |
+|---|---:|---:|---:|---:|
+| connection setup p50 | – | 2.7–3.3 ms | 1.1 ms | ~1 ms |
+| RTT 64 B p50 | 0.15 ms | 1.5–1.7 ms | 0.51 ms | 0.73 ms |
+| 1 MB echo | 2596 Mbit/s | 452–522 Mbit/s | 2540 Mbit/s | 7.3 Mbit/s |
+| 8 MB echo | 6071 Mbit/s | 655–700 Mbit/s | 4626 Mbit/s | – |
+| record layer, 256 KiB | – | 75–88 MB/s | 657–713 MB/s | 0.9–1.8 MB/s |
+| record layer, 1 MiB | – | 75–89 MB/s | 920–960 MB/s | 1.0–1.8 MB/s |
+| per-record fixed cost | – | ~0.9 ms | ~0.17 ms | – |
+
+The 5–7x bulk win and 3x latency win the 1.0 record layer took from 0.3.1 are
+real and still in the code; what changed underneath them is the covertext the
+default seals at. The old ~0.17 ms per-record figure and today's 1.24 ms are the
+same operation on the same code: a sealed `http`-shaped covertext at 256 bytes
+versus one at 700. The per-length table above reproduces it — 0.165 ms at
+length 200 — which is the cleanest evidence that the regression against these
+historical rows is the format's length and nothing else.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -240,9 +240,8 @@ app → [client relay] ──FTE──→ [server relay] → dest
   steady-state setup.
 - Interactive traffic: one 64 B message costs one 700-byte header plus a 93-byte
   body — 793 B on the wire, **12.4x expansion**, and 1.25 ms of CPU per
-  direction. In `format` mode the same message is one covertext: 200 B and
-  0.165 ms if the encoder picks the shortest `http` length, 80 B and 0.069 ms on
-  `smtp`.
+  direction. In `format` mode the same message is one covertext: 271 B and 0.26 ms on `http` (the shortest length that holds 64 bytes; a
+  200-byte covertext carries only 50), 183 B and about 0.13 ms on `smtp`.
 - Sealing's random pad (`os.urandom`), per-record `Cipher` construction, buffer
   concatenation and the body/remainder slices are each under 1% of a record.
 - In `format` mode every covertext is one DFA rank/unrank, so the payload per

--- a/README.md
+++ b/README.md
@@ -162,8 +162,11 @@ terminator the format's language cannot produce anywhere else; `dns` is framed
 by the two-byte length prefix RFC 1035 puts in front of every DNS-over-TCP
 message, which is framing rather than part of its regex, so one pattern serves
 every length (and its query names run 72–254 octets rather than always 254).
-The two handshake records and a `hybrid` mode header are always at the top of
-the range.
+The two handshake records are always at the top of the range. A `hybrid` mode
+header is fixed length too, but at the *shortest* length the format can hold one
+in (the `hdr` column below): a header carries only the length of the raw body
+behind it, and a short covertext is several times cheaper to produce than a long
+one.
 
 `http` is the default. A client given no `--format` and no `?format=` hint
 picks the format whose protocol runs on the server's port -- a server on 21
@@ -177,17 +180,20 @@ the capacity of one covertext:
 
 ```console
 $ fteproxy formats
-name  role      port          mode    req len  req cap  resp len  resp cap
-dns   req/resp  53            format   90-272   22-154    90-272    17-148
-ftp   req/resp  21            format   64-256   15-161    64-256    16-163
-http  req/resp  80,8080,8000  hybrid  200-700   63-448   200-700    52-434  (default)
-sip   req/resp  5060          format  300-800   99-472   300-800   101-474
-smtp  req/resp  25,587        format   80-320   20-181    80-320    29-215
+name  role      port          mode      hdr  req len  req cap  resp len  resp cap
+dns   req/resp  53            format     90   90-272   22-154    90-272    17-148
+ftp   req/resp  21            format  91/64   64-256   15-161    64-256    16-163
+http  req/resp  80,8080,8000  hybrid    200  200-700   63-448   200-700    52-434  (default)
+sip   req/resp  5060          format    300  300-800   99-472   300-800   101-474
+smtp  req/resp  25,587        format     80   80-320   20-181    80-320    29-215
 ```
 
 A range in the length column is a format that varies its covertext length; a
 single number is a fixed-length one (the `20260110` shape catalog is all
-fixed-length).
+fixed-length). `hdr` is the covertext length a `hybrid` header goes in --
+request and response after a slash when the two differ, as they do for `ftp`,
+whose reply pattern has just enough room at 64 bytes and whose command pattern
+has not.
 
 The comprehensive catalog of abstract *shapes* that earlier versions defaulted
 to -- 46 entries, 23 base names (`manual-http`, `words`, `base64`, …) -- still
@@ -198,8 +204,10 @@ The client picks the format and the record-layer mode and puts both in the
 handshake; the server follows. Nothing has to be configured to match.
 
 - `--mode hybrid` (default): each record is a fixed-length covertext header
-  followed by raw authenticated ciphertext. Fast — hundreds of MB/s — but only
-  the header blends in with the target protocol.
+  followed by raw authenticated ciphertext. The header goes in the shortest
+  covertext the format has room for one in (the `hdr` column above), since all
+  it carries is the length of the body behind it. Fast — hundreds of MB/s — but
+  only the header blends in with the target protocol.
 - `--mode format`: every byte on the wire is in the format, so the whole
   stream is indistinguishable from the protocol, and each covertext takes a
   length from across the format's range. Much slower (about 1 MB/s), for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -157,8 +157,14 @@ first. This section covers what fteproxy adds on top of it.
     distribution: eight discrete values, sized by what the record layer is
     carrying, are not the continuous, content-driven lengths of real HTTP or
     SIP, and an adversary who models message lengths finely can still tell the
-    difference. Two things stay fixed: a `hybrid` header, and the two handshake
-    records, which are always at the format's longest length.
+    difference. Two things stay fixed. The two handshake records are always at
+    the format's longest length, because the server has to frame a client hello
+    before it can decrypt anything. A `hybrid` header is fixed too, but at the
+    *shortest* length the format has that can hold one (`http`: 200, not 700) --
+    it carries four bytes, so nothing is gained by putting it in a long
+    covertext and a great deal of ranking time is lost. Either way a hybrid
+    stream still shows one repeated header length; that is the mode's
+    fingerprint, and it is the next bullet's subject.
   - **One message type dominates.** Unranking a full-capacity plaintext lands
     in the same branch of the alternation nearly every time, so in practice
     every `http` request samples as `GET`, every `sip` request as `ACK`, every
@@ -192,8 +198,9 @@ first. This section covers what fteproxy adds on top of it.
   place a high-entropy tail belongs, so those ship as `mode_hint: format`
   (every byte in the protocol, at about 1 MB/s) and running them under
   `--mode hybrid` leaks an obvious high-entropy tail after each line -- and,
-  because a `hybrid` header is fixed length, gives back the length fingerprint
-  the format-mode records no longer have. `dns` in `hybrid` mode is worse than
+  because a `hybrid` header is one fixed length (the shortest the format can
+  hold one in), gives back the length fingerprint the format-mode records no
+  longer have. `dns` in `hybrid` mode is worse than
   the others: a DNS message is self-delimiting, so a raw body after the
   covertext is a tail the length prefix does not account for -- visible to
   anything that reads DNS-over-TCP framing at all.

--- a/docs/format-authoring.md
+++ b/docs/format-authoring.md
@@ -100,8 +100,29 @@ Then, in `format` mode, each record picks one of
 `fteproxy.defs.spec_allowed_lengths(spec)` — eight lengths spread evenly across
 the range, including both ends — and is sealed with a fixed-length cipher at
 that length. Both ends derive the set from the same definitions entry, so
-nothing about it is negotiated. `hybrid` mode, the two handshake records and the
-server's first-record scan all stay at `max_length`.
+nothing about it is negotiated. The two handshake records and the server's
+first-record scan stay at `max_length`: the server has to frame a client hello
+before it can decrypt anything, so the hello's length cannot depend on its
+contents, and the longest covertext is the one choice that always has room.
+
+A `hybrid`-mode header is a fixed-length frame too, but it goes at
+**`fteproxy.hybrid_header_length(spec)` — the shortest allowed length whose
+cipher has room for a header**, not at `max_length`. A header carries four
+bytes, the length of the raw body behind it, and nothing else
+(`record_layer.HYBRID_HEADER_BYTES`, 16 bytes of plaintext once the seal's
+length and sequence fields are counted). Ranking a covertext gets superlinearly
+more expensive as it gets longer — sealing `http`'s header at 200 bytes instead
+of 700 is roughly seven to eight times cheaper per record — and every hybrid
+record pays it once, so sealing a four-byte header at the format's longest
+length made the shipped default several times slower in bulk and in latency than
+it needed to be, for nothing. The length is computed
+from the definitions entry by that one function, so both ends reach the same
+answer and the decoder's frame size follows from its own header cipher; nothing
+about it is negotiated either. For a fixed-length format there is one allowed
+length, so this *is* `max_length` and nothing changes. A format with no allowed
+length that can hold a header cannot run in hybrid mode at all: `defs-check`
+refuses it, and a session that asks for hybrid is refused with
+`fteproxy.HybridUnsupportedError` rather than quietly framed some other way.
 
 Those lengths are always lengths **on the wire**. For the two framings below
 that is the same as the cipher's covertext length; for `length-prefix` framing

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -139,9 +139,14 @@ protocols) rather than by a fixed slice. `dns` is framed by the two-byte
 big-endian length prefix RFC 1035 puts in front of every DNS-over-TCP message:
 that prefix is framing rather than part of the format's regex, so one pattern
 serves all eight of its lengths, and a `dns` query name now runs 72–254 octets
-instead of padding to 254 every time. Two things stay fixed length: a `hybrid`
-mode header, and the two handshake records, which are always at the top of the
-format's range. `http-response` lost its body field to
+instead of padding to 254 every time. Two things stay fixed length. The two
+handshake records are always at the top of the format's range, because the
+server has to frame a client hello before it can decrypt anything. A `hybrid`
+mode header is fixed too, but at the *shortest* length the format can hold one
+in — 200 bytes for `http` rather than 700, 80 for `smtp`, 90 for `dns` — since
+all it carries is the four-byte length of the raw body behind it. `fteproxy
+formats` shows the length per format in its `hdr` column. `http-response` lost
+its body field to
 make this safe -- a field that could contain CRLF CRLF would break terminator
 framing -- and is now a header-block-only 200/302/304/404 response with
 `Content-Length: 0`.
@@ -156,9 +161,12 @@ bytes); its `manual-http-*` formats are unchanged at length 256, carrying 150
 
 ## Performance
 
-Bulk throughput is unchanged: the record layer's framing, sealing and chunking
-are as they were, and the hybrid body still runs at 670–970 MB/s in the
-microbenchmark. Connection setup costs about 1.6 ms more than the same build
+The record layer's framing, sealing and chunking are as they were, and the
+hybrid body is untouched. What did change is the formatted half of a hybrid
+record: putting the header in the shortest covertext that holds one instead of
+in the format's longest cuts the per-record header cost by about 7–8x for
+`http` in the microbenchmark, which is most of the cost of a hybrid record at
+ordinary write sizes. Connection setup costs about 1.6 ms more than the same build
 without the handshake (0.7 → 2.3 ms p50 on loopback) — two X25519 key
 generations, four exchanges, and the two extra round trips that buy server
 authentication and an in-band destination. See

--- a/examples/formats/README.md
+++ b/examples/formats/README.md
@@ -44,18 +44,20 @@ carries:
 
 ```console
 $ fteproxy formats
-name  role      port          mode    req len  req cap  resp len  resp cap
-dns   req/resp  53            format   90-272   22-154    90-272    17-148
-ftp   req/resp  21            format   64-256   15-161    64-256    16-163
-http  req/resp  80,8080,8000  hybrid  200-700   63-448   200-700    52-434  (default)
-sip   req/resp  5060          format  300-800   99-472   300-800   101-474
-smtp  req/resp  25,587        format   80-320   20-181    80-320    29-215
+name  role      port          mode      hdr  req len  req cap  resp len  resp cap
+dns   req/resp  53            format     90   90-272   22-154    90-272    17-148
+ftp   req/resp  21            format  91/64   64-256   15-161    64-256    16-163
+http  req/resp  80,8080,8000  hybrid    200  200-700   63-448   200-700    52-434  (default)
+sip   req/resp  5060          format    300  300-800   99-472   300-800   101-474
+smtp  req/resp  25,587        format     80   80-320   20-181    80-320    29-215
 ```
 
 A range means the format varies its covertext length: in `--mode format` each
 record picks a length from across it, so a capture shows a spread of message
 sizes rather than one repeated size. Every shipped format has one; the
-`20260110` shape catalog is fixed-length throughout.
+`20260110` shape catalog is fixed-length throughout. `hdr` is where a
+`--mode hybrid` header goes -- the shortest covertext the format has room for
+one in, request and response after a slash when the two differ.
 
 Given neither `--format` nor a `?format=` hint in the connection string, the
 client picks the format whose protocol runs on the server's port -- `ftp` for a

--- a/fteproxy/__init__.py
+++ b/fteproxy/__init__.py
@@ -267,6 +267,18 @@ class ChannelNotReadyException(Exception):
     """The peer has not reached the point where this call can be served."""
 
 
+class HybridUnsupportedError(Exception):
+    """This format cannot run in ``hybrid`` mode.
+
+    Raised when no covertext length the format emits has room for a hybrid
+    header (:data:`fteproxy.record_layer.HYBRID_HEADER_BYTES`). Refusing is the
+    point: falling back to another length would leave the two ends framing the
+    stream differently, which surfaces as a connection that authenticates its
+    handshake and then cannot decode a record. ``--mode format`` runs such a
+    format; no shipped format is one.
+    """
+
+
 class OpenRefused(Exception):
     """The peer would not open the requested stream.
 
@@ -365,6 +377,128 @@ def _cipher_for(format_name, key, cover=False):
                           fteproxy.defs.get_framing(format_name), build=build)
 
 
+# --------------------------------------------------------------------------- #
+# The hybrid header length
+# --------------------------------------------------------------------------- #
+
+#: Key used only to *measure* a cipher's plaintext capacity.
+#: ``max_plaintext_bytes`` is a function of the pattern and the covertext
+#: length and never of the key, so which key this is cannot change an answer --
+#: and the answer must not depend on a session key, since the two ends of a
+#: connection work it out separately and have different keys for each direction.
+_PROBE_KEY = b'\x00' * 32
+
+
+@functools.lru_cache(maxsize=1024)
+def _hybrid_header_length(regex, framing, lengths):
+    """The shortest of ``lengths`` whose cipher holds a hybrid header, or None.
+
+    Split out from :func:`hybrid_header_length` so the answer is cached on
+    hashable arguments -- a definitions entry is a dict, and this is asked once
+    per direction per connection. The cache is keyed on everything the answer
+    depends on (the pattern, the framing and the length set), so pointing the
+    loader at another release cannot return a stale length.
+
+    Measured, not guessed: each candidate length's real cipher is built and
+    asked for its ``max_plaintext_bytes``. Capacity is a step function of the
+    covertext length with no closed form -- a format's rank space depends on how
+    much of the pattern is literal -- so the shortest length that fits is
+    ``smtp``'s 80 in one release and something else in the next.
+
+    A length whose cipher cannot be built at all is simply not a candidate:
+    libfte refuses a format with no room for even an empty message
+    (``FTEError``) and a length its language has no strings at
+    (``ValueError``), and either way there is no header to be sealed there.
+    This searches for the shortest length that *works*; whether an unusable
+    length belongs in the format's set at all is ``fteproxy.defs.validate``'s
+    question, and it reports that in its own words.
+    """
+    for length in lengths:
+        try:
+            capacity = _framed_cipher(regex, length, _PROBE_KEY,
+                                      framing).max_plaintext_bytes
+        except (fte.FTEError, ValueError):
+            continue
+        if capacity >= fteproxy.record_layer.HYBRID_HEADER_BYTES:
+            return length
+    return None
+
+
+def hybrid_header_length(spec):
+    """The wire length a ``hybrid``-mode record's header is sealed at.
+
+    The shortest length in ``fteproxy.defs.spec_allowed_lengths(spec)`` whose
+    cipher has room for :data:`fteproxy.record_layer.HYBRID_HEADER_BYTES` of
+    plaintext, or ``None`` if the format has no such length and therefore cannot
+    run in hybrid mode at all.
+
+    **Why it is not ``max_length``.** A hybrid header carries four bytes: the
+    length of the raw body behind it. Sealing that at the format's longest
+    covertext -- which is what the handshake and the server's first-record scan
+    have to do -- buys nothing and costs a great deal, because ranking a
+    covertext gets superlinearly more expensive as it gets longer: sealing
+    ``http``'s header at 200 bytes rather than 700 is roughly seven to eight
+    times cheaper per record (see PERFORMANCE.md). Every hybrid data record pays
+    that once, so the shipped default was several times slower in bulk and in
+    latency than it needed to be, to carry four bytes.
+
+    **Why nothing negotiates it.** Both ends compute it from the same
+    definitions entry with this one function, exactly as they derive the
+    variable-length length set, so the sender's header cipher and the receiver's
+    are the same cipher and the decoder's frame size follows from it. Nothing
+    about it goes on the wire.
+
+    A fixed-length format has one allowed length, so this returns that length
+    and its hybrid framing is unchanged.
+    """
+    return _hybrid_header_length(
+        spec['regex'], fteproxy.defs.spec_framing(spec),
+        tuple(fteproxy.defs.spec_allowed_lengths(spec)))
+
+
+def _hybrid_header_cipher(format_name, key):
+    """The cipher one direction's hybrid headers are sealed with.
+
+    Raises :class:`HybridUnsupportedError` rather than falling back to
+    ``max_length``: a silent fallback would be a format running in a mode it
+    cannot carry, which shows up as a connection that will not decode.
+    """
+    spec = fteproxy.defs._spec(format_name)
+    length = hybrid_header_length(spec)
+    if length is None:
+        raise HybridUnsupportedError(
+            'format %s has no covertext length that can hold a %d-byte hybrid '
+            'header (it emits %r), so it cannot run in hybrid mode'
+            % (format_name, fteproxy.record_layer.HYBRID_HEADER_BYTES,
+               fteproxy.defs.spec_allowed_lengths(spec)))
+    return _spec_cipher(spec, length, key)
+
+
+def _check_hybrid_supported(base, mode):
+    """Refuse ``hybrid`` unless *both* directions of ``base`` can carry a header.
+
+    A session seals one direction with each entry, so one direction with no room
+    for a header is enough to make the mode unusable for the base.
+
+    Called before either end commits to a session -- the client before it sends
+    its hello, the server before it answers one -- so the failure is a clear
+    error rather than a stream that authenticates and then cannot be framed.
+    Cannot fire for any format in a loaded release: ``check_capacities``
+    already requires :data:`fteproxy.defs.MIN_CAPACITY` bytes at the length the
+    handshake seals at, which is one of the allowed lengths and far more than a
+    header needs.
+    """
+    if mode != fteproxy.handshake.MODE_HYBRID:
+        return
+    for name in _format_pair(base):
+        if hybrid_header_length(fteproxy.defs._spec(name)) is None:
+            raise HybridUnsupportedError(
+                'format %s has no covertext length that can hold a %d-byte '
+                'hybrid header, so %s cannot run in hybrid mode; use '
+                '"--mode format"'
+                % (name, fteproxy.record_layer.HYBRID_HEADER_BYTES, base))
+
+
 def _variable_lengths_for_spec(spec, key):
     """The :class:`~fteproxy.record_layer.VariableLength` a definitions spec
     describes, keyed with ``key``.
@@ -401,6 +535,14 @@ def _session_channel(base, mode, keys, is_client):
     length it may emit; in ``hybrid`` mode it does not, because a hybrid record
     is a fixed-length header plus a raw body and only the header is in the
     format at all.
+
+    A hybrid header is sealed at :func:`hybrid_header_length`, not at the
+    format's ``max_length``: it carries four bytes, so it is put in the shortest
+    covertext that holds them. Both ends run this same function over the same
+    definitions entry -- and, for a given direction, over the *same* entry, since
+    a client's outgoing request format is the server's incoming one -- so the
+    two header ciphers are identical and the decoder's frame size follows from
+    its own without anything being negotiated.
     """
     request, response = _format_pair(base)
     outgoing, incoming = ((request, response) if is_client
@@ -408,12 +550,13 @@ def _session_channel(base, mode, keys, is_client):
     out_header, out_body = keys.outgoing(is_client)
     in_header, in_body = keys.incoming(is_client)
     hybrid = (mode == fteproxy.handshake.MODE_HYBRID)
+    header_cipher = _hybrid_header_cipher if hybrid else _cipher_for
     encoder = fteproxy.record_layer.Encoder(
-        cipher=_cipher_for(outgoing, out_header),
+        cipher=header_cipher(outgoing, out_header),
         body_cipher=_make_body_cipher(out_body) if hybrid else None,
         variable=None if hybrid else _variable_for(outgoing, out_header))
     decoder = fteproxy.record_layer.Decoder(
-        cipher=_cipher_for(incoming, in_header),
+        cipher=header_cipher(incoming, in_header),
         body_cipher=_make_body_cipher(in_body) if hybrid else None,
         variable=None if hybrid else _variable_for(incoming, in_header))
     return encoder, decoder
@@ -558,6 +701,10 @@ class _FTESocketWrapper(object):
 
     def _client_handshake(self):
         request, response = _format_pair(self._format)
+        # Before a byte goes out: a mode this format cannot carry is this end's
+        # own configuration error, and it should read as one rather than as a
+        # server that would not answer.
+        _check_hybrid_supported(self._format, self._mode)
         driver = fteproxy.handshake.ClientHandshake(
             server_public=self._server_public, format=self._format,
             mode=self._mode, defs=self._defs)
@@ -706,6 +853,15 @@ class _FTESocketWrapper(object):
                     fteproxy.defs.getLength(matched)):
             raise HandshakeFailedException('hello format does not match its '
                                            'covertext format')
+
+        # The client names the mode; check this end can carry it *before*
+        # answering, so a hello asking for hybrid on a format that cannot frame
+        # a hybrid header is rejected like any other hello this server will not
+        # serve, rather than after a server hello has already gone out.
+        try:
+            _check_hybrid_supported(base, hello.mode)
+        except HybridUnsupportedError as e:
+            raise HandshakeFailedException(str(e))
 
         response_cipher = _cipher_for(response, self._cover_key, cover=True)
         try:

--- a/fteproxy/cli.py
+++ b/fteproxy/cli.py
@@ -375,6 +375,35 @@ def _span(low, high):
     return str(low) if low == high else '%d-%d' % (low, high)
 
 
+def _hybrid_header_cell(directions, definitions):
+    """The ``hdr`` cell of a ``formats`` row: where a hybrid header goes.
+
+    ``200`` when both directions of the base put their headers in the same
+    covertext length, ``91/64`` (request/response) when the two differ -- which
+    they may, since each direction's length is computed from its own entry and a
+    request and a response pattern have different rank spaces at the same
+    length. ``-`` if either direction has no length that holds a header, since
+    then the base cannot run in hybrid mode.
+    """
+    cells = []
+    for direction in ('request', 'response'):
+        name = directions.get(direction)
+        if name is None:
+            continue
+        try:
+            length = fteproxy.hybrid_header_length(definitions[name])
+        except Exception:
+            length = None
+        if length is None:
+            return '-'
+        cells.append(str(length))
+    if not cells:
+        return '-'
+    if len(set(cells)) == 1:
+        return cells[0]
+    return '/'.join(cells)
+
+
 def do_formats(args):
     """Print each base format name with its schema-v2 metadata and capacity.
 
@@ -387,7 +416,12 @@ def do_formats(args):
 
     A variable-length format shows both as a range -- ``200-700`` -- because in
     ``format`` mode it picks a length per record from across that range. The top
-    of the range is the length a handshake record and a ``hybrid`` header use.
+    of the range is the length the two handshake records seal at.
+
+    The ``hdr`` column is where a ``hybrid``-mode header goes instead: the
+    shortest length that holds one (:func:`fteproxy.hybrid_header_length`), for
+    the request direction and, when it differs, the response direction after a
+    slash. ``-`` means the format cannot run in hybrid mode at all.
     """
     try:
         definitions = select_defs(args.defs)
@@ -429,7 +463,7 @@ def do_formats(args):
         ports = fteproxy.defs.spec_port(primary_spec)
         port = ','.join(str(p) for p in ports) if ports else '-'
         mode = fteproxy.defs.spec_mode_hint(primary_spec)
-        row += [role, port, mode]
+        row += [role, port, mode, _hybrid_header_cell(bases[base], definitions)]
         for direction in ('request', 'response'):
             name = bases[base].get(direction)
             if name is None:
@@ -451,7 +485,7 @@ def do_formats(args):
         descriptions[base] = fteproxy.defs.spec_description(primary_spec)
         defaults[base] = (base == default)
 
-    header = ['name', 'role', 'port', 'mode',
+    header = ['name', 'role', 'port', 'mode', 'hdr',
               'req len', 'req cap', 'resp len', 'resp cap']
     left = {0, 1, 2, 3}  # name/role/port/mode left-justified; numbers right
     widths = [max(len(r[i]) for r in [header] + rows) for i in range(len(header))]
@@ -460,6 +494,8 @@ def do_formats(args):
           'per direction')
     print('a length range means the format varies its covertext length per '
           'record in format mode')
+    print('hdr is the covertext length a hybrid-mode header goes in '
+          '(request/response when they differ)')
     print()
 
     def _emit(row, trailer):
@@ -511,18 +547,28 @@ def do_defs_check(args):
             definitions = json.load(handle)
         name_w = max(len(name) for name, _l, _c, _m in summary)
         spans = {}
+        headers = {}
         for name, length, _capacity, _mode in summary:
-            lengths = fteproxy.defs.spec_allowed_lengths(
-                definitions.get(name, {'length': length}))
+            spec = definitions.get(name, {'length': length})
+            lengths = fteproxy.defs.spec_allowed_lengths(spec)
             spans[name] = _span(lengths[0], lengths[-1])
+            # Validation has already refused anything with no such length, so
+            # this is a number for every format that got here.
+            try:
+                headers[name] = str(fteproxy.hybrid_header_length(spec))
+            except Exception:
+                headers[name] = '-'
         span_w = max(len(span) for span in spans.values())
+        header_w = max(len(value) for value in headers.values())
         for name, _length, capacity, mode_hint in summary:
-            print('  %s  length %s  capacity %5d  %s'
+            print('  %s  length %s  capacity %5d  hybrid header %s  %s'
                   % (name.ljust(name_w), spans[name].rjust(span_w),
-                     capacity, mode_hint))
+                     capacity, headers[name].rjust(header_w), mode_hint))
         if any('-' in span for span in spans.values()):
             print('a length range varies per record in format mode; the '
                   'capacity shown is the one at the top of the range')
+        print('the two handshake records seal at the top of the range; a '
+              'hybrid-mode header seals at the shortest length that holds one')
     return EXIT_OK
 
 

--- a/fteproxy/defs/__init__.py
+++ b/fteproxy/defs/__init__.py
@@ -278,8 +278,9 @@ def getLength(format_name):
     """The fixed-frame covertext length of a format.
 
     For a variable-length format this is its ``max_length``: see
-    :func:`spec_length` for why the fixed-frame paths (the handshake, the
-    first-record scan, a hybrid header) all use the longest covertext.
+    :func:`spec_length` for why the handshake and the server's first-record scan
+    use the longest covertext. A hybrid-mode header does not -- it is a
+    fixed-length frame too, but at :func:`fteproxy.hybrid_header_length`.
     """
     definitions = load_definitions()
     try:
@@ -312,11 +313,17 @@ def spec_length(spec):
     """The wire length of the *single* covertext the fixed frames are built at.
 
     For a fixed-length format that is its ``length`` (or the configured
-    default). For a variable-length one it is ``max_length``: the handshake, the
-    server's first-record scan and a hybrid-mode header are all fixed-length
-    frames, and they use the longest covertext the format emits so that one
-    frame size serves every format. Only post-handshake *format*-mode data
-    records vary (see :func:`spec_allowed_lengths`).
+    default). For a variable-length one it is ``max_length``, which is what the
+    two handshake records and the server's first-record scan seal at: the server
+    has to frame a client hello before it can decrypt anything, so the hello's
+    length cannot depend on the format's contents, and the longest covertext is
+    the one choice that always has room.
+
+    A hybrid-mode header is a fixed-length frame too, but *not* this one: it
+    carries four bytes and is sealed at the shortest allowed length that holds
+    them (:func:`fteproxy.hybrid_header_length`). Only post-handshake
+    *format*-mode data records vary per record (see
+    :func:`spec_allowed_lengths`).
 
     Always a length *on the wire*. For a ``length-prefix`` format the cipher
     behind it is built at ``length - LENGTH_PREFIX_BYTES``, since the prefix is

--- a/fteproxy/defs/validate.py
+++ b/fteproxy/defs/validate.py
@@ -10,10 +10,16 @@ carry traffic is caught before it ships:
 * build the libfte cipher at every length the format may emit and require
   ``max_plaintext_bytes >=`` the capacity floor
   (:data:`fteproxy.defs.MIN_CAPACITY`) at the length the handshake seals at;
+* require at least one allowed length to have room for a hybrid header
+  (:data:`fteproxy.record_layer.HYBRID_HEADER_BYTES`), since a format with none
+  cannot run in ``hybrid`` mode and a session asking for it is refused rather
+  than framed some other way. ``defs-check`` reports the length that is used;
 * round-trip a batch of random payloads through
   :class:`fteproxy.record_layer.Encoder`/:class:`~fteproxy.record_layer.Decoder`
   in the format's ``mode_hint`` -- and in *both* modes when the hint is
-  ``hybrid``, since the client's ``--mode`` may override it either way;
+  ``hybrid``, since the client's ``--mode`` may override it either way. The
+  hybrid pass frames at the header length a live session uses, not at
+  ``max_length``;
 * assert every sealed **format-mode** covertext fully matches the regex, so the
   bytes on the wire really are drawn from the format's language -- for a
   ``length-prefix`` format, after taking the framing prefix off, since the
@@ -522,18 +528,39 @@ def validate_format(name, spec, samples=_SAMPLES):
         if not prefixed:
             check_terminator_uniqueness(name, regex, terminator)
 
+    # A format has to have somewhere to put a hybrid header, or it cannot run in
+    # hybrid mode at all -- and a session that asked for hybrid would be refused
+    # outright (:class:`fteproxy.HybridUnsupportedError`) rather than quietly
+    # framed some other way. Checked after the per-length build above, so a
+    # format with an unusable length is reported as that rather than as this.
+    # The capacity floor already guarantees a header fits for anything that gets
+    # this far -- the length it is measured at is one of the allowed lengths and
+    # MIN_CAPACITY dwarfs a header -- so this states the requirement rather than
+    # leaving it standing on a coincidence between two unrelated constants.
+    header_length = fteproxy.hybrid_header_length(spec)
+    if header_length is None:
+        raise FormatValidationError(
+            '%s: none of the covertext lengths %r has room for a %d-byte hybrid '
+            'header, so this format cannot run in hybrid mode'
+            % (name, fteproxy.defs.spec_allowed_lengths(spec),
+               rl.HYBRID_HEADER_BYTES))
+
     pattern = _compiled_regex(regex)
     for mode in _modes_for(mode_hint):
         hybrid = (mode == fteproxy.defs.MODE_HYBRID)
         # A variable-length format varies only in format mode: a hybrid record
-        # is a fixed-length header plus a raw body.
+        # is a fixed-length header plus a raw body. That header goes at
+        # ``header_length``, the shortest length that holds one, which is what a
+        # live session uses -- so the round trip exercises the frame size the
+        # product actually writes rather than one only this check ever sees.
         variable_lengths = None if hybrid else lengths
+        frame_length = header_length if hybrid else length
         encoder = rl.Encoder(
-            cipher=fteproxy._spec_cipher(spec, length, _KEY),
+            cipher=fteproxy._spec_cipher(spec, frame_length, _KEY),
             body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None,
             variable=variable_lengths)
         decoder = rl.Decoder(
-            cipher=fteproxy._spec_cipher(spec, length, _KEY),
+            cipher=fteproxy._spec_cipher(spec, frame_length, _KEY),
             body_cipher=fteproxy._make_body_cipher(_KEY) if hybrid else None,
             variable=variable_lengths)
         for i in range(samples):

--- a/fteproxy/record_layer.py
+++ b/fteproxy/record_layer.py
@@ -54,8 +54,12 @@ allowed lengths per record and seals at it, and is delimited one of two ways
     bytes.
 
 Either way the fixed-length fingerprint is gone from format-mode data records,
-while hybrid headers and the two handshake records stay fixed-length. See
-``docs/format-authoring.md``.
+while hybrid headers and the two handshake records stay fixed-length. The two
+handshake records are fixed at the format's ``max_length``, because the server
+frames the client hello before it can decrypt anything; a hybrid header is fixed
+at the *shortest* allowed length that holds :data:`HYBRID_HEADER_BYTES`, because
+that is all a header carries and covertext cost grows superlinearly with length.
+See ``docs/format-authoring.md``.
 """
 
 import os
@@ -94,6 +98,18 @@ _SEAL_OVERHEAD = _LEN.size + _SEQ.size
 _TYPE_LEN = 1
 # Hybrid-mode header payload: the length of the raw body that follows it.
 _OVERFLOW_LEN = struct.Struct('>I')
+
+#: Plaintext capacity a ``hybrid``-mode header cipher must have.
+#:
+#: A hybrid header carries one thing: the :data:`_OVERFLOW_LEN` count of the raw
+#: body behind it. :func:`_seal` wraps that in the length and sequence fields,
+#: so the whole sealed plaintext is exactly these 16 bytes and a covertext that
+#: holds 16 bytes of plaintext holds a header. That is *all* it has to hold --
+#: no payload rides in a hybrid header -- which is why a hybrid header does not
+#: have to be sealed at the format's longest covertext the way the handshake's
+#: two records are. :func:`fteproxy.hybrid_header_length` turns this number into
+#: the length one format's headers go out at.
+HYBRID_HEADER_BYTES = _OVERFLOW_LEN.size + _SEAL_OVERHEAD
 
 #: The framing header of a ``length-prefix`` format: a big-endian count of the
 #: message bytes that follow it (RFC 1035 4.2.2). Not part of any format's

--- a/fteproxy/tests/realism/__init__.py
+++ b/fteproxy/tests/realism/__init__.py
@@ -120,10 +120,13 @@ def record_layer_pair(spec, hybrid=False, key=_KEY):
     connection, minus the handshake: in ``format`` mode a variable-length format
     also gets the ciphers for every length it may emit, and in ``hybrid`` mode
     it does not, because a hybrid record is a fixed-length header plus a raw
-    body. A protocol's test file uses this so it exercises the framing the
-    product actually uses rather than a hand-rolled approximation of it.
+    body -- sealed at :func:`fteproxy.hybrid_header_length`, the shortest length
+    that holds one, not at ``max_length``. A protocol's test file uses this so
+    it exercises the framing the product actually uses rather than a hand-rolled
+    approximation of it.
     """
-    length = fteproxy.defs.spec_length(spec)
+    length = (fteproxy.hybrid_header_length(spec) if hybrid
+              else fteproxy.defs.spec_length(spec))
     variable = (None if hybrid or not fteproxy.defs.spec_is_variable(spec)
                 else fteproxy._variable_lengths_for_spec(spec, key))
     body = fteproxy._make_body_cipher(key) if hybrid else None

--- a/fteproxy/tests/test_variable_length.py
+++ b/fteproxy/tests/test_variable_length.py
@@ -39,9 +39,16 @@ What these tests pin down:
 * **terminator uniqueness**, the property terminator framing rests on, including
   that the pre-F7 ``http-response`` regex (which absorbed a body and so could
   carry a CRLF CRLF inside a covertext) is rejected by the check;
-* what did **not** change: the two handshake records and a ``hybrid`` header are
-  still one fixed ``max_length`` covertext, the four text formats' fragments are
-  byte for byte what F7 shipped, and the shape catalog is still fixed length.
+* what did **not** change: the two handshake records are still one fixed
+  ``max_length`` covertext, the four text formats' fragments are byte for byte
+  what F7 shipped, and the shape catalog is still fixed length.
+
+A ``hybrid`` header is still a *fixed*-length covertext, but no longer at
+``max_length``. F7 pinned it there beside the hello; since a header carries only
+the 4-byte length of the body behind it, and ranking a covertext gets
+superlinearly more expensive with length, it now goes in the shortest allowed
+length that has room for one (``fteproxy.hybrid_header_length``) --
+:class:`TestHybridHeaderLength` is where that rule is pinned down.
 """
 
 import collections
@@ -49,6 +56,7 @@ import os
 import re
 import socket
 import threading
+import time
 
 import pytest
 
@@ -171,8 +179,9 @@ class TestAllowedLengths:
 
     @pytest.mark.parametrize('name', sorted(VARIABLE))
     def test_get_length_is_the_top_of_the_range(self, name):
-        """What the fixed-frame paths use: the handshake, the server's
-        first-record scan, and a hybrid header."""
+        """What the handshake and the server's first-record scan use. (A hybrid
+        header is a fixed frame too, but at its own, shorter, length: see
+        :class:`TestHybridHeaderLength`.)"""
         assert fteproxy.defs.getLength(name) == _spec(name)['max_length']
 
     def test_a_partial_declaration_is_refused_at_load(self):
@@ -760,31 +769,39 @@ class _Reader(threading.Thread):
             self.data += chunk
 
 
+def _handshaken(base, mode):
+    """A real client/server pair over a socketpair, handshake completed.
+
+    Module level so the tests further down that need a live session -- the
+    hybrid header ones -- use the same wiring rather than a second copy of it.
+    """
+    client_sock, server_sock = socket.socketpair()
+    client = fteproxy.wrap_socket(client_sock, server_id=SERVER_PUBLIC,
+                                  format=base, mode=mode)
+    client._socket = _Recorder(client_sock)
+    server = fteproxy.wrap_socket(server_sock, server_key=SERVER_PRIVATE)
+    errors = []
+
+    def accept():
+        try:
+            server.handshake()
+        except Exception as e:                          # pragma: no cover
+            errors.append(e)
+
+    thread = threading.Thread(target=accept)
+    thread.start()
+    try:
+        client.handshake()
+    finally:
+        thread.join(10)
+    assert not errors, errors
+    return client, server
+
+
 class TestFixedFramingSurvives:
 
     def _handshaken(self, base, mode):
-        """A real client/server pair over a socketpair, handshake completed."""
-        client_sock, server_sock = socket.socketpair()
-        client = fteproxy.wrap_socket(client_sock, server_id=SERVER_PUBLIC,
-                                      format=base, mode=mode)
-        client._socket = _Recorder(client_sock)
-        server = fteproxy.wrap_socket(server_sock, server_key=SERVER_PRIVATE)
-        errors = []
-
-        def accept():
-            try:
-                server.handshake()
-            except Exception as e:                      # pragma: no cover
-                errors.append(e)
-
-        thread = threading.Thread(target=accept)
-        thread.start()
-        try:
-            client.handshake()
-        finally:
-            thread.join(10)
-        assert not errors, errors
-        return client, server
+        return _handshaken(base, mode)
 
     @pytest.mark.parametrize('mode', ['format', 'hybrid'])
     def test_the_client_hello_is_one_max_length_covertext(self, mode):
@@ -828,7 +845,17 @@ class TestFixedFramingSurvives:
             client.close()
             server.close()
 
-    def test_a_hybrid_header_is_still_fixed_at_max_length(self):
+    def test_a_hybrid_header_is_fixed_at_the_shortest_length_that_holds_one(self):
+        """Still one fixed-length covertext per record, and still real HTTP --
+        but at 200 bytes, not at the 700 the handshake uses.
+
+        Until this change a hybrid header was sealed at ``max_length`` beside
+        the hello, which spent a full 700-byte ranking on every record to carry
+        four bytes. The expectation this test used to state (header
+        length == ``getLength``) is the thing that changed; everything around it
+        -- one covertext, matching the regex, followed by a raw body -- is as it
+        was.
+        """
         client, server = self._handshaken('http', 'hybrid')
         try:
             assert client._encoder._variable is None
@@ -839,11 +866,18 @@ class TestFixedFramingSurvives:
             reader.join(20)
             assert reader.data == b'z' * 4000
             header = client._socket.sent[1]
-            length = fteproxy.defs.getLength('http-request')
+            length = fteproxy.hybrid_header_length(_spec('http-request'))
+            assert length == 200
+            assert length < fteproxy.defs.getLength('http-request') == 700
             pattern = re.compile(
                 _spec('http-request')['regex'].encode('latin-1'), re.DOTALL)
             assert pattern.fullmatch(header[:length])
             assert len(header) > length          # header plus a raw body
+            # The frame size both ends read is that same length, and it is what
+            # the decoder derives from its own header cipher rather than being
+            # told.
+            assert client._encoder._cipher.output_format.max_length == length
+            assert server._decoder._frame_size == length
         finally:
             client.close()
             server.close()
@@ -903,3 +937,300 @@ class TestFixedFramingSurvives:
             rl.Encoder(cipher=cipher, body_cipher=body, variable=variable)
         with pytest.raises(ValueError):
             rl.Decoder(cipher=cipher, body_cipher=body, variable=variable)
+
+
+# --------------------------------------------------------------------------- #
+# The hybrid header length
+# --------------------------------------------------------------------------- #
+
+#: What :func:`fteproxy.hybrid_header_length` works out for each shipped entry.
+#:
+#: Written down as well as derived (:meth:`TestHybridHeaderLength.
+#: test_the_length_is_the_shortest_that_holds_a_header` re-derives it from the
+#: ciphers) because these numbers are what goes on the wire: a release that
+#: moved one of them would change the covertext length of every hybrid record,
+#: which is a fingerprint change and should not pass silently.
+#:
+#: They are not symmetric, and there is no reason they should be: each direction
+#: is computed from its own entry, and a request pattern and a response pattern
+#: have different amounts of literal text, hence different rank space at the
+#: same covertext length. ``ftp`` is the case in point -- its response pattern
+#: has just enough room at 64 bytes and its request pattern has not.
+HYBRID_HEADER = {
+    'http-request': 200, 'http-response': 200,
+    'ftp-request': 91, 'ftp-response': 64,
+    'smtp-request': 80, 'smtp-response': 80,
+    'sip-request': 300, 'sip-response': 300,
+    'dns-request': 90, 'dns-response': 90,
+}
+
+#: The five shipped base names.
+BASES = ('http', 'ftp', 'smtp', 'sip', 'dns')
+
+
+def _session_keys():
+    """Distinct per-direction keys, as a handshake would produce."""
+    return fteproxy.handshake.SessionKeys(
+        auth=bytes([1]) * 32, c2s_header=bytes([2]) * 32,
+        c2s_body=bytes([3]) * 32, s2c_header=bytes([4]) * 32,
+        s2c_body=bytes([5]) * 32)
+
+
+def _channels(base, mode=fteproxy.handshake.MODE_HYBRID):
+    """Both ends of a session, built the way a completed handshake builds them."""
+    keys = _session_keys()
+    return (fteproxy._session_channel(base, mode, keys, is_client=True),
+            fteproxy._session_channel(base, mode, keys, is_client=False))
+
+
+class TestHybridHeaderLength:
+    """A hybrid header goes in the shortest covertext that holds one.
+
+    A hybrid record is a sealed header carrying the 4-byte length of the raw
+    body behind it, and nothing else. Until this change the header was sealed at
+    the format's ``max_length``, alongside the client hello -- which the
+    handshake genuinely needs, because the server has to frame the hello before
+    it can decrypt anything. A data header does not: both ends already share the
+    keys and the definitions, so the length can be anything they both compute
+    the same way.
+
+    Sealing it at ``max_length`` was expensive, because ranking a covertext gets
+    superlinearly more costly as it gets longer -- an ``http`` covertext at 700
+    bytes costs seven to eight times what one at 200 does. Every hybrid record
+    paid that, for four bytes of payload.
+    """
+
+    # -- the rule ---------------------------------------------------------- #
+
+    @pytest.mark.parametrize('name', sorted(HYBRID_HEADER))
+    def test_the_computed_length_per_shipped_format(self, name):
+        assert fteproxy.hybrid_header_length(_spec(name)) == HYBRID_HEADER[name]
+
+    @pytest.mark.parametrize('name', sorted(HYBRID_HEADER))
+    def test_the_length_is_the_shortest_that_holds_a_header(self, name):
+        """Re-derive the rule from the ciphers themselves.
+
+        The chosen length has room for a sealed header, and every shorter length
+        the format emits does not -- which is what makes it *the* shortest, not
+        merely a workable one.
+        """
+        spec = _spec(name)
+        chosen = fteproxy.hybrid_header_length(spec)
+        for length in fteproxy.defs.spec_allowed_lengths(spec):
+            capacity = fteproxy._spec_cipher(spec, length, _KEY) \
+                .max_plaintext_bytes
+            fits = capacity >= rl.HYBRID_HEADER_BYTES
+            if length < chosen:
+                assert not fits, (name, length, capacity)
+            elif length == chosen:
+                assert fits, (name, length, capacity)
+
+    def test_a_header_holds_exactly_what_it_carries(self):
+        """The 16 bytes are the 4-byte body length inside the 12-byte seal --
+        the whole sealed plaintext, since no payload rides in a header."""
+        assert rl.HYBRID_HEADER_BYTES == 16
+        assert rl.HYBRID_HEADER_BYTES == rl._OVERFLOW_LEN.size + rl._SEAL_OVERHEAD
+
+    @pytest.mark.parametrize('name', sorted(HYBRID_HEADER))
+    def test_the_length_is_one_the_format_emits(self, name):
+        """Not a length invented for headers: it comes out of the same set a
+        format-mode record picks from, so a hybrid header is indistinguishable
+        from a format-mode record of that length."""
+        assert fteproxy.hybrid_header_length(_spec(name)) in \
+            fteproxy.defs.spec_allowed_lengths(_spec(name))
+
+    def test_a_fixed_length_format_is_unchanged(self):
+        """The shape catalog has one allowed length, so that is where its
+        headers went before and where they go now."""
+        fteproxy.conf.setValue('fteproxy.defs.release', '20260110')
+        fteproxy.defs._definitions = None
+        definitions = fteproxy.defs.load_definitions()
+        for name, spec in definitions.items():
+            assert fteproxy.hybrid_header_length(spec) == \
+                fteproxy.defs.spec_length(spec), name
+
+    def test_a_format_with_no_room_cannot_run_hybrid(self):
+        """No shipped format is one -- the capacity floor is 128 bytes and a
+        header needs 16 -- so the refusal is exercised on a synthetic entry.
+        It has to be a refusal and not a fallback: quietly sealing at some other
+        length would leave the two ends framing the stream differently."""
+        tiny = {'regex': r'^[a-z][a-z][a-z][a-z]\r\n$', 'length': 6}
+        assert fteproxy.hybrid_header_length(tiny) is None
+        with pytest.raises(validate.FormatValidationError) as excinfo:
+            validate.validate_format('tiny-request', tiny, samples=1)
+        assert 'tiny-request' in str(excinfo.value)
+
+    # -- both ends agree, without negotiating ------------------------------ #
+
+    @pytest.mark.parametrize('base', BASES)
+    def test_both_ends_build_the_same_header_cipher(self, base):
+        """Nothing about the header length goes on the wire. Each end runs the
+        same function over the same definitions entry -- and for a given
+        direction it is the *same* entry, since a client's outgoing request
+        format is the server's incoming one."""
+        (client_enc, client_dec), (server_enc, server_dec) = _channels(base)
+        for encoder, decoder, name in (
+                (client_enc, server_dec, base + '-request'),
+                (server_enc, client_dec, base + '-response')):
+            expected = HYBRID_HEADER[name]
+            assert encoder._cipher.output_format.max_length == expected
+            assert decoder._frame_size == expected
+            # The decoder's frame size follows from its own header cipher; it is
+            # never told what to expect.
+            assert decoder._cipher.output_format.max_length == decoder._frame_size
+
+    @pytest.mark.parametrize('base', BASES)
+    def test_a_hybrid_session_round_trips_both_ways(self, base):
+        """Both ends built by ``_session_channel``, as a completed handshake
+        builds them, carrying traffic in both directions."""
+        (client_enc, client_dec), (server_enc, server_dec) = _channels(base)
+        assert client_enc._body_cipher is not None
+        assert client_enc._variable is None      # hybrid frames a fixed header
+        for i in range(8):
+            up = os.urandom(1 + i * 997)
+            client_enc.push(up)
+            server_dec.push(client_enc.pop())
+            assert server_dec.pop() == up
+
+            down = os.urandom(1 + i * 631)
+            server_enc.push(down)
+            client_dec.push(server_enc.pop())
+            assert client_dec.pop() == down
+        assert not server_dec.failed and not client_dec.failed
+
+    @pytest.mark.parametrize('base', BASES)
+    def test_the_header_on_the_wire_is_that_length(self, base):
+        """The first ``hdr`` bytes of a record are one covertext of the format,
+        and the body follows immediately behind it."""
+        (client_enc, _client_dec), (_server_enc, _server_dec) = _channels(base)
+        spec = _spec(base + '-request')
+        length = HYBRID_HEADER[base + '-request']
+        pattern = re.compile(spec['regex'].encode('latin-1'), re.DOTALL)
+        client_enc.push(b'q' * 64)
+        wire = client_enc.pop()
+        header = wire[:length]
+        assert len(wire) > length
+        if fteproxy.defs.spec_framing(spec) == \
+                fteproxy.defs.FRAMING_LENGTH_PREFIX:
+            # The prefix is framing, not language: it announces the message the
+            # regex describes.
+            prefix = rl.PREFIX_LEN
+            assert int.from_bytes(header[:prefix], 'big') == length - prefix
+            assert pattern.fullmatch(header[prefix:])
+        else:
+            assert pattern.fullmatch(header)
+
+    # -- the handshake is untouched ---------------------------------------- #
+
+    def test_the_hello_is_still_max_length_while_the_header_is_not(self):
+        """The two halves of the old rule come apart: the hello stays at 700
+        because the server frames it before it can decrypt anything, and the
+        data header drops to 200 because both ends already agree on it."""
+        client, server = _handshaken('http', 'hybrid')
+        try:
+            reader = _Reader(server, 1000)
+            reader.start()
+            client.send(b'y' * 1000)
+            reader.join(20)
+            assert reader.data == b'y' * 1000
+
+            hello = client._socket.sent[0]
+            assert len(hello) == 700 == fteproxy.defs.getLength('http-request')
+            header = client._socket.sent[1][:200]
+            assert len(header) == 200
+            pattern = re.compile(
+                _spec('http-request')['regex'].encode('latin-1'), re.DOTALL)
+            assert pattern.fullmatch(hello)      # both are still real HTTP
+            assert pattern.fullmatch(header)
+        finally:
+            client.close()
+            server.close()
+
+    @pytest.mark.parametrize('base', ['http', 'smtp'])
+    def test_the_real_client_server_path_carries_hybrid(self, base):
+        """The whole product: two sockets, a real handshake, and bulk traffic in
+        hybrid mode -- for ``http`` and for one line protocol."""
+        client, server = _handshaken(base, 'hybrid')
+        try:
+            assert client.negotiated_mode == 'hybrid'
+            assert server.negotiated_mode == 'hybrid'
+            expected = os.urandom(20000)
+            reader = _Reader(server, len(expected))
+            reader.start()
+            client.send(expected)
+            reader.join(30)
+            assert reader.data == expected
+            # Every data record's header is one covertext of the computed
+            # length, on both ends of the connection.
+            length = HYBRID_HEADER[base + '-request']
+            assert client._encoder._cipher.output_format.max_length == length
+            assert server._decoder._frame_size == length
+            assert length < fteproxy.defs.getLength(base + '-request')
+        finally:
+            client.close()
+            server.close()
+
+    # -- the point of the exercise ----------------------------------------- #
+
+    def test_a_short_header_costs_far_less_per_record(self):
+        """The measurement the change exists for.
+
+        One 64-byte payload per record through a real hybrid encoder, with the
+        header cipher at the computed length and then at ``max_length``. Loose
+        on purpose -- it is a ratio on a machine running a test suite, not a
+        benchmark -- but the gap it is guarding is about 7x, so 3x has room, and
+        the absolute bound is the same claim stated a second way.
+        """
+        spec = _spec('http-request')
+        payload = b'p' * 64
+        records = 40
+
+        def cost(length):
+            encoder = rl.Encoder(
+                cipher=fteproxy._spec_cipher(spec, length, _KEY),
+                body_cipher=fteproxy._make_body_cipher(_KEY))
+            encoder.push(payload)               # warm the DFA cache
+            encoder.pop()
+            start = time.perf_counter()
+            for _ in range(records):
+                encoder.push(payload)
+                encoder.pop()
+            return (time.perf_counter() - start) / records
+
+        short = cost(fteproxy.hybrid_header_length(spec))
+        long = cost(fteproxy.defs.spec_length(spec))
+        assert short * 3 < long, (short, long)
+        assert short < 0.4e-3, short
+
+    def test_hybrid_is_refused_at_session_setup(self, monkeypatch):
+        """A format that cannot hold a header is refused where a session is
+        built, not left to fail as a stream that will not decode.
+
+        The refusal has to happen for a *base*, both directions, since a session
+        seals one direction with each entry. Exercised on a synthetic release,
+        because no shipped format is small enough to reach it.
+        """
+        tiny = {'regex': r'^[a-z][a-z][a-z][a-z]\r\n$', 'length': 6}
+        monkeypatch.setattr(fteproxy.defs, '_definitions',
+                            {'tiny-request': tiny, 'tiny-response': tiny})
+
+        with pytest.raises(fteproxy.HybridUnsupportedError) as excinfo:
+            fteproxy._check_hybrid_supported(
+                'tiny', fteproxy.handshake.MODE_HYBRID)
+        assert 'tiny-request' in str(excinfo.value)
+        assert 'format' in str(excinfo.value)   # names the mode that would work
+        with pytest.raises(fteproxy.HybridUnsupportedError):
+            fteproxy._hybrid_header_cipher('tiny-request', _KEY)
+        with pytest.raises(fteproxy.HybridUnsupportedError):
+            fteproxy._session_channel('tiny', fteproxy.handshake.MODE_HYBRID,
+                                      _session_keys(), is_client=True)
+
+        # ``format`` mode is unaffected: the check is about hybrid headers.
+        fteproxy._check_hybrid_supported('tiny', fteproxy.handshake.MODE_FORMAT)
+
+    @pytest.mark.parametrize('base', BASES)
+    def test_no_shipped_format_is_refused(self, base):
+        """The counterpart: the capacity floor makes the refusal unreachable for
+        every format in the release."""
+        fteproxy._check_hybrid_supported(base, fteproxy.handshake.MODE_HYBRID)
+        fteproxy._check_hybrid_supported(base, fteproxy.handshake.MODE_FORMAT)


### PR DESCRIPTION
The benchmark refresh showed the shipped default (http, hybrid) running
about 4x slower in bulk and 5x in latency than the old fixed-256-byte
catalog, and traced it to one F7 choice: every hybrid data header was
sealed at the format's max_length (700 for http) even though it carries
only the 4-byte body length, and covertext cost grows faster than linearly
with length (0.17 ms per record at 200 bytes, 1.24 ms at 700).

A hybrid header is now sealed at the shortest allowed length whose cipher
holds it: fteproxy.hybrid_header_length(spec) returns the smallest allowed
length whose cipher max_plaintext_bytes >= record_layer.HYBRID_HEADER_BYTES
(16: the 12-byte seal plus the 4-byte body length; the record type byte
rides in the body). Both ends of _session_channel compute it from the same
definitions entry, so nothing is negotiated and the decoder's frame size
follows from its own header cipher. Measured from the real ciphers, the
header lengths become: http 700 -> 200, sip 800 -> 300, smtp 320 -> 80,
dns 272 -> 90 (cipher at 88 behind the length prefix), ftp 256 -> 91 for
requests and 64 for replies (an exact 16-byte fit). The two shape catalogs
have one length per entry and are unchanged by construction.

The handshake is untouched: the client and server hellos and the server's
first-record scan still seal at max_length through the handshake path, and
fteproxy/handshake.py is byte-for-byte the same. A captured http hello is
still one 700-byte covertext.

validate.py requires every format to have a header-capable length and
reports it; defs-check and the formats listing show it (an "hdr" column,
request/response when they differ). If a format had no such length, session
setup refuses hybrid mode with HybridUnsupportedError on the client before
the hello and on the server before the server hello (as the standard silent
rejection); unreachable for any shipped format since MIN_CAPACITY is 128.

Measured per-record hybrid cost at 64 bytes: http 0.64 -> 0.08 ms, sip
0.63 -> 0.11, smtp 0.15 -> 0.035, dns 0.15 -> 0.043, ftp 0.10 -> 0.034.
Bulk http hybrid, 8 MiB: 64 KiB writes 97 -> 575 MB/s, 16 KiB 25 -> 176,
1 MiB 910 -> 1830. PERFORMANCE.md is re-measured in the following commit.

One F7 test asserted a hybrid header is at max_length; it is renamed and
now asserts the header is 200 for http, below the 700 the hello uses, and
that the encoder's cipher length equals the peer decoder's frame size.
Docs: format-authoring, SECURITY.md (the hello stays at max length; hybrid
headers do not), README and the release notes.

Suite green at 868 (was 810).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
