### PR TITLE
Harden dependency automation and workflow security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types: ["minor", "patch"]
+        # Release-only actions need manual review; keep their PRs separate.
+        exclude-patterns:
+          - "pypa/gh-action-pypi-publish"
+          - "actions/upload-artifact"
+          - "actions/download-artifact"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ master ]
+    branches: [master, main]
   pull_request:
-    branches: [ master ]
+    branches: [master, main]
   schedule:
     # Weekly, Mondays at 07:17 UTC
     - cron: '17 7 * * 1'
@@ -17,6 +17,7 @@ jobs:
     # Deterministic check name used as a required status check: "Analyze (Python)"
     name: Analyze (Python)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       security-events: write
       actions: read
@@ -25,6 +26,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
@@ -37,3 +40,28 @@ jobs:
       uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:python"
+
+  analyze-actions:
+    name: Analyze (Actions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Analyze workflow security
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:actions

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,50 +4,46 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  approve-and-enable-auto-merge:
+  enable-auto-merge:
     if: >-
       github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.user.id == 49699333 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    # This job only reads verified metadata and enables auto-merge; it never
+    # checks out or executes the pull request source.
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Fetch verified Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Only patch and minor bumps are approved and merged unattended. A major
-      # bump can change a package's or an action's behaviour, a bump of the
-      # fte line is a wire-format change (see dependabot.yml), and
-      # pypa/gh-action-pypi-publish receives the PyPI trusted-publishing OIDC
-      # token and is never exercised by CI, so those need a human review.
-      - name: Approve pull request
+      # Required CI and security checks gate the merge. Major updates and
+      # release-only actions need a maintainer to inspect and merge the PR.
+      - name: Enable squash auto-merge for routine updates
         if: >-
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
-          !contains(steps.metadata.outputs.dependency-names, 'fte') &&
-          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
-        run: gh pr review --approve "$PR_URL"
+          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish') &&
+          !contains(steps.metadata.outputs.dependency-names, 'actions/upload-artifact') &&
+          !contains(steps.metadata.outputs.dependency-names, 'actions/download-artifact') &&
+          !contains(steps.metadata.outputs.dependency-names, 'fte')
+        run: gh pr merge --auto --squash --match-head-commit "$PR_HEAD_SHA" "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-
-      - name: Enable auto-merge
-        if: >-
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
-          !contains(steps.metadata.outputs.dependency-names, 'fte') &&
-          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Reject vulnerable dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: never
+          retry-on-snapshot-warnings: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -50,6 +52,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -80,6 +84,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -100,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -120,7 +128,7 @@ jobs:
 
   ci-success:
     # Aggregate gate. This single check is the required status check for branch
-    # protection on master. It passes only if every matrix job above succeeded,
+    # protection on the default branch. It passes only if every matrix job above succeeded,
     # so the required-checks list never needs updating when the matrix changes.
     name: CI Success
     if: always()


### PR DESCRIPTION
Dependabot now enables squash auto-merge only for verified bot PRs with patch or minor updates. Major updates and release-only actions remain for maintainer review. The merge command checks the PR head SHA, and the job no longer grants automatic review approvals.

Fix CodeQL triggers to include the current default branch, `main`, so its required check actually runs. Preserve the existing manual handling of `fte` updates.

Add dependency review to reject changes with known moderate-or-higher vulnerabilities, extend CodeQL to scan Actions workflows, and stop retaining checkout credentials. Keep release-only actions out of Dependabot's routine update groups.

Validation: all repository workflows pass actionlint 1.7.12 and zizmor 1.30.0 (standard offline audit); Dependabot YAML parses successfully. Existing CI and both CodeQL analyses run on this PR.
